### PR TITLE
Update Iroha to v1.0 beta-3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Caliper is a blockchain performance benchmark framework, which allows users to t
 Currently supported blockchain solutions:
 * [fabric v1.0+](https://github.com/hyperledger/fabric), the lastest version that has been verified is v1.1.0 
 * [sawtooth 1.0+](https://github.com/hyperledger/sawtooth-core)
-* [Iroha 1.0 beta-2](https://github.com/hyperledger/iroha)
+* [Iroha 1.0 beta-3](https://github.com/hyperledger/iroha)
 
 Hyperledger Composer is also supported, please see [Composer Performance Test](./docs/Composer.md).
 
@@ -35,7 +35,7 @@ Run `npm install` in caliper folder to install dependencies locally
 ### Install blockchain SDKs
 * Fabric
   * Install using the repository
-    * run `npm install fabric-ca-client fabric-client` in the root folder
+    * run `npm install grpc@1.10.1 fabric-ca-client fabric-client` in the root folder
     * If you want to test fabric with old version such as v1.1.0, you should install compatible client SDK,  
     e.g. `npm install fabric-ca-client@1.1.0 fabric-client@1.1.0` 
   
@@ -49,7 +49,7 @@ Run `npm install` in caliper folder to install dependencies locally
     * run `npm install sawtooth-sdk` in the root folder
 
 * Iroha
-  * Install Iroha Library by `npm install iroha-lib` in Caliper's root folder.
+  * Install Iroha Library by `npm install --no-save iroha-lib@0.1.7` in Caliper's root folder.
   * The package is in **alfa phase**, so if you have some problems with installing or compilation - please contact [Iroha maintainers](https://github.com/hyperledger/iroha/issues).
 
 * Composer

--- a/network/iroha/simplenetwork/docker-compose.yml
+++ b/network/iroha/simplenetwork/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   iroha-node0:
-    image: hyperledger/iroha@sha256:b26333a7fdd12f6bb31f159d65f67c380c22e8d88b10d2cc6ed89541ebc7798e
+    image: hyperledger/iroha@sha256:8e27c29fd3ebd8a999b63e79f6091a419bd91f0113acdeb600f66423f743bf29
     container_name: iroha_node0
     ports:
       - "50051:50051"
@@ -26,7 +26,7 @@ services:
       - SYS_PTRACE
 
   iroha-node1:
-    image: hyperledger/iroha@sha256:b26333a7fdd12f6bb31f159d65f67c380c22e8d88b10d2cc6ed89541ebc7798e
+    image: hyperledger/iroha@sha256:8e27c29fd3ebd8a999b63e79f6091a419bd91f0113acdeb600f66423f743bf29
     container_name: iroha_node1
     ports:
       - "50052:50051"

--- a/network/iroha/simplenetwork/node0/config.sample
+++ b/network/iroha/simplenetwork/node0/config.sample
@@ -3,10 +3,9 @@
   "torii_port" : 50051,
   "internal_port" : 10001,
   "pg_opt" : "host=iroha_pg0 port=5432 user=postgres password=mysecretpassword",
-  "redis_host" : "iroha_redis0",
-  "redis_port" : 6379,
   "max_proposal_size" : 10,
   "proposal_delay" : 5000,
   "vote_delay" : 5000,
-  "load_delay" : 5000
+  "load_delay" : 5000,
+  "mst_enable" : false
 }

--- a/network/iroha/simplenetwork/node1/config.sample
+++ b/network/iroha/simplenetwork/node1/config.sample
@@ -3,10 +3,9 @@
   "torii_port" : 50051,
   "internal_port" : 10001,
   "pg_opt" : "host=iroha_pg1 port=5432 user=postgres password=mysecretpassword",
-  "redis_host" : "iroha_redis1",
-  "redis_port" : 6379,
   "max_proposal_size" : 10,
   "proposal_delay" : 5000,
   "vote_delay" : 5000,
-  "load_delay" : 5000
+  "load_delay" : 5000,
+  "mst_enable" : false
 }

--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
     "commander": "^2.11.0",
     "dockerode": "^2.5.0",
     "fs-extra": "^4.0.2",
-    "grpc": "1.10.1",
-    "iroha-lib": "^0.1.4",
     "jsrsasign": "^8.0.4",
     "mustache": "^2.3.0",
     "node-zookeeper-client": "^0.2.2",


### PR DESCRIPTION
This PR introduces the new release of Iroha [v1.0 beta-3](https://github.com/hyperledger/iroha/releases/tag/v1.0.0_beta-3)

I actualized used containers in **docker-compose.yml**, simple benchmark code (we slightly changed our API) and node configs.

### PLEASE PAY ATTENTION: 

I removed grpc@1.10.1 from the main **package.json** because:
1. It sufficiently increases dependencies installing time by `npm install`. grpc _of this version_ compiles from sources, despite I have a very widespread system (Ubuntu 18.04, x86_64).
2. This grpc package conflicts with the version from **iroha-lib** package.

So I removed both dependencies and specify in README.md additional dependency iroha-lib@0.1.7 in Iroha's section and grpc@1.10.1 in Fabric's section. It's not the best solution, but I couldn't think of a better one

Also
We are planning to use Caliper in our CI to benchmark new versions of Iroha from this version. :+1: 
