### PR TITLE
Add rate controllers and related extensions, update docs

### DIFF
--- a/benchmark/simple/config-composite-rate.json
+++ b/benchmark/simple/config-composite-rate.json
@@ -1,0 +1,63 @@
+{
+  "blockchain": {
+    "type": "fabric",
+    "config": "benchmark/simple/fabric.json"
+  },
+  "command" : {
+    "start": "docker-compose -f network/fabric/simplenetwork/docker-compose.yaml up -d",
+    "end" : "docker-compose -f network/fabric/simplenetwork/docker-compose.yaml down;docker rm $(docker ps -aq);docker rmi $(docker images dev* -q)"
+  },
+  "test": {
+    "name": "simple",
+    "description" : "This is an example benchmark for caliper, to test the backend DLT's performance with simple account opening & querying transactions",
+    "clients": {
+      "type": "local",
+      "number": 5
+    },
+    "rounds": [{
+        "label" : "open",
+        "txDuration" : [30],
+        "rateControl" : [{
+          "type": "composite-rate",
+          "opts": {
+            "weights": [10, 5, 5, 10],
+            "rateControllers": [
+              {
+                "type": "fixed-rate",
+                "opts": {"tps" : 100}
+              },
+              {
+                "type": "fixed-rate",
+                "opts": {"tps" : 200}
+              },
+              {
+                "type": "zero-rate",
+                "opts": { }
+              },
+              {
+                "type": "fixed-rate",
+                "opts": {"tps" : 100}
+              }
+            ],
+            "logChange": true
+          }
+        }],
+        "arguments": { "money": 10000 },
+        "callback" : "benchmark/simple/open.js"
+      }]
+  },
+  "monitor": {
+    "type": ["docker", "process"],
+    "docker":{
+      "name": ["all"]
+    },
+    "process": [
+      {
+        "command" : "node",
+        "arguments" : "local-client.js",
+        "multiOutput" : "avg"
+      }
+    ],
+    "interval": 1
+  }
+}

--- a/docs/RateControllers.md
+++ b/docs/RateControllers.md
@@ -2,13 +2,22 @@
 
 The rate at which transactions are input to the blockchain system is a key factor within performance tests. It may be desired to send transactions at a specified rate or follow a specified profile. Caliper permits the specification of custom rate controllers to enable a user to perform testing under a custom loading mechanism. A user may specify their own rate controller or use one of the defualt options:
 
-- Fixed rate
-- PID rate
+* [Fixed rate](#fixed-rate)
+* [PID rate](#pid-rate)
+* [Composite rate](#composite-rate)
+* [Zero rate](#zero-rate)
 
 ## Fixed Rate
 The fixed rate controller is the most basic controller, and also the default option if no controller is specified. It will send input transactions at a fixed interval that is specified as TPS (transactions per second).
 
-The fixed rate controller, driving at 10 TPS, is specifed through the following controller option: `{"type": "fixed-rate", "opts": {"tps" : 10}}`
+The fixed rate controller, driving at 10 TPS, is specifed through the following controller option: 
+
+```json
+{
+  "type": "fixed-rate", 
+  "opts": {"tps" : 10}
+}
+```
 
 ## PID Rate
 The PID rate controller is a basic PID (proportional-derivative-integral) controller for driving the tests at a target loading (backlog transactions). This controller will aim to maintain a defined backlog of transactions within the system by modifying the driven TPS.
@@ -25,11 +34,119 @@ There are numerous methods to tune the control parameters. A good starting point
 5. Set P and D to the last stable values.
 6. Increase the I gain until it brings you to the setpoint with the number of oscillations desired (normally zero but a quicker response can be had if you don't mind a couple oscillations of overshoot)
 
-The PID rate controller, targeting a backlog of 5 transactions and seeded with and intial TPS of 2, and enabling viewing of the control parameters, is specified through the following controller option: `{"type": "pid-rate", "opts": {"targetLoad": 5, "initialTPS": 2, "proportional": 0.2, "integral": 0.0001, "derrivative": 0.1, "showVars": true}}`. In the specification, `proportional`, `derrivative` and `integral` respectively specify the gains `Kp`, `Kd`, and `Ki`, used within the controller.
+The PID rate controller, targeting a backlog of 5 transactions and seeded with and intial TPS of 2, and enabling viewing of the control parameters, is specified through the following controller option: 
+
+```json
+{
+  "type": "pid-rate", 
+  "opts": {
+    "targetLoad": 5, 
+    "initialTPS": 2, 
+    "proportional": 0.2, 
+    "integral": 0.0001, 
+    "derrivative": 0.1, 
+    "showVars": true
+  }
+}
+``` 
+
+In the specification, `proportional`, `derrivative` and `integral` respectively specify the gains `Kp`, `Kd`, and `Ki`, used within the controller.
+
+## Composite Rate
+
+A benchmark round in Caliper is associated with a single rate controller. However, a single rate controller is rarely sufficient to model advanced client behaviors. Moreover, implementing new rate controllers for such behaviors can be cumbersome and error-prone. Most of the time a complex client behavior can be split into several, simpler phases. 
+
+Accordingly, the composite rate controller enables the configuration of multiple "simpler" rate controllers _in a single round_, promoting the reusability of existing rate controller implementations. The composite rate controller will automatically switch between the given controllers according to the specified weights (see the configuration details after the example).
+
+For example, the definition of a square wave function (with varying amplitude) as the transaction submission rate is as easy as switching between [fixed rate](#fixed-rate) controllers with different TPS settings:
+
+```json
+{
+  "type": "composite-rate", 
+  "opts": {
+    "weights": [2, 1, 2], 
+    "rateControllers": [
+      {
+        "type": "fixed-rate", 
+        "opts": {"tps" : 100}
+      },
+      {
+        "type": "fixed-rate", 
+        "opts": {"tps" : 300}
+      },
+      {
+        "type": "fixed-rate", 
+        "opts": {"tps" : 200}
+      }
+    ],  
+    "logChange": true
+  }
+}
+```
+
+The composite rate controller can be specified by setting the rate controller `type` to the `composite-rate` string. The available options (`opts` property) are the following:
+* `weights`: an array of "number-like" values (explicit numbers or numbers as strings) specifying the weights associated with the rate controllers defined in the `rateControllers` property. 
+    
+    The weights do not necessarily have to sum to `1`, since they will eventually be normalized to a vector of unit length. This means, that the weights can be specified in a manner that is the most intuitive for the given configuration. For example, the weights can correspond to durations, numbers of transactions or ratios. 
+    
+    In the above example, the weights are corresponding to ratios (2:1:2). The exact meaning of the weights is determined by whether the benchmark round is _duration-based_ or _transaction number-based_. If the above controller definition is used in a round with a duration of 5 minutes, then in the first 2 minutes the transactions will be submitted at 100 TPS, then at 300 TPS for the next minute, and at 200 TPS for the last 2 minutes of the round.
+    
+    Note, that 0 weights are also allowed in the array. Setting the weight of one or more controllers to 0 is a convenient way to "remove/disable" those controllers without actually removing them from the configuration file.
+
+* `rateControllers`: an array of arbitrary rate controller specifications. See the documentation of the individual rate controllers on how to configure them. The number of specified rate controllers must equal to the number of specified weights.
+
+    Note, that technically, composite rate controllers can be nested to form a hierarchy. However, using a composite rate controller incurs an additional execution overhead in the rate control logic. Keep this in mind before specifying a deep hierarchy of composite rate controllers, or just flatten the hierarchy to a single level.
+    
+* `logChange`: a `boolean` value indicating whether the switches between the specified rate controllers should be logged or not.
+
+**Important!** The existence of the composite rate controller is completely transparent to the specified "sub-controllers." This is achieved by essentially placing the controllers in a "virtualized" round, i.e., "lying" to the them about: 
+* the duration of the round (for duration-based rounds),
+* the total number of transactions to submit (for transaction number-based rounds),
+* the starting time of the round,
+* the index of the next transaction to submit, and
+* the set of previously executed transactions.
+
+This "virtualization" does not affect the memoryless controllers, i.e., the controllers whose control logic does not depend on global round properties or past transaction results. However, other controllers might exhibit some strange (but hopefully transient) behavior due to this "virtualized" round approach. The logic of the [PID controller](#pid-rate) for example depends on the transaction backlog, but the (possibly pending) transactions submitted in the previous phase (with a different controller) are not visible to the controller.
+
+## Zero Rate
+
+This controller stops the workload generation for the duration of the round. Using the controller on its own for a round is meaningless. However, it can be used as a building block inside a [composite rate](#composite-rate) controller. The zero rate controller can be used only in _duration-based_ rounds!
+
+```json
+{
+  "type": "composite-rate", 
+  "opts": {
+    "weights": [30, 10, 10, 30], 
+    "rateControllers": [
+      {
+        "type": "fixed-rate", 
+        "opts": {"tps" : 100}
+      },
+      {
+        "type": "fixed-rate", 
+        "opts": {"tps" : 500}
+      },
+      {
+        "type": "zero-rate", 
+        "opts": { }
+      },
+      {
+        "type": "fixed-rate", 
+        "opts": {"tps" : 100}
+      }
+    ],  
+    "logChange": true
+  }
+}
+```
+
+Let's assume, that the above example is placed in a round definition with an 80 seconds duration (note the intuitive specification of the weights). In this case, an initial 30 seconds _normal_ workload is followed by a 10 seconds _intensive_ workload, which is followed by a 10 seconds _cooldown_ period, etc.
+
+The controller is identified by the `zero-rate` string as the value of the `type` property and requires no additional configuration.
 
 ## Custom Controllers
 
-Rate controllers must extend `/src/comm/rate-control/rateInterface.js`, providing concrete implementations for `init` and `applyRateControl`. Once created it must be listed within `/src/comm/rate-control/rateControl.js` as an available controller within the constructor.
+Rate controllers must extend `/src/comm/rate-control/rateInterface.js`, providing concrete implementations for `init`, `applyRateControl`, and optionally for `end`. Once created it must be listed within `/src/comm/rate-control/rateControl.js` as an available controller within the constructor.
 
 Custom options are passed to the controller through the `opts` parameter. For example `{"type": "my-rate-control", "opts": {"opt1" : x, "opt2" : [a,b,c]}}` will use the rate controller `my-rate-control` and pass it the `opts` object that will be available for use within the rate controller for custom actions.
 

--- a/src/comm/client/client-util.js
+++ b/src/comm/client/client-util.js
@@ -140,6 +140,7 @@ function startTest(number, message, clientArgs, updates, results) {
             client.results = results;
             client.updates = updates;
             message.clientargs = clientArgs[idx];
+            message.clientIdx = idx;
             idx++;
 
             client.obj.send(message);

--- a/src/comm/client/local-client.js
+++ b/src/comm/client/local-client.js
@@ -96,6 +96,7 @@ async function runFixedNumber(msg, cb, context) {
     }
 
     await Promise.all(promises);
+    await rateControl.end();
     return await blockchain.releaseContext(context);
 }
 
@@ -126,6 +127,7 @@ async function runDuration(msg, cb, context) {
     }
 
     await Promise.all(promises);
+    await rateControl.end();
     return await blockchain.releaseContext(context);
 }
 

--- a/src/comm/rate-control/compositeRate.js
+++ b/src/comm/rate-control/compositeRate.js
@@ -1,0 +1,268 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+const RateInterface = require('./rateInterface.js');
+const RateControl = require('./rateControl.js');
+const Util = require('../util');
+
+/**
+ * Encapsulates a controller and its scheduling information.
+ *
+ * Time related values are expressed in millisecond!
+ *
+ * @property {number} weight The weight associated with the controller.
+ * @property {boolean} last Indicates whether the controller is the last in the round.
+ * @property {object} controllerOptions The supplied options for the controller.
+ * @property {RateControl} controller The controller instance.
+ * @property {number} firstTxIndex The first Tx index associated with the controller.
+ *                                 It is used to calculate the adjusted Tx index passed to the controller.
+ * @property {number} startTimeDifference The difference between the start time of the round and the controller.
+ *                                        It is used to calculate the adjusted start time passed to the controller.
+ * @property {number} lastTxIndex The last Tx index associated with the controller based on its weight.
+ *                                Only used in Tx number-based rounds.
+ * @property {number} relFinishTime The finish time of the controller based on its weight, relative to the start time of the round.
+ *                                  Only used in duration-based rounds.
+ */
+class ControllerData {
+    /**
+     * Initialize a new instance of the ControllerData class.
+     * @param {number} weight The weight associated with the controller.
+     * @param {object} controllerOptions The specified options for the controller.
+     * @param {RateControl} controller The controller object.
+     */
+    constructor(weight, controllerOptions, controller) {
+        this.weight = weight;
+        this.isLast = false;
+        this.controllerOptions = controllerOptions;
+        this.controller = controller;
+        this.firstTxIndex = 0; // correct default value for the first sub-controller
+        this.startTimeDifference = 0; // correct default value for the first sub-controller
+        this.lastTxIndex = 0;
+        this.relFinishTime = 0;
+    }
+}
+
+/**
+ * Composite rate controller for applying different rate controllers after one an other in the same round.
+ *
+ * Time related values are expressed in millisecond!
+ *
+ * @property {Blockchain} blockchain The initialized blockchain object.
+ * @property {object} options The user-supplied options for the controller.
+ * @property {number[]} options.weights The list of weights for the different controllers.
+ * @property {object[]} options.rateControllers The list of descriptors of the controllers.
+ * @property {boolean} options.logChange Indicates whether to log when switching to a new controller.
+ * @property {ControllerData[]} controllers The list of relevant controllers and their scheduling information.
+ * @property {number} activeControllerIndex The index of the currently active controller.
+ * @property {number} clientIdx The index of the current client.
+ * @property {function} controllerSwitch Duration-based or Tx number-based function for handling controller switches.
+ */
+class CompositeRateController extends RateInterface{
+    /**
+     * Creates a new instance of the CompositeRateController class.
+     * @constructor
+     * @param {Blockchain} blockchain The initialized blockchain object.
+     * @param {object} opts Options for the rate controller.
+     * @throws {Error} Throws error if there is a problem with the weight and/or controller options.
+     */
+    constructor(blockchain, opts) {
+        super(blockchain, opts);
+
+        this.controllers = [];
+        this.activeControllerIndex = 0;
+        this.clientIdx = -1;
+        this.controllerSwitch = null;
+        this.logControllerChange = (this.options.logChange &&
+            typeof(this.options.logChange) === 'boolean' && this.options.logChange) || false;
+
+        this.__prepareControllers();
+    }
+
+    /**
+     * Internal method for preparing the controllers for further use.
+     * @private
+     */
+    __prepareControllers() {
+        let weights = this.options.weights;
+        let rateControllers = this.options.rateControllers;
+
+        if (!Array.isArray(weights) || !Array.isArray(rateControllers)) {
+            throw new Error('Weight and controller definitions must be arrays.');
+        }
+
+        if (weights.length !== rateControllers.length) {
+            throw new Error('The number of weights and controllers must be the same.');
+        }
+
+        const nan = weights.find(w => isNaN(Number(w)));
+        if (nan) {
+            throw new Error('Not-a-number element among weights: ' + nan);
+        }
+
+        // store them explicitly as numbers to avoid surprises later
+        weights = weights.map(w => Number(w));
+
+        // check for negative weights
+        // zero weights should be fine to allow easy temporary removal of controllers from the config file
+        const negativeWeight = weights.find(w => w < 0);
+        if (negativeWeight) {
+            throw new Error('Negative element among weights: ' + negativeWeight);
+        }
+
+        // normalize weights
+        const weightSum = weights.reduce((prev, w) => prev + w, 0);
+        if (weightSum === 0) {
+            throw new Error('Every weight is zero.');
+        }
+        weights = weights.map(w => w / weightSum);
+
+        // create controller instances, skip zero-weight cases
+        for (let i = 0; i < weights.length; ++i) {
+            if (weights[i] === 0) {
+                continue;
+            }
+
+            let info = new ControllerData(weights[i], rateControllers[i], new RateControl(rateControllers[i], this.blockchain));
+            this.controllers.push(info);
+        }
+
+        // mark the last controller
+        this.controllers[this.controllers.length - 1].isLast = true;
+    }
+
+    /**
+     * Internal method for switching controller (when needed) in a duration-based round.
+     * @param {number} start The start time of the round provided by the client module.
+     * @param {number} idx The index of the current Tx provided by the client module.
+     * @private
+     */
+    async __controllerSwitchForDuration(start, idx) {
+        let active = this.controllers[this.activeControllerIndex];
+        const timeNow = Date.now();
+        if (active.isLast || ((timeNow - start) < active.relFinishTime)) {
+            return;
+        }
+
+        await active.controller.end();
+
+        this.activeControllerIndex++;
+        active = this.controllers[this.activeControllerIndex];
+        active.firstTxIndex = idx;
+        active.startTimeDifference = Date.now() - start;
+        if (this.logControllerChange) {
+            Util.log(`[CompositeRateController] Switching controller in Client#${this.clientIdx} at Tx#${idx} after ${active.startTimeDifference}ms.`);
+        }
+    }
+
+    /**
+     * Internal method for switching controller (when needed) in a Tx number-based round.
+     * @param {number} start The start time of the round provided by the client module.
+     * @param {number} idx The index of the current Tx provided by the client module.
+     * @private
+     */
+    async __controllerSwitchForTxNumber(start, idx) {
+        let active = this.controllers[this.activeControllerIndex];
+        if (active.isLast || (idx <= active.lastTxIndex)) {
+            return;
+        }
+
+        await active.controller.end();
+
+        this.activeControllerIndex++;
+        active = this.controllers[this.activeControllerIndex];
+        active.firstTxIndex = idx ;
+        active.startTimeDifference = Date.now() - start;
+        if (this.logControllerChange) {
+            Util.log(`[CompositeRateController] Switching controller in Client#${this.clientIdx} at Tx#${idx} after ${active.startTimeDifference}ms.`);
+        }
+    }
+
+    /**
+     * Initializes the composite rate controller.
+     *
+     * @param {object} msg Client options with adjusted per-client load settings.
+     * @param {string} msg.type The type of the message. Currently always 'test'
+     * @param {string} msg.label The label of the round.
+     * @param {object} msg.rateControl The rate control to use for the round.
+     * @param {number} msg.trim The number/seconds of transactions to trim from the results.
+     * @param {object} msg.args The user supplied arguments for the round.
+     * @param {string} msg.cb The path of the user's callback module.
+     * @param {string} msg.config The path of the network's configuration file.
+     * @param {number} msg.numb The number of transactions to generate during the round.
+     * @param {number} msg.txDuration The length of the round in SECONDS.
+     * @param {number} msg.totalClients The number of clients executing the round.
+     * @param {number} msg.clients The number of clients executing the round.
+     * @param {object} msg.clientargs Arguments for the client.
+     * @param {number} msg.clientIdx The index of the current client.
+     */
+    async init(msg) {
+        let currentSum = 0;
+        this.clientIdx = msg.clientIdx;
+
+        // pre-set switch logic to avoid an other condition check during rate control
+        this.controllerSwitch = msg.numb ? this.__controllerSwitchForTxNumber : this.__controllerSwitchForDuration;
+
+        for (let i = 0; i < this.controllers.length; ++i) {
+            let controllerData = this.controllers[i];
+            currentSum += controllerData.weight;
+
+            // create a modified copy of the client options according to the weights
+            let controllerMsg = Object.assign({}, msg);
+            controllerMsg.rateControl = controllerData.controllerOptions;
+
+            // scale down number of txs or duration
+            if (msg.numb) {
+                controllerMsg.numb = Math.floor(msg.numb * controllerData.weight);
+                controllerData.lastTxIndex = Math.floor(msg.numb * currentSum);
+            } else {
+                controllerMsg.txDuration = Math.floor(msg.txDuration * controllerData.weight);
+                controllerData.relFinishTime = Math.floor(msg.txDuration * 1000 * currentSum);
+            }
+
+            await controllerData.controller.init(controllerMsg);
+        }
+
+        this.activeControllerIndex = 0;
+    }
+
+    /**
+     * Perform the rate control by delegating to the currently active controller
+     * and switching controller (if necessary).
+     * @param {number} start The epoch time at the start of the round (ms precision).
+     * @param {number} idx Sequence number of the current transaction.
+     * @param {object[]} currentResults The list of results of finished transactions.
+     * @return {Promise} A promise that will resolve after the necessary time to keep the defined Tx rate.
+     */
+    async applyRateControl(start, idx, currentResults) {
+        await this.controllerSwitch(start, idx);
+        const active = this.controllers[this.activeControllerIndex];
+        // lie to the controller about the parameters to make this controller transparent
+        // NOTE: if the shallow copying of slice is too slow for higher TPS rates,
+        // consider making it configurable, maybe the underlying controllers do not need the results
+        return active.controller.applyRateControl(start + active.startTimeDifference, idx - active.firstTxIndex,
+            currentResults.slice(active.firstTxIndex));
+    }
+
+    /**
+     * Notify the rate controller about the end of the round.
+     *
+     * @return {Promise} The return promise
+     */
+    async end() {
+        return this.controllers[this.activeControllerIndex].controller.end();
+    }
+}
+
+module.exports = CompositeRateController;

--- a/src/comm/rate-control/noRate.js
+++ b/src/comm/rate-control/noRate.js
@@ -1,0 +1,77 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const RateInterface = require('./rateInterface.js');
+const Util = require('../util');
+
+/**
+ * Rate controller for pausing load generation for a given time.
+ *
+ * Can only be applied for duration-based rounds!
+ *
+ * @property {Blockchain} blockchain The initialized blockchain object.
+ * @property {object} options The user-supplied options for the controller.
+ */
+class NoRateController extends RateInterface{
+    /**
+     * Creates a new instance of the UnboundedRateController class.
+     * @constructor
+     * @param {Blockchain} blockchain The initialized blockchain object.
+     * @param {object} opts Options for the rate controller.
+     */
+    constructor(blockchain, opts) {
+        super(blockchain, opts);
+        this.sleepTime = 0;
+    }
+
+    /**
+     * Initializes the rate controller.
+     *
+     * @param {object} msg Client options with adjusted per-client load settings.
+     * @param {string} msg.type The type of the message. Currently always 'test'
+     * @param {string} msg.label The label of the round.
+     * @param {object} msg.rateControl The rate control to use for the round.
+     * @param {number} msg.trim The number/seconds of transactions to trim from the results.
+     * @param {object} msg.args The user supplied arguments for the round.
+     * @param {string} msg.cb The path of the user's callback module.
+     * @param {string} msg.config The path of the network's configuration file.
+     * @param {number} msg.numb The number of transactions to generate during the round.
+     * @param {number} msg.txDuration The length of the round in SECONDS.
+     * @param {number} msg.totalClients The number of clients executing the round.
+     * @param {number} msg.clients The number of clients executing the round.
+     * @param {object} msg.clientargs Arguments for the client.
+     */
+    async init(msg) {
+        if (msg.numb) {
+            throw new Error('This rate controller can only be applied for duration-based rounds');
+        }
+
+        this.sleepTime = msg.txDuration * 1000;
+    }
+
+    /**
+     * Perform the rate control by sleeping through the round.
+     * @param {number} start The epoch time at the start of the round (ms precision).
+     * @param {number} idx Sequence number of the current transaction.
+     * @param {object[]} currentResults The list of results of finished transactions.
+     * @return {Promise} A promise that will resolve after the necessary time to keep the defined Tx rate.
+     */
+    async applyRateControl(start, idx, currentResults) {
+        return Util.sleep(this.sleepTime);
+    }
+}
+
+module.exports = NoRateController;

--- a/src/comm/rate-control/rateControl.js
+++ b/src/comm/rate-control/rateControl.js
@@ -35,6 +35,16 @@ let RateControl = class {
             this.controller = new interval(blockchain, rateControl.opts);
             break;
         }
+        case 'composite-rate': {
+            const CompositeRateController = require('./compositeRate.js');
+            this.controller = new CompositeRateController(blockchain, rateControl.opts);
+            break;
+        }
+        case 'zero-rate': {
+            const NoRateController = require('./noRate.js');
+            this.controller = new NoRateController(blockchain, rateControl.opts);
+            break;
+        }
         default:
             throw new Error('Unknown rate control type ' + rateControl.type);
         }
@@ -60,6 +70,16 @@ let RateControl = class {
         return this.controller.applyRateControl(start, idx, results);
     }
 
+    /**
+     * Notify the rate controller about the end of the round.
+     *
+     * @return {Promise} The return promise.
+     */
+    end() {
+        if (typeof this.controller.end === 'function') {
+            return this.controller.end();
+        }
+    }
 };
 
 module.exports = RateControl;


### PR DESCRIPTION
The aim of this PR is to pave the road for advanced workload modelling. Contributions include:

* Added `end` method to the rate controller proxy to signal the end of a round (in a backward compatible/optional way).
* Modified round execution workflow to call this `end` method.
* Added a composite rate controller implementation.
* Added a zero rate controller implementation.
* Extended the rate controller documentation.
* Added a sample configuration to demonstrate the usage of the new controllers.
* Propagate client index to _local_ clients.

Signed-off-by: Attila Klenik <a.klenik@gmail.com>