### PR TITLE
Simplify install document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,6 @@ For beginners of Caliper, if you want to :
 
   The `caliper/src` folder contains source codes for all supported DLTs.
   
-* Help to improve the benchmark engineer
+* Help to improve the benchmark engine
 
-  The `caliper/src/comm` folder contains source codes for the benchmark engineer. For example, the `bench-flow.js` implements the default end-to-end test flow.
+  The `caliper/src/comm` folder contains source codes for the benchmark engine. For example, the `bench-flow.js` implements the default end-to-end test flow.

--- a/README.md
+++ b/README.md
@@ -34,14 +34,9 @@ Run `npm install` in caliper folder to install dependencies locally
 
 ### Install blockchain SDKs
 * Fabric
-  * Install with source code
-    * Clone [fabric-sdk-node](https://github.com/hyperledger/fabric-sdk-node) and checkout release-1.1
-    * Run the headless tests to make sure everything is ok
-    * Install **fabric-client** and **fabric-ca-client** from the SDK, e.g run `npm install path-to-sdk/fabric-client path-to-sdk/fabric-ca-client` in caliper's root folder, or just copy the `node_modules` from fabric-sdk-node project
-  * Or install using the repository
-    * run `npm install fabric-ca-client@1.1.0 fabric-client@1.1.0` in the root folder
-  
-  (If you want to test fabric with old version such as v1.0, you should install compatible client SDK) 
+  * Install using the repository
+    * run `npm install fabric-ca-client fabric-client` in the root folder
+    * If you want to test fabric with old version such as v1.0, you should install compatible client SDK, e.g `npm install fabric-ca-client@1.1.0 fabric-client@1.1.0`
   
 * Sawtooth
   * Clone [sawtooth-core](https://github.com/hyperledger/sawtooth-core) and run the `./bin/run_tests -m javascript_sdk` to test the SDK
@@ -72,17 +67,16 @@ Run `npm install` in caliper folder to install dependencies locally
 
 ## Run benchmark
 
-All predefined benchmarks can be found in [*caliper/benchmark*](./benchmark) folder. 
-To start a benchmark, just run `node main.js -c yourconfig.json -n yournetwork.json` in the folder of the benchmark. 
+All predefined benchmarks can be found in [*/benchmark*](./benchmark) folder. 
+To start a benchmark, just run these in root folder
+```bash
+node benchmark/simple/main.js -c yourconfig.json -n yournetwork.json
+```
 * -c : specify the config file of the benchmark, if not used,  *config.json* will be used as default.
 * -n : specify the config file of the blockchain network under test. If not used, the file address must be specified in the benchmak config file.
-```bash
-# start the simple benchmark, default config.json is used
-cd ~/caliper/benchmark/simple
-node main.js
-```
 
-Some example SUTs are provided in [*caliper/network*](./network) folder, they can be launched automatically before the test by setting the bootstrap commands in the configuration file, e.g
+
+Some example SUTs are provided in [*/network*](./network) folder, they can be launched automatically before the test by setting the bootstrap commands in the configuration file, e.g
 ```json
 {
   "command" : {

--- a/README.md
+++ b/README.md
@@ -177,5 +177,9 @@ Generally speaking, to write a new caliper benchmark, you need to:
 /src | Souce code of the framework
 /src/contract | Smart contracts for different blockchain systems
 
+## How to contribute
+
+See [Contributing](/CONTRIBUTING.md). 
+
 ## License
 The Caliper codebase is release under the [Apache 2.0 license](./LICENSE). Any documentation developed by the Caliper Project is licensed under the Creative Commons Attribution 4.0 International License. You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Run `npm install` in caliper folder to install dependencies locally
 * Fabric
   * Install using the repository
     * run `npm install fabric-ca-client fabric-client` in the root folder
-    * If you want to test fabric with old version such as v1.0, you should install compatible client SDK, e.g `npm install fabric-ca-client@1.1.0 fabric-client@1.1.0`
+    * If you want to test fabric with old version such as v1.0, you should install compatible client SDK,   
+    e.g `npm install fabric-ca-client@1.1.0 fabric-client@1.1.0`
   
 * Sawtooth
   * Clone [sawtooth-core](https://github.com/hyperledger/sawtooth-core) and run the `./bin/run_tests -m javascript_sdk` to test the SDK


### PR DESCRIPTION
`npm install` of fabric-sdk-node can fits for most cases.
And seemingly there is some duplicated documents in benchmark/simple/main