### PR TITLE
Update Composer query test to use precompiled VL query

### DIFF
--- a/src/contract/composer/vehicle-lifecycle-network/queries.qry
+++ b/src/contract/composer/vehicle-lifecycle-network/queries.qry
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+query selectAllCarsByColour {
+    description: "Select all cars based on their colour"
+    statement:
+        SELECT org.vda.Vehicle
+            WHERE (vehicleDetails.colour==_$colour)
+}


### PR DESCRIPTION
Composer 0.19.x now automatically creates indexes within CouchDB for any queries listed within the queries file of a business network that is deployed, in order to maximise the performance of queries.

This PR changes the example query test to use a query within the vehicle lifecycle network queries file so that the query tests being run are running at their maximum performance, as per the recommended best practise for Composer business networks. 

Signed-off-by: Nick Lincoln <nkl199@yahoo.co.uk>