### PR TITLE
Redesign sawtooth adapter to make it easy to add new use uses

### DIFF
--- a/src/sawtooth/Application/BatchBuilder.js
+++ b/src/sawtooth/Application/BatchBuilder.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2017 HUAWEI All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @file, Batch builder interface for usecases, each use cases has to override buildBatch and calculateAddress methods 
+ */
+
+
+'use strict'
+
+class BatchBuilder {
+    constructor() {
+    }
+
+    buildBatch(args) {
+        throw new Error('buildBatch is not implemented for this application!!');
+    }
+
+    calculateAddress(name) {
+        throw new Error('calculateAddress is not implemented for this application!!');
+    }
+
+}
+
+module.exports = BatchBuilder;

--- a/src/sawtooth/Application/BatchBuilderFactory.js
+++ b/src/sawtooth/Application/BatchBuilderFactory.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2017 HUAWEI All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @file, Factory class for generating batch builder instances based the txn family name and version.
+ */
+
+'use strict'
+
+var SimpleBatchBuilder = require('./SimpleBatchBuilder.js')
+
+class BatchBuilderFactory {
+    static getBatchBuilder(familyName, familyVersion) {
+        let sawtoothContractVersion = '1.0'
+        if (familyVersion === 'v0') {
+            sawtoothContractVersion = '1.0'
+        }
+
+        if(familyName === 'simple') {
+            return new SimpleBatchBuilder(familyName, sawtoothContractVersion);
+        }
+        else {
+            throw new Error('There is no batch builder for '+ familyName +' and '+ familyVersion);
+        }
+   } 
+}
+
+module.exports = BatchBuilderFactory;

--- a/src/sawtooth/Application/SimpleBatchBuilder.js
+++ b/src/sawtooth/Application/SimpleBatchBuilder.js
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2017 HUAWEI All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @file, batchBuilder for simple use case and it use case specific logic to
+ * buildBatch and calculateAddress
+ **/
+
+'use strict'
+
+var BatchBuilder = require('./BatchBuilder.js')
+
+class SimpleBatchBuilder extends BatchBuilder {
+
+    constructor(fName, fVersion) {
+        super();
+        this.familyName = fName;
+        this.familyVersion = fVersion;
+    }
+
+    buildBatch(args) {
+        const {createHash} = require('crypto');
+        const {createContext, CryptoFactory} = require('sawtooth-sdk/signing');
+        const context = createContext('secp256k1');
+        const {protobuf} = require('sawtooth-sdk');
+
+        const privateKey = context.newRandomPrivateKey();
+        const signer = new CryptoFactory(context).newSigner(privateKey);
+        var addr = args['account'];
+        var address = this.calculateAddress(addr);
+        var addresses = [address];
+
+        const cbor = require('cbor');
+        const payloadBytes = cbor.encode(args);
+    
+        const transactionHeaderBytes = protobuf.TransactionHeader.encode({
+            familyName: this.familyName,
+            familyVersion: this.familyVersion,
+            inputs: addresses,
+            outputs: addresses,
+            signerPublicKey: signer.getPublicKey().asHex(),
+            batcherPublicKey: signer.getPublicKey().asHex(),
+            dependencies: [],
+            payloadSha512: createHash('sha512').update(payloadBytes).digest('hex')
+        }).finish();
+
+        const txnSignature = signer.sign(transactionHeaderBytes);
+        const transaction = protobuf.Transaction.create({
+            header: transactionHeaderBytes,
+            headerSignature: txnSignature,
+            payload: payloadBytes
+        });
+
+        const transactions = [transaction];
+        const batchHeaderBytes = protobuf.BatchHeader.encode({
+            signerPublicKey: signer.getPublicKey().asHex(),
+            transactionIds: transactions.map((txn) => txn.headerSignature),
+        }).finish();
+
+        const batchSignature = signer.sign(batchHeaderBytes);
+        const batch = protobuf.Batch.create({
+            header: batchHeaderBytes,
+            headerSignature: batchSignature,
+            transactions: transactions
+        });
+
+        const batchListBytes = protobuf.BatchList.encode({
+            batches: [batch]
+        }).finish();
+
+        return batchListBytes;
+    }
+
+    calculateAddress(name) {
+        const crypto = require('crypto');
+        const _hash = (x) =>
+            crypto.createHash('sha512').update(x).digest('hex').toLowerCase();
+
+        const familyNameSpace = _hash(this.familyName).substring(0, 6);
+        let address = familyNameSpace + _hash(name).slice(-64);
+        return address;
+    }
+ 
+}
+module.exports = SimpleBatchBuilder;

--- a/src/sawtooth/sawtooth.js
+++ b/src/sawtooth/sawtooth.js
@@ -10,9 +10,13 @@
 'use strict'
 
 var BlockchainInterface = require('../comm/blockchain-interface.js')
+var BatchBuilder = require('./Application/BatchBuilder.js')
+var BatchBuilderFactory = require('./Application/BatchBuilderFactory.js')
+
 class Sawtooth extends BlockchainInterface {
 	constructor(config_path) {
 		 super(config_path);
+                 this.batchBuilder;
 	}
 
 	gettype() {
@@ -40,20 +44,12 @@ class Sawtooth extends BlockchainInterface {
 	}
 
 	invokeSmartContract(context, contractID, contractVer, args, timeout) {
-		const address = calculateAddresses(contractID, args)
-		let sawtoothContractVersion = '1.0'
-			if (contractVer === 'v0') {
-				sawtoothContractVersion = '1.0'
-			}
-		const batchBytes = createBatch(contractID, sawtoothContractVersion, address, args)
-		return submitBatches(batchBytes)
+                var builder = BatchBuilderFactory.getBatchBuilder(contractID, contractVer);
+		const batchBytes = builder.buildBatch(args);
+		return submitBatches(batchBytes);
 	}
 
 	queryState(context, contractID, contractVer, queryName) {
-		let sawtoothContractVersion = '1.0'
-			if (contractVer === 'v0') {
-				sawtoothContractVersion = '1.0'
-			}
 		return querybycontext(context, contractID, contractVer, queryName)
 	}
 
@@ -66,9 +62,10 @@ module.exports = Sawtooth;
 
 const restApiUrl = 'http://127.0.0.1:8008'
 
-function querybycontext(context, contractID, contractVer, name) {
-	const address = calculateAddress(contractID, name)
-	return getState(address)
+function querybycontext(context, contractID, contractVer, address) {
+        var builder = BatchBuilderFactory.getBatchBuilder(contractID, contractVer);
+        const addr = builder.calculateAddress(address);
+	return getState(addr);
 }
 
 function getState(address) {
@@ -209,84 +206,3 @@ function getBatchStatusByRequest(resolve, statusLink, invoke_status, intervalID,
 	})
 }
 
-function calculateAddress(family, name) {
-
-	const crypto = require('crypto')
-
-	const _hash = (x) =>
-	crypto.createHash('sha512').update(x).digest('hex').toLowerCase()
-
-	const INT_KEY_NAMESPACE = _hash(family).substring(0, 6)
-	let address = INT_KEY_NAMESPACE + _hash(name).slice(-64)
-	return address
-}
-
-function calculateAddresses(family, args) {
-	const crypto = require('crypto')
-
-	const _hash = (x) =>
-	crypto.createHash('sha512').update(x).digest('hex').toLowerCase()
-
-	const INT_KEY_NAMESPACE = _hash(family).substring(0, 6)
-	let addresses = []
-
-	for (let key in args){
-	    let address = INT_KEY_NAMESPACE + _hash(args[key]).slice(-64)
-		addresses.push(address)
-	}
-	return addresses
-}
-
-function createBatch(contractID, contractVer, addresses, args) {
-
-	const {createHash} = require('crypto')
-	const {createContext, CryptoFactory} = require('sawtooth-sdk/signing')
-	const context = createContext('secp256k1')
-	const {protobuf} = require('sawtooth-sdk')
-	const privateKey = context.newRandomPrivateKey()
-	const signer = new CryptoFactory(context).newSigner(privateKey)
-
-	const cbor = require('cbor')
-	const payloadBytes = cbor.encode(args)
-
-	const transactionHeaderBytes = protobuf.TransactionHeader.encode({
-		familyName: contractID,
-		familyVersion: contractVer,
-		inputs: addresses,
-		outputs: addresses,
-		signerPublicKey: signer.getPublicKey().asHex(),
-		batcherPublicKey: signer.getPublicKey().asHex(),
-		dependencies: [],
-		payloadSha512: createHash('sha512').update(payloadBytes).digest('hex')
-	     }).finish()
-
-	const txnSignature = signer.sign(transactionHeaderBytes)
-
-	const transaction = protobuf.Transaction.create({
-			header: transactionHeaderBytes,
-			headerSignature: txnSignature,
-			payload: payloadBytes
-		})
-
-	const transactions = [transaction]
-
-	const batchHeaderBytes = protobuf.BatchHeader.encode({
-                        signerPublicKey: signer.getPublicKey().asHex(),
-                        transactionIds: transactions.map((txn) => txn.headerSignature),
-		}).finish()
-
-	const batchSignature = signer.sign(batchHeaderBytes)
-
-	const batch = protobuf.Batch.create({
-			header: batchHeaderBytes,
-			headerSignature: batchSignature,
-			transactions: transactions
-		})
-
-	const batchListBytes = protobuf.BatchList.encode({
-		    batches: [batch]
-	}).finish()
-
-	return batchListBytes
-
-}


### PR DESCRIPTION
1. Generalize the sawtooth adapter
2. Move use case specific code like batch creation and adddress creation to application adapter
3. Each application has to implement batch builder interface.

Signed-off-by: Ramakrishna Srinivasamurthy <ramakrishna.srinivasamurthy@intel.com>