### PR TITLE
Fix rejected Fabric proposal handling

### DIFF
--- a/src/fabric/e2eUtils.js
+++ b/src/fabric/e2eUtils.js
@@ -608,7 +608,7 @@ async function invokebycontext(context, id, version, args, timeout){
                 // one_good = channel.verifyProposalResponse(proposal_response);
                 one_good = true;
             } else {
-                let err = new Error('Endorsement denied with status code: ' + proposal_response.response.status);
+                let err = new Error('Endorsement denied: ' + proposal_response.toString());
                 invokeStatus.error_flags |= TxErrorEnum.BadProposalResponseError;
                 invokeStatus.error_messages[TxErrorIndex.BadProposalResponseError] = err.toString();
                 // explicit rejection, early life-cycle termination, definitely failed


### PR DESCRIPTION
The error handling part of a rejected Fabric Tx proposal referenced an undefined attribute of the response.
In case of rejected proposal, an explicit `Error` object is returned as result (see [this SDK code](https://github.com/hyperledger/fabric-sdk-node/blob/bc7d7db22e209f3c2477a0023ba0e8a0201cebe6/fabric-client/lib/client-utils.js#L103)).

@haojun can you review this quick-fix?