### PR TITLE
Eslint compatible: Fabric and drm benchmark files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -17,7 +17,6 @@ node_modules
 
 # Benchmarks
 /benchmark/drm
-/benchmark/simple
 
 # Scripts
 /scripts

--- a/.eslintignore
+++ b/.eslintignore
@@ -16,7 +16,6 @@ coverage
 node_modules
 
 # Benchmarks
-/benchmark/drm
 
 # Scripts
 /scripts

--- a/benchmark/drm/main.js
+++ b/benchmark/drm/main.js
@@ -6,28 +6,40 @@
 */
 
 
-'use strict'
+'use strict';
 
-var configFile;
-var networkFile;
+let configFile;
+let networkFile;
+
+/**
+ * Set benchmark config file
+ * @param {*} file config file of the benchmark,  default is config.json
+ */
 function setConfig(file) {
     configFile = file;
 }
 
+/**
+ * Set benchmark network file
+ * @param {*} file config file of the blockchain system, eg: fabric.json
+ */
 function setNetwork(file) {
     networkFile = file;
 }
 
+/**
+ * Entry point of the Benchmarking script.
+ */
 function main() {
-    var program = require('commander');
+    let program = require('commander');
     program.version('0.1')
         .option('-c, --config <file>', 'config file of the benchmark, default is config.json', setConfig)
         .option('-n, --network <file>', 'config file of the blockchain system under test, if not provided, blockchain property in benchmark config is used', setNetwork)
         .parse(process.argv);
 
-    var path = require('path');
-    var fs = require('fs-extra');
-    var absConfigFile;
+    const path = require('path');
+    const fs = require('fs-extra');
+    let absConfigFile;
     if(typeof configFile === 'undefined') {
         absConfigFile = path.join(__dirname, 'config.json');
     }
@@ -39,8 +51,8 @@ function main() {
         return;
     }
 
-    var absNetworkFile;
-    var absCaliperDir = path.join(__dirname, '../..');
+    let absNetworkFile;
+    let absCaliperDir = path.join(__dirname, '../..');
     if(typeof networkFile === 'undefined') {
         try{
             let config = require(absConfigFile);
@@ -60,7 +72,7 @@ function main() {
     }
 
 
-    var framework = require('../../src/comm/bench-flow.js');
+    const framework = require('../../src/comm/bench-flow.js');
     framework.run(absConfigFile, absNetworkFile);
 }
 

--- a/benchmark/drm/main.js
+++ b/benchmark/drm/main.js
@@ -8,6 +8,8 @@
 
 'use strict';
 
+const Util = require('../../src/comm/util');
+
 let configFile;
 let networkFile;
 
@@ -47,7 +49,7 @@ function main() {
         absConfigFile = path.join(__dirname, configFile);
     }
     if(!fs.existsSync(absConfigFile)) {
-        console.log('file ' + absConfigFile + ' does not exist');
+        Util.log('file ' + absConfigFile + ' does not exist');
         return;
     }
 
@@ -59,7 +61,7 @@ function main() {
             absNetworkFile = path.join(absCaliperDir, config.blockchain.config);
         }
         catch(err) {
-            console.log('failed to find blockchain.config in ' + absConfigFile);
+            Util.log('failed to find blockchain.config in ' + absConfigFile);
             return;
         }
     }
@@ -67,7 +69,7 @@ function main() {
         absNetworkFile = path.join(__dirname, networkFile);
     }
     if(!fs.existsSync(absNetworkFile)) {
-        console.log('file ' + absNetworkFile + ' does not exist');
+        Util.log('file ' + absNetworkFile + ' does not exist');
         return;
     }
 

--- a/benchmark/drm/publish.js
+++ b/benchmark/drm/publish.js
@@ -6,41 +6,41 @@
 */
 
 
-'use strict'
+'use strict';
 
-var crypto = require('crypto');
+const crypto = require('crypto');
 
-module.exports.info  = "publishing digital items";
+module.exports.info  = 'publishing digital items';
 
-var bc, contx;
-var itemBytes = 1024;   // default value
-var ids = [];           // save the generated item ids
+let bc, contx;
+let itemBytes = 1024;   // default value
+let ids = [];           // save the generated item ids
 
 module.exports.ids = ids;
 
 module.exports.init = function(blockchain, context, args) {
     if(args.hasOwnProperty('itemBytes') ) {
-       itemBytes = args.itemBytes;
+        itemBytes = args.itemBytes;
     }
 
     bc       = blockchain;
     contx    = context;
     return Promise.resolve();
-}
+};
 
 module.exports.run = function() {
-    var date   = new Date();
-    var today  = (date.getMonth() + 1) + '/' + date.getDate() + '/' + date.getFullYear();
-    var author = process.pid.toString();
-    var buf    = crypto.randomBytes(itemBytes).toString('base64');
-    var item = {
-                    'author' : author,
-                    'createtime' : today,
-                    'info' : '',
-                    'item' : buf
-                };
+    const date   = new Date();
+    const today  = (date.getMonth() + 1) + '/' + date.getDate() + '/' + date.getFullYear();
+    const author = process.pid.toString();
+    const buf    = crypto.randomBytes(itemBytes).toString('base64');
+    const item = {
+        'author' : author,
+        'createtime' : today,
+        'info' : '',
+        'item' : buf
+    };
     return bc.invokeSmartContract(contx, 'drm', 'v0', {verb : 'publish', item: JSON.stringify(item)}, 120);
-}
+};
 
 module.exports.end = function(results) {
     for (let i in results){
@@ -50,7 +50,7 @@ module.exports.end = function(results) {
         }
     }
     return Promise.resolve();
-}
+};
 /**********************
 * save published items' identity
 **********************/

--- a/benchmark/drm/query.js
+++ b/benchmark/drm/query.js
@@ -6,25 +6,25 @@
 */
 
 
-'use strict'
+'use strict';
 
-module.exports.info  = "querying digital items";
+module.exports.info  = 'querying digital items';
 
-var bc, contx;
-var itemIDs;
+let bc, contx;
+let itemIDs;
 module.exports.init = function(blockchain, context, args) {
-    var publish = require('./publish.js');
+    const publish = require('./publish.js');
     bc      = blockchain;
     contx   = context;
     itemIDs = publish.ids;
     return Promise.resolve();
-}
+};
 
 module.exports.run = function() {
-    var id  = itemIDs[Math.floor(Math.random()*(itemIDs.length))];
+    const id  = itemIDs[Math.floor(Math.random()*(itemIDs.length))];
     return bc.queryState(contx, 'drm', 'v0', id);
-}
+};
 
 module.exports.end = function(results) {
     return Promise.resolve();
-}
+};

--- a/benchmark/simple/main.js
+++ b/benchmark/simple/main.js
@@ -6,28 +6,40 @@
 */
 
 
-'use strict'
+'use strict';
 
-var configFile;
-var networkFile;
+let configFile;
+let networkFile;
+
+/**
+ * Set benchmark config file
+ * @param {*} file config file of the benchmark,  default is config.json
+ */
 function setConfig(file) {
     configFile = file;
 }
 
+/**
+ * Set benchmark network file
+ * @param {*} file config file of the blockchain system, eg: fabric.json
+ */
 function setNetwork(file) {
     networkFile = file;
 }
 
+/**
+ * Entry point of the Benchmarking script.
+ */
 function main() {
-    var program = require('commander');
+    let program = require('commander');
     program.version('0.1')
         .option('-c, --config <file>', 'config file of the benchmark, default is config.json', setConfig)
         .option('-n, --network <file>', 'config file of the blockchain system under test, if not provided, blockchain property in benchmark config is used', setNetwork)
         .parse(process.argv);
 
-    var path = require('path');
-    var fs = require('fs-extra');
-    var absConfigFile;
+    const path = require('path');
+    const fs = require('fs-extra');
+    let absConfigFile;
     if(typeof configFile === 'undefined') {
         absConfigFile = path.join(__dirname, 'config.json');
     }
@@ -39,8 +51,8 @@ function main() {
         return;
     }
 
-    var absNetworkFile;
-    var absCaliperDir = path.join(__dirname, '../..');
+    let absNetworkFile;
+    let absCaliperDir = path.join(__dirname, '../..');
     if(typeof networkFile === 'undefined') {
         try{
             let config = require(absConfigFile);
@@ -60,7 +72,7 @@ function main() {
     }
 
 
-    var framework = require('../../src/comm/bench-flow.js');
+    const framework = require('../../src/comm/bench-flow.js');
     framework.run(absConfigFile, absNetworkFile);
 }
 

--- a/benchmark/simple/main.js
+++ b/benchmark/simple/main.js
@@ -8,6 +8,8 @@
 
 'use strict';
 
+const Util = require('../../src/comm/util');
+
 let configFile;
 let networkFile;
 
@@ -47,7 +49,7 @@ function main() {
         absConfigFile = path.join(__dirname, configFile);
     }
     if(!fs.existsSync(absConfigFile)) {
-        console.log('file ' + absConfigFile + ' does not exist');
+        Util.log('file ' + absConfigFile + ' does not exist');
         return;
     }
 
@@ -59,7 +61,7 @@ function main() {
             absNetworkFile = path.join(absCaliperDir, config.blockchain.config);
         }
         catch(err) {
-            console.log('failed to find blockchain.config in ' + absConfigFile);
+            Util.log('failed to find blockchain.config in ' + absConfigFile);
             return;
         }
     }
@@ -67,7 +69,7 @@ function main() {
         absNetworkFile = path.join(__dirname, networkFile);
     }
     if(!fs.existsSync(absNetworkFile)) {
-        console.log('file ' + absNetworkFile + ' does not exist');
+        Util.log('file ' + absNetworkFile + ' does not exist');
         return;
     }
 

--- a/benchmark/simple/open.js
+++ b/benchmark/simple/open.js
@@ -5,34 +5,35 @@
 *
 */
 
-'use strict'
+'use strict';
 
-module.exports.info  = "opening accounts";
+module.exports.info  = 'opening accounts';
 
-var accounts = [];
-var initMoney;
-var bc, contx;
+let accounts = [];
+let initMoney;
+let bc, contx;
 module.exports.init = function(blockchain, context, args) {
     if(!args.hasOwnProperty('money')) {
-        return Promise.reject(new Error("simple.open - 'money' is missed in the arguments"));
+        return Promise.reject(new Error('simple.open - "money" is missed in the arguments'));
     }
 
     initMoney = args['money'].toString();
     bc = blockchain;
     contx = context;
     return Promise.resolve();
-}
+};
 
-var dic = 'abcdefghijklmnopqrstuvwxyz';
+const dic = 'abcdefghijklmnopqrstuvwxyz';
 function get26Num(number){
-    var result = '';
+    let result = '';
     while(number > 0) {
         result += dic.charAt(number % 26);
         number = parseInt(number/26);
     }
     return result;
 }
-var prefix;
+
+let prefix;
 function generateAccount() {
     // should be [a-z]{1,9}
     if(typeof prefix === 'undefined') {
@@ -42,13 +43,13 @@ function generateAccount() {
 }
 
 module.exports.run = function() {
-    var newAcc = generateAccount();
+    let newAcc = generateAccount();
     accounts.push(newAcc);
     return bc.invokeSmartContract(contx, 'simple', 'v0', {verb: 'open', account: newAcc, money: initMoney}, 30);
-}
+};
 
 module.exports.end = function(results) {
     return Promise.resolve();
-}
+};
 
 module.exports.accounts = accounts;

--- a/benchmark/simple/open.js
+++ b/benchmark/simple/open.js
@@ -17,13 +17,18 @@ module.exports.init = function(blockchain, context, args) {
         return Promise.reject(new Error('simple.open - "money" is missed in the arguments'));
     }
 
-    initMoney = args['money'].toString();
+    initMoney = args.money.toString();
     bc = blockchain;
     contx = context;
     return Promise.resolve();
 };
 
 const dic = 'abcdefghijklmnopqrstuvwxyz';
+/**
+ * Generate string by picking characters from dic variable
+ * @param {*} number character to select
+ * @returns {String} string generated based on @param number
+ */
 function get26Num(number){
     let result = '';
     while(number > 0) {
@@ -34,6 +39,10 @@ function get26Num(number){
 }
 
 let prefix;
+/**
+ * Generate unique account key for the transaction
+ * @returns {String} account key
+ */
 function generateAccount() {
     // should be [a-z]{1,9}
     if(typeof prefix === 'undefined') {

--- a/benchmark/simple/query.js
+++ b/benchmark/simple/query.js
@@ -5,28 +5,28 @@
 *
 */
 
-'use strict'
+'use strict';
 
-module.exports.info  = "querying accounts";
+module.exports.info  = 'querying accounts';
 
 
-var bc, contx;
-var accounts;
+let bc, contx;
+let accounts;
 module.exports.init = function(blockchain, context, args) {
-    var open = require('./open.js');
+    const open = require('./open.js');
     bc       = blockchain;
     contx    = context;
     accounts = open.accounts;
     return Promise.resolve();
-}
+};
 
 module.exports.run = function() {
-    var acc  = accounts[Math.floor(Math.random()*(accounts.length))];
+    const acc  = accounts[Math.floor(Math.random()*(accounts.length))];
 
     return bc.queryState(contx, 'simple', 'v0', acc);
-}
+};
 
 module.exports.end = function(results) {
     // do nothing
     return Promise.resolve();
-}
+};


### PR DESCRIPTION
Regarding issue #48 , updated  benchmark/fabric and benchmark/drm config files to adhere to eslint rules.
Changes:
1. prefer `const` and `let ` over `var`.
2. prefer `'` over `"`.
3. Add missing semicolons.
4. JS-doc for main.js

