### PR TITLE
Fixed Fabric Tx life-cycle handling

### DIFF
--- a/src/fabric/constant.js
+++ b/src/fabric/constant.js
@@ -1,10 +1,31 @@
-'use strict'
+'use strict';
 
 var os   = require('os');
 var path = require('path');
 
 var tempdir = path.join(os.tmpdir(), 'hfc');
 
+const TxErrorEnum = {
+    NoError: 0,
+    ProposalResponseError: 1,
+    BadProposalResponseError: 2,
+    OrdererResponseError: 4,
+    BadOrdererResponseError: 8,
+    EventNotificationError: 16,
+    BadEventNotificationError: 32
+};
+
+const TxErrorIndex = {
+    ProposalResponseError: 0,
+    BadProposalResponseError: 1,
+    OrdererResponseError: 2,
+    BadOrdererResponseError: 3,
+    EventNotificationError: 4,
+    BadEventNotificationError: 5
+};
+
 module.exports = {
-    tempdir: tempdir
-}
+    tempdir: tempdir,
+    TxErrorIndex: TxErrorIndex,
+    TxErrorEnum: TxErrorEnum
+};


### PR DESCRIPTION
@haojun Here is the PR addressing issue #24 

Notable changes:
* Using async/await
* Added verified and error-related properties to the Tx status object

Regarding unverified failures:
Since it is not straightforward how to incorporate (if at all) the extra time needed to verify a Tx status through a query (and when to do that), I think the best option, for now, is to leave this to the callback module. It still has access to the configured context (except the event hubs) in the `end` callback, so if needed, verification can happen there.