### PR TITLE
Delete Unused Container

### DIFF
--- a/network/fabric/simplenetwork/docker-compose.yaml
+++ b/network/fabric/simplenetwork/docker-compose.yaml
@@ -189,11 +189,3 @@ services:
         - ./crypto-config/peerOrganizations/org2.example.com/peers/peer1.org2.example.com/:/etc/hyperledger/msp/peer
     depends_on:
       - orderer.example.com
-
-  couchdb:
-    container_name: couchdb
-    image: hyperledger/fabric-couchdb:x86_64-0.4.6
-    ports:
-      - 5984:5984
-    environment:
-      DB_URL: http://localhost:5984/member_db


### PR DESCRIPTION
In `network/fabric/simplenetwork/docker-compose.yaml` the container `couchdb` is defined but not used.