### PR TITLE
enable multi-client and multi-round tests in Composer benchmarks

### DIFF
--- a/benchmark/composer/composer-test-utils.js
+++ b/benchmark/composer/composer-test-utils.js
@@ -1,0 +1,46 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+ * Test Utilities for Composer benchmark tests
+ */
+class TestUtil {
+    /**
+     * Internal helper function to remove all items within a registry that follow a naming convention
+     * @param {Registry} registry the asset registry to use
+     * @param {String} baseName the base name of the assets to remove
+     */
+    static async clearAll(registry, baseName) {
+        let assets =[];
+        let retrieve = true;
+        let innerId = 0;
+        while (retrieve){
+            let id = baseName + '_' + innerId++;
+            let exists = await registry.exists(id);
+            if (exists){
+                let asset = await registry.get(id);
+                assets.push(asset);
+            } else {
+                retrieve = false;
+            }
+        }
+        await registry.removeAll(assets);
+    }
+
+}
+
+// Exports
+module.exports = TestUtil;

--- a/benchmark/composer/config-composer.json
+++ b/benchmark/composer/config-composer.json
@@ -12,15 +12,23 @@
     "description" : "This is an example Composer perf test",
     "clients": {
       "type": "local",
-      "number": 1
+      "number": 2
     },
     "rounds": [{
-              "label" : "basic-sample-network",
-              "txNumber" : [50],
-              "trim" : 0,
-              "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 10}}],
-              "arguments": {"testAssets": 50},
-              "callback" : "benchmark/composer/composer-samples/basic-sample-network.js"
+                "label" : "basic-sample-network",
+                "txNumber" : [25],
+                "trim" : 0,
+                "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 5}}],
+                "arguments": {"testAssets": 25},
+                "callback" : "benchmark/composer/composer-samples/basic-sample-network.js"
+            },
+            {
+                "label" : "basic-sample-network",
+                "txNumber" : [50],
+                "trim" : 0,
+                "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 10}}],
+                "arguments": {"testAssets": 50},
+                "callback" : "benchmark/composer/composer-samples/basic-sample-network.js"
             }]
   },
   "monitor": {

--- a/docs/Composer.md
+++ b/docs/Composer.md
@@ -40,7 +40,6 @@ The sample configuration file `/caliper/benchmark/composer/config-composer.json`
 
 Points to note:
 - The test `label` must match a corresponding `chaincodes` tag that is present within the network topology configration file.
-- Currently, only a single client test is supported
 
 To run a Composer based test, on a published set of versions, the required process is:
 - npm install, having specified the required Hyperledger Fabric/Composer versions


### PR DESCRIPTION
Currently the Composer benchmark tests are in single client and single round mode only. This PR enables the benchmarks to be run in multi-client mode with multiple test rounds.

This was enabled by using the OS hostname and process id as a UUID within each test for the creation and manipulation of assets in each benchmark test.

Changes include:
- benchmarks edited to enable multi client/round
- config file changed so that travis test is in multi-client/round for composer
- docs updated to remove limitation on modes

PR checks made:
- eslint compliant
- each benchmark passes in multi-client/round mode
- travis build passes in multi-client/round mode

Signed-off-by: Nick Lincoln <nkl199@yahoo.co.uk>