### PR TITLE
Bug fix for runDuration

### DIFF
--- a/src/comm/client/local-client.js
+++ b/src/comm/client/local-client.js
@@ -185,6 +185,6 @@ async function runDuration(msg, cb, context) {
         await rateControl.applyRateControl(start, txNum++, results);
     }
 
-    await Promise.all(results);
+    await Promise.all(promises);
     return await blockchain.releaseContext(context);    
 }


### PR DESCRIPTION
Signed-off-by: Haojun Zhou <zhouhaojun@huawei.com>

Replace the wrong promise.all array in runDuration