### PR TITLE
Node CC and metadata support, node CC examples

### DIFF
--- a/benchmark/marbles/config-fabric-go.json
+++ b/benchmark/marbles/config-fabric-go.json
@@ -1,0 +1,42 @@
+{
+  "blockchain": {
+    "type": "fabric",
+    "config": "benchmark/marbles/fabric-go.json"
+  },
+  "command" : {
+    "start": "docker-compose -f network/fabric/2-org-1-peer/docker-compose-tls.yaml up -d",
+    "end" : "docker-compose -f network/fabric/2-org-1-peer/docker-compose-tls.yaml down;docker rm $(docker ps -aq);docker rmi $(docker images dev* -q)"
+  },
+  "test": {
+    "clients": {
+      "type": "local",
+      "number": 5
+    },
+    "rounds": [{
+        "label" : "init",
+        "txNumber" : [500, 500, 500],
+        "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 25}}, {"type": "fixed-rate", "opts": {"tps" : 50}}, {"type": "fixed-rate", "opts": {"tps" : 75}}],
+        "callback" : "benchmark/marbles/init.js"
+      },
+      {
+        "label" : "query",
+        "txNumber" : [15, 15],
+        "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 5}}, {"type": "fixed-rate", "opts": {"tps" : 5}}],
+        "callback" : "benchmark/marbles/query.js"
+      }]
+  },
+  "monitor": {
+    "type": ["docker", "process"],
+    "docker":{
+      "name": ["all"]
+    },
+    "process": [
+      {
+        "command" : "node",
+        "arguments" : "local-client.js",
+        "multiOutput" : "avg"
+      }
+    ],
+    "interval": 1
+  }
+}

--- a/benchmark/marbles/config-fabric-node.json
+++ b/benchmark/marbles/config-fabric-node.json
@@ -1,0 +1,42 @@
+{
+  "blockchain": {
+    "type": "fabric",
+    "config": "benchmark/marbles/fabric-node.json"
+  },
+  "command" : {
+    "start": "docker-compose -f network/fabric/2-org-1-peer/docker-compose-tls.yaml up -d",
+    "end" : "docker-compose -f network/fabric/2-org-1-peer/docker-compose-tls.yaml down;docker rm $(docker ps -aq);docker rmi $(docker images dev* -q)"
+  },
+  "test": {
+    "clients": {
+      "type": "local",
+      "number": 5
+    },
+    "rounds": [{
+      "label" : "init",
+      "txNumber" : [500, 500, 500],
+      "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 25}}, {"type": "fixed-rate", "opts": {"tps" : 50}}, {"type": "fixed-rate", "opts": {"tps" : 75}}],
+      "callback" : "benchmark/marbles/init.js"
+    },
+      {
+        "label" : "query",
+        "txNumber" : [15, 15],
+        "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 5}}, {"type": "fixed-rate", "opts": {"tps" : 5}}],
+        "callback" : "benchmark/marbles/query.js"
+      }]
+  },
+  "monitor": {
+    "type": ["docker", "process"],
+    "docker":{
+      "name": ["all"]
+    },
+    "process": [
+      {
+        "command" : "node",
+        "arguments" : "local-client.js",
+        "multiOutput" : "avg"
+      }
+    ],
+    "interval": 1
+  }
+}

--- a/benchmark/marbles/fabric-go.json
+++ b/benchmark/marbles/fabric-go.json
@@ -1,0 +1,91 @@
+{
+  "fabric": {
+    "cryptodir": "network/fabric/config/crypto-config",
+    "network": {
+      "orderer": {
+        "url": "grpcs://localhost:7050",
+        "mspid": "OrdererMSP",
+        "user": {
+          "key": "network/fabric/config/crypto-config/ordererOrganizations/example.com/users/Admin@example.com/msp/keystore/key.pem",
+          "cert": "network/fabric/config/crypto-config/ordererOrganizations/example.com/users/Admin@example.com/msp/signcerts/Admin@example.com-cert.pem"
+        },
+        "server-hostname": "orderer.example.com",
+        "tls_cacerts": "network/fabric/config/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt"
+      },
+      "org1": {
+        "name": "peerOrg1",
+        "mspid": "Org1MSP",
+        "user": {
+          "key": "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
+          "cert": "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem"
+        },
+        "ca": {
+          "url": "https://localhost:7054",
+          "name": "ca-org1"
+        },
+        "peer1": {
+          "requests": "grpcs://localhost:7051",
+          "events": "grpcs://localhost:7053",
+          "server-hostname": "peer0.org1.example.com",
+          "tls_cacerts": "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt"
+        }
+      },
+      "org2": {
+        "name": "peerOrg2",
+        "mspid": "Org2MSP",
+        "ca": {
+          "url": "https://localhost:8054",
+          "name": "ca-org2"
+        },
+        "peer1": {
+          "requests": "grpcs://localhost:8051",
+          "events": "grpcs://localhost:8053",
+          "server-hostname": "peer0.org2.example.com",
+          "tls_cacerts": "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt"
+        }
+      }
+    },
+    "channel": [
+      {
+        "name": "mychannel",
+        "config": "network/fabric/config/mychannel.tx",
+        "organizations": ["org1", "org2"],
+        "deployed": false
+      }
+    ],
+    "chaincodes": [{"id": "marbles", "path": "contract/fabric/marbles/go", "language":"golang", "version": "v1", "channel": "mychannel", "metadataPath": "src/contract/fabric/marbles/go/metadata"}],
+    "endorsement-policy": {
+      "identities": [
+        {
+          "role": {
+            "name": "member",
+            "mspId": "Org1MSP"
+          }
+        },
+        {
+          "role": {
+            "name": "member",
+            "mspId": "Org2MSP"
+          }
+        },
+        {
+          "role": {
+            "name": "admin",
+            "mspId": "Org1MSP"
+          }
+        }
+      ],
+      "policy": { "2-of": [{"signed-by": 0}, {"signed-by": 1}]}
+    },
+    "context": {
+      "init": "mychannel",
+      "query": "mychannel"
+    }
+  },
+  "info" : {
+    "Version": "1.1.0",
+    "Size": "2 Peers",
+    "Orderer": "Solo",
+    "Distribution": "Single Host"
+  }
+}

--- a/benchmark/marbles/fabric-node.json
+++ b/benchmark/marbles/fabric-node.json
@@ -1,0 +1,91 @@
+{
+  "fabric": {
+    "cryptodir": "network/fabric/config/crypto-config",
+    "network": {
+      "orderer": {
+        "url": "grpcs://localhost:7050",
+        "mspid": "OrdererMSP",
+        "user": {
+          "key": "network/fabric/config/crypto-config/ordererOrganizations/example.com/users/Admin@example.com/msp/keystore/key.pem",
+          "cert": "network/fabric/config/crypto-config/ordererOrganizations/example.com/users/Admin@example.com/msp/signcerts/Admin@example.com-cert.pem"
+        },
+        "server-hostname": "orderer.example.com",
+        "tls_cacerts": "network/fabric/config/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt"
+      },
+      "org1": {
+        "name": "peerOrg1",
+        "mspid": "Org1MSP",
+        "user": {
+          "key": "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
+          "cert": "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem"
+        },
+        "ca": {
+          "url": "https://localhost:7054",
+          "name": "ca-org1"
+        },
+        "peer1": {
+          "requests": "grpcs://localhost:7051",
+          "events": "grpcs://localhost:7053",
+          "server-hostname": "peer0.org1.example.com",
+          "tls_cacerts": "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt"
+        }
+      },
+      "org2": {
+        "name": "peerOrg2",
+        "mspid": "Org2MSP",
+        "ca": {
+          "url": "https://localhost:8054",
+          "name": "ca-org2"
+        },
+        "peer1": {
+          "requests": "grpcs://localhost:8051",
+          "events": "grpcs://localhost:8053",
+          "server-hostname": "peer0.org2.example.com",
+          "tls_cacerts": "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt"
+        }
+      }
+    },
+    "channel": [
+      {
+        "name": "mychannel",
+        "config": "network/fabric/config/mychannel.tx",
+        "organizations": ["org1", "org2"],
+        "deployed": false
+      }
+    ],
+    "chaincodes": [{"id": "marbles", "path": "src/contract/fabric/marbles/node", "language":"node", "version": "v1", "channel": "mychannel", "metadataPath": "src/contract/fabric/marbles/node/metadata"}],
+    "endorsement-policy": {
+      "identities": [
+        {
+          "role": {
+            "name": "member",
+            "mspId": "Org1MSP"
+          }
+        },
+        {
+          "role": {
+            "name": "member",
+            "mspId": "Org2MSP"
+          }
+        },
+        {
+          "role": {
+            "name": "admin",
+            "mspId": "Org1MSP"
+          }
+        }
+      ],
+      "policy": { "2-of": [{"signed-by": 0}, {"signed-by": 1}]}
+    },
+    "context": {
+      "init": "mychannel",
+      "query": "mychannel"
+    }
+  },
+  "info" : {
+    "Version": "1.1.0",
+    "Size": "2 Peers",
+    "Orderer": "Solo",
+    "Distribution": "Single Host"
+  }
+}

--- a/benchmark/marbles/init.js
+++ b/benchmark/marbles/init.js
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+module.exports.info  = 'Creating marbles.';
+
+let txIndex = 0;
+let colors = ['red', 'blue', 'green', 'black', 'white', 'pink', 'rainbow'];
+let owners = ['Alice', 'Bob', 'Claire', 'David'];
+let bc, contx;
+module.exports.init = function(blockchain, context, args) {
+    bc = blockchain;
+    contx = context;
+    return Promise.resolve();
+};
+
+module.exports.run = function() {
+    txIndex++;
+    return bc.invokeSmartContract(contx, 'marbles', 'v1',
+        {
+            verb: 'initMarble',
+            name: 'marble_' + txIndex.toString() + '_' + process.pid.toString(),
+            color: colors[txIndex % colors.length],
+            size: (((txIndex % 10) + 1) * 10).toString(), // [10, 100]
+            owner: owners[txIndex % owners.length]
+        }, 30);
+};
+
+module.exports.end = function(results) {
+    return Promise.resolve();
+};

--- a/benchmark/marbles/main.js
+++ b/benchmark/marbles/main.js
@@ -1,0 +1,100 @@
+/**
+* Copyright 2017 HUAWEI. All Rights Reserved.
+*
+* SPDX-License-Identifier: Apache-2.0
+*
+*/
+
+
+'use strict';
+
+const Util = require('../../src/comm/util');
+
+let configFile;
+let networkFile;
+
+/**
+ * Set benchmark config file
+ * @param {*} file config file of the benchmark,  default is config.json
+ */
+function setConfig(file) {
+    configFile = file;
+}
+
+/**
+ * Set benchmark network file
+ * @param {*} file config file of the blockchain system, eg: fabric.json
+ */
+function setNetwork(file) {
+    networkFile = file;
+}
+
+/**
+ * Entry point of the Benchmarking script.
+ */
+function main() {
+    let program = require('commander');
+    program.version('0.1')
+        .option('-c, --config <file>', 'config file of the benchmark, default is config.json', setConfig)
+        .option('-n, --network <file>', 'config file of the blockchain system under test, if not provided, blockchain property in benchmark config is used', setNetwork)
+        .parse(process.argv);
+
+    const path = require('path');
+    const fs = require('fs-extra');
+    let absConfigFile;
+    if(typeof configFile === 'undefined') {
+        absConfigFile = path.join(__dirname, 'config.json');
+    }
+    else {
+        absConfigFile = path.join(__dirname, configFile);
+    }
+    if(!fs.existsSync(absConfigFile)) {
+        Util.log('file ' + absConfigFile + ' does not exist');
+        return;
+    }
+
+    let absNetworkFile;
+    let absCaliperDir = path.join(__dirname, '../..');
+    if(typeof networkFile === 'undefined') {
+        try{
+            let config = require(absConfigFile);
+            absNetworkFile = path.join(absCaliperDir, config.blockchain.config);
+        }
+        catch(err) {
+            Util.log('failed to find blockchain.config in ' + absConfigFile);
+            return;
+        }
+    }
+    else {
+        absNetworkFile = path.join(__dirname, networkFile);
+    }
+    if(!fs.existsSync(absNetworkFile)) {
+        Util.log('file ' + absNetworkFile + ' does not exist');
+        return;
+    }
+
+
+    const framework = require('../../src/comm/bench-flow.js');
+    framework.run(absConfigFile, absNetworkFile);
+}
+
+main();
+
+
+
+
+
+
+/*
+var config_path;
+if(process.argv.length < 3) {
+    config_path = path.join(__dirname, 'config.json');
+}
+else {
+    config_path = path.join(__dirname, process.argv[2]);
+}
+
+// use default framework to run the tests
+var framework = require('../../src/comm/bench-flow.js');
+framework.run(config_path);
+*/

--- a/benchmark/marbles/query.js
+++ b/benchmark/marbles/query.js
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+module.exports.info  = 'Querying marbles.';
+
+let txIndex = 0;
+let owners = ['Alice', 'Bob', 'Claire', 'David'];
+let bc, contx;
+module.exports.init = function(blockchain, context, args) {
+    bc = blockchain;
+    contx = context;
+    return Promise.resolve();
+};
+
+module.exports.run = function() {
+    txIndex++;
+    // TODO: until Fabric query is implemented, use invoke
+    return bc.invokeSmartContract(contx, 'marbles', 'v1',
+        {
+            verb: 'queryMarblesByOwner',
+            owner: owners[txIndex % owners.length]
+        }, 120);
+};
+
+module.exports.end = function(results) {
+    return Promise.resolve();
+};

--- a/benchmark/simple/config-node.json
+++ b/benchmark/simple/config-node.json
@@ -1,28 +1,30 @@
 {
   "blockchain": {
     "type": "fabric",
-    "config": "benchmark/simple/fabric.json"
+    "config": "benchmark/simple/fabric-node.json"
   },
   "command" : {
     "start": "docker-compose -f network/fabric/simplenetwork/docker-compose.yaml up -d",
     "end" : "docker-compose -f network/fabric/simplenetwork/docker-compose.yaml down;docker rm $(docker ps -aq);docker rmi $(docker images dev* -q)"
   },
   "test": {
+    "name": "simple",
+    "description" : "This is an example benchmark for caliper, to test the backend DLT's performance with simple account opening & querying transactions",
     "clients": {
       "type": "local",
       "number": 5
     },
     "rounds": [{
         "label" : "open",
-        "txNumber" : [5000, 5000, 5000],
-        "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 100}}, {"type": "fixed-rate", "opts": {"tps" : 200}}, {"type": "fixed-rate", "opts": {"tps" : 300}}],
-        "arguments": {  "money": 10000 },
+        "txNumber" : [1000, 1000, 1000],
+        "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 50}}, {"type": "fixed-rate", "opts": {"tps" : 100}}, {"type": "fixed-rate", "opts": {"tps" : 150}}],
+        "arguments": { "money": 10000 },
         "callback" : "benchmark/simple/open.js"
       },
       {
         "label" : "query",
         "txNumber" : [5000, 5000],
-        "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 300}}, {"type": "fixed-rate", "opts": {"tps" : 400}}],
+        "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 100}}, {"type": "fixed-rate", "opts": {"tps" : 200}}],
         "callback" : "benchmark/simple/query.js"
       }]
   },

--- a/benchmark/simple/config.json
+++ b/benchmark/simple/config.json
@@ -5,7 +5,7 @@
   },
   "command" : {
     "start": "docker-compose -f network/fabric/simplenetwork/docker-compose.yaml up -d",
-    "end" : "docker-compose -f network/fabric/simplenetwork/docker-compose.yaml down;docker rm $(docker ps -aq)"
+    "end" : "docker-compose -f network/fabric/simplenetwork/docker-compose.yaml down;docker rm $(docker ps -aq);docker rmi $(docker images dev* -q)"
   },
   "test": {
     "name": "simple",

--- a/benchmark/simple/fabric-node.json
+++ b/benchmark/simple/fabric-node.json
@@ -3,29 +3,35 @@
     "cryptodir": "network/fabric/simplenetwork/crypto-config",
     "network": {
       "orderer": {
-        "url": "grpcs://10.229.42.159:7050",
+        "url": "grpcs://localhost:7050",
         "mspid": "OrdererMSP",
-        "msp": "network/fabric/simplenetwork/crypto-config/ordererOrganizations/example.com/msp/",
+        "user": {
+          "key": "network/fabric/simplenetwork/crypto-config/ordererOrganizations/example.com/users/Admin@example.com/msp/keystore/be595291403ff68280a724d7e868521815ad9e2fc8c5486f6d7ce6b62d6357cd_sk",
+          "cert": "network/fabric/simplenetwork/crypto-config/ordererOrganizations/example.com/users/Admin@example.com/msp/signcerts/Admin@example.com-cert.pem"
+        },
         "server-hostname": "orderer.example.com",
         "tls_cacerts": "network/fabric/simplenetwork/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt"
       },
       "org1": {
         "name": "peerOrg1",
         "mspid": "Org1MSP",
-        "msp": "network/fabric/simplenetwork/crypto-config/peerOrganizations/org1.example.com/msp/",
+        "user": {
+          "key": "network/fabric/simplenetwork/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/0d2b2fc385b10fa59003217e1bb5af2d24a3d762266e287867a1bc290eb44657_sk",
+          "cert": "network/fabric/simplenetwork/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem"
+        },
         "ca": {
-          "url": "https://10.229.42.159:7054",
+          "url": "https://localhost:7054",
           "name": "ca-org1"
         },
         "peer1": {
-          "requests": "grpcs://10.229.42.159:7051",
-          "events": "grpcs://10.229.42.159:7053",
+          "requests": "grpcs://localhost:7051",
+          "events": "grpcs://localhost:7053",
           "server-hostname": "peer0.org1.example.com",
           "tls_cacerts": "network/fabric/simplenetwork/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt"
         },
         "peer2": {
-          "requests": "grpcs://10.229.42.159:7057",
-          "events": "grpcs://10.229.42.159:7059",
+          "requests": "grpcs://localhost:7057",
+          "events": "grpcs://localhost:7059",
           "server-hostname": "peer1.org1.example.com",
           "tls_cacerts": "network/fabric/simplenetwork/crypto-config/peerOrganizations/org1.example.com/peers/peer1.org1.example.com/tls/ca.crt"
         }
@@ -33,20 +39,19 @@
       "org2": {
         "name": "peerOrg2",
         "mspid": "Org2MSP",
-        "msp": "network/fabric/simplenetwork/crypto-config/peerOrganizations/org2.example.com/msp/",
         "ca": {
-          "url": "https://10.229.42.159:8054",
+          "url": "https://localhost:8054",
           "name": "ca-org2"
         },
         "peer1": {
-          "requests": "grpcs://10.229.42.159:8051",
-          "events": "grpcs://10.229.42.159:8053",
+          "requests": "grpcs://localhost:8051",
+          "events": "grpcs://localhost:8053",
           "server-hostname": "peer0.org2.example.com",
           "tls_cacerts": "network/fabric/simplenetwork/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt"
         },
         "peer2": {
-          "requests": "grpcs://10.229.42.159:8057",
-          "events": "grpcs://10.229.42.159:8059",
+          "requests": "grpcs://localhost:8057",
+          "events": "grpcs://localhost:8059",
           "server-hostname": "peer1.org2.example.com",
           "tls_cacerts": "network/fabric/simplenetwork/crypto-config/peerOrganizations/org2.example.com/peers/peer1.org2.example.com/tls/ca.crt"
         }
@@ -56,10 +61,11 @@
       {
         "name": "mychannel",
         "config": "network/fabric/simplenetwork/mychannel.tx",
-        "organizations": ["org1", "org2"]
+        "organizations": ["org1", "org2"],
+        "deployed": false
       }
     ],
-    "chaincodes": [{"id": "simple", "path": "contract/fabric/simple/go", "language":"golang", "version": "v0", "channel": "mychannel"}],
+    "chaincodes": [{"id": "simple", "path": "src/contract/fabric/simple/node", "language":"node", "version": "v0", "channel": "mychannel"}],
     "endorsement-policy": {
       "identities": [
         {
@@ -89,7 +95,7 @@
     }
   },
   "info" : {
-    "Version": "1.0.5",
+    "Version": "1.1.0",
     "Size": "4 Peers",
     "Orderer": "Solo",
     "Distribution": "Single Host"

--- a/benchmark/simple/fabric.json
+++ b/benchmark/simple/fabric.json
@@ -65,7 +65,7 @@
         "deployed": false
       }
     ],
-    "chaincodes": [{"id": "simple", "path": "contract/fabric/simple", "language":"golang", "version": "v0", "channel": "mychannel"}],
+    "chaincodes": [{"id": "simple", "path": "contract/fabric/simple/go", "language":"golang", "version": "v0", "channel": "mychannel"}],
     "endorsement-policy": {
       "identities": [
         {

--- a/docs/Fabric Configuration.md
+++ b/docs/Fabric Configuration.md
@@ -62,12 +62,20 @@ The fabric configuration is a json file which defines a fabric object with six m
 }
 ```
 
-* **chaincodes**: defines one or more chaincodes, those chaincodes can be installed and instantiated on all peers of the specific channel by calling *Blockchain.installSmartContract()* function.  
+* **chaincodes**: defines one or more chaincodes, those chaincodes can be installed and instantiated on all peers of the specific channel by calling `Blockchain.installSmartContract()` function.  
   
-  Optionally an `init` attribute can also be set to an array of *string* values. This array will be passed as the argument to the chaincode's *Init* method. The `init` attribute defaults to an empty array.
+  Optionally an `init` attribute can also be set to an array of *string* values. This array will be passed as the argument to the chaincode's `Init` method. The `init` attribute defaults to an empty array.
   
-  The *path* attribute is relative to the *caliper/src* folder, since *$GOPATH* is temporarily set to the caliper root folder during benchmark execution. If you would like to install a Golang chaincode from a previously set *$GOPATH*, then set the *OVERWRITE_GOPATH* environment variable to *FALSE* before running the benchmark:  
+  The `language` property denotes the chaincode platform (i.e., the language it's written in). The currently supported values (by Caliper and the SDK) are: `golang` (default) and `node`.
+  
+  *Golang chaincode:* The `path` attribute by default is relative to the `caliper/src` folder, since `$GOPATH` is temporarily set to the Caliper root folder during benchmark execution. If you would like to install a Golang chaincode from a previously set `$GOPATH`, then set the `OVERWRITE_GOPATH` environment variable to `FALSE` before running the benchmark:  
+  
   ```GOPATH=~/mygopath OVERWRITE_GOPATH=FALSE node main.js```
+  
+  *Node.js chaincode:* The `path` attribute can be either relative to the Caliper root folder or an absolute path. Node.js chaincodes are supported starting from version `1.1.0` of Fabric and the Node SDK, so make sure that the Docker image and the SDK versions are appropriate. 
+  
+  The `metadataPath` attribute (for both languages) denotes any extra metadata that should be deployed with the chaincode, e.g., the CouchDB indexes to build. The `metadataPath` attribute can be either relative to the Caliper root folder or an absolute path. For the necessary folder structure, please refer to the [SDK documentation](https://fabric-sdk-node.github.io/tutorial-metadata-chaincode.html).
+  
 ```json
 {
   "chaincodes": [
@@ -76,7 +84,9 @@ The fabric configuration is a json file which defines a fabric object with six m
       "path": "contract/fabric/drm", 
       "version": "v0", 
       "channel": "mychannel",
-      "init": ["init_arg1", "init_arg2"]
+      "init": ["init_arg1", "init_arg2"],
+      "language": "golang",
+      "metadataPath": "src/contract/fabric/drm/metadata"
     }
   ]
 }

--- a/src/comm/util.js
+++ b/src/comm/util.js
@@ -13,10 +13,15 @@
  */
 
 'use strict';
+const path = require('path');
+
+// comm --> src --> root
+const rootDir = path.join('..', '..');
 
 /**
  * Internal Utility class for Caliper
- */class Util {
+ */
+class Util {
 
     /**
      * Perform a sleep
@@ -34,6 +39,24 @@
     static log(...msg) {
         // eslint-disable-next-line no-console
         console.log(...msg);
+    }
+
+    /**
+     * Creates an absolute path from the provided relative path if necessary.
+     * @param {String} relOrAbsPath The relative or absolute path to convert to an absolute path.
+     *                              Relative paths are considered relative to the Caliper root folder.
+     * @return {String} The resolved absolute path.
+     */
+    static resolvePath(relOrAbsPath) {
+        if (!relOrAbsPath) {
+            throw new Error('Util.resolvePath: Parameter is undefined');
+        }
+
+        if (path.isAbsolute(relOrAbsPath)) {
+            return relOrAbsPath;
+        }
+
+        return path.join(__dirname, rootDir, relOrAbsPath);
     }
 }
 

--- a/src/contract/fabric/marbles/go/marbles.go
+++ b/src/contract/fabric/marbles/go/marbles.go
@@ -1,0 +1,657 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+/*
+* NOTE: This implementation is a replica of the following:
+* https://github.com/hyperledger/fabric-samples/blob/release-1.1/chaincode/marbles02/node/marbles_chaincode.js
+*/
+
+// ====CHAINCODE EXECUTION SAMPLES (CLI) ==================
+
+// ==== Invoke marbles ====
+// peer chaincode invoke -C myc1 -n marbles -c '{"Args":["initMarble","marble1","blue","35","tom"]}'
+// peer chaincode invoke -C myc1 -n marbles -c '{"Args":["initMarble","marble2","red","50","tom"]}'
+// peer chaincode invoke -C myc1 -n marbles -c '{"Args":["initMarble","marble3","blue","70","tom"]}'
+// peer chaincode invoke -C myc1 -n marbles -c '{"Args":["transferMarble","marble2","jerry"]}'
+// peer chaincode invoke -C myc1 -n marbles -c '{"Args":["transferMarblesBasedOnColor","blue","jerry"]}'
+// peer chaincode invoke -C myc1 -n marbles -c '{"Args":["delete","marble1"]}'
+
+// ==== Query marbles ====
+// peer chaincode query -C myc1 -n marbles -c '{"Args":["readMarble","marble1"]}'
+// peer chaincode query -C myc1 -n marbles -c '{"Args":["getMarblesByRange","marble1","marble3"]}'
+// peer chaincode query -C myc1 -n marbles -c '{"Args":["getHistoryForMarble","marble1"]}'
+
+// Rich Query (Only supported if CouchDB is used as state database):
+//   peer chaincode query -C myc1 -n marbles -c '{"Args":["queryMarblesByOwner","tom"]}'
+//   peer chaincode query -C myc1 -n marbles -c '{"Args":["queryMarbles","{\"selector\":{\"owner\":\"tom\"}}"]}'
+
+// INDEXES TO SUPPORT COUCHDB RICH QUERIES
+//
+// Indexes in CouchDB are required in order to make JSON queries efficient and are required for
+// any JSON query with a sort. As of Hyperledger Fabric 1.1, indexes may be packaged alongside
+// chaincode in a META-INF/statedb/couchdb/indexes directory. Each index must be defined in its own
+// text file with extension *.json with the index definition formatted in JSON following the
+// CouchDB index JSON syntax as documented at:
+// http://docs.couchdb.org/en/2.1.1/api/database/find.html#db-index
+//
+// This marbles02 example chaincode demonstrates a packaged
+// index which you can find in META-INF/statedb/couchdb/indexes/indexOwner.json.
+// For deployment of chaincode to production environments, it is recommended
+// to define any indexes alongside chaincode so that the chaincode and supporting indexes
+// are deployed automatically as a unit, once the chaincode has been installed on a peer and
+// instantiated on a channel. See Hyperledger Fabric documentation for more details.
+//
+// If you have access to the your peer's CouchDB state database in a development environment,
+// you may want to iteratively test various indexes in support of your chaincode queries.  You
+// can use the CouchDB Fauxton interface or a command line curl utility to create and update
+// indexes. Then once you finalize an index, include the index definition alongside your
+// chaincode in the META-INF/statedb/couchdb/indexes directory, for packaging and deployment
+// to managed environments.
+//
+// In the examples below you can find index definitions that support marbles02
+// chaincode queries, along with the syntax that you can use in development environments
+// to create the indexes in the CouchDB Fauxton interface or a curl command line utility.
+//
+
+//Example hostname:port configurations to access CouchDB.
+//
+//To access CouchDB docker container from within another docker container or from vagrant environments:
+// http://couchdb:5984/
+//
+//Inside couchdb docker container
+// http://127.0.0.1:5984/
+
+// Index for docType, owner.
+// Note that docType and owner fields must be prefixed with the "data" wrapper
+//
+// Index definition for use with Fauxton interface
+// {"index":{"fields":["data.docType","data.owner"]},"ddoc":"indexOwnerDoc", "name":"indexOwner","type":"json"}
+//
+// Example curl command line to define index in the CouchDB channel_chaincode database
+// curl -i -X POST -H "Content-Type: application/json" -d "{\"index\":{\"fields\":[\"data.docType\",\"data.owner\"]},\"name\":\"indexOwner\",\"ddoc\":\"indexOwnerDoc\",\"type\":\"json\"}" http://hostname:port/myc1_marbles/_index
+//
+
+// Index for docType, owner, size (descending order).
+// Note that docType, owner and size fields must be prefixed with the "data" wrapper
+//
+// Index definition for use with Fauxton interface
+// {"index":{"fields":[{"data.size":"desc"},{"data.docType":"desc"},{"data.owner":"desc"}]},"ddoc":"indexSizeSortDoc", "name":"indexSizeSortDesc","type":"json"}
+//
+// Example curl command line to define index in the CouchDB channel_chaincode database
+// curl -i -X POST -H "Content-Type: application/json" -d "{\"index\":{\"fields\":[{\"data.size\":\"desc\"},{\"data.docType\":\"desc\"},{\"data.owner\":\"desc\"}]},\"ddoc\":\"indexSizeSortDoc\", \"name\":\"indexSizeSortDesc\",\"type\":\"json\"}" http://hostname:port/myc1_marbles/_index
+
+// Rich Query with index design doc and index name specified (Only supported if CouchDB is used as state database):
+//   peer chaincode query -C myc1 -n marbles -c '{"Args":["queryMarbles","{\"selector\":{\"docType\":\"marble\",\"owner\":\"tom\"}, \"use_index\":[\"_design/indexOwnerDoc\", \"indexOwner\"]}"]}'
+
+// Rich Query with index design doc specified only (Only supported if CouchDB is used as state database):
+//   peer chaincode query -C myc1 -n marbles -c '{"Args":["queryMarbles","{\"selector\":{\"docType\":{\"$eq\":\"marble\"},\"owner\":{\"$eq\":\"tom\"},\"size\":{\"$gt\":0}},\"fields\":[\"docType\",\"owner\",\"size\"],\"sort\":[{\"size\":\"desc\"}],\"use_index\":\"_design/indexSizeSortDoc\"}"]}'
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+	pb "github.com/hyperledger/fabric/protos/peer"
+)
+
+// SimpleChaincode example simple Chaincode implementation
+type SimpleChaincode struct {
+}
+
+type marble struct {
+	ObjectType string `json:"docType"` //docType is used to distinguish the various types of objects in state database
+	Name       string `json:"name"`    //the fieldtags are needed to keep case from bouncing around
+	Color      string `json:"color"`
+	Size       int    `json:"size"`
+	Owner      string `json:"owner"`
+}
+
+// ===================================================================================
+// Main
+// ===================================================================================
+func main() {
+	err := shim.Start(new(SimpleChaincode))
+	if err != nil {
+		fmt.Printf("Error starting Simple chaincode: %s", err)
+	}
+}
+
+// Init initializes chaincode
+// ===========================
+func (t *SimpleChaincode) Init(stub shim.ChaincodeStubInterface) pb.Response {
+	return shim.Success(nil)
+}
+
+// Invoke - Our entry point for Invocations
+// ========================================
+func (t *SimpleChaincode) Invoke(stub shim.ChaincodeStubInterface) pb.Response {
+	function, args := stub.GetFunctionAndParameters()
+	fmt.Println("invoke is running " + function)
+
+	// Handle different functions
+	if function == "initMarble" { //create a new marble
+		return t.initMarble(stub, args)
+	} else if function == "transferMarble" { //change owner of a specific marble
+		return t.transferMarble(stub, args)
+	} else if function == "transferMarblesBasedOnColor" { //transfer all marbles of a certain color
+		return t.transferMarblesBasedOnColor(stub, args)
+	} else if function == "delete" { //delete a marble
+		return t.delete(stub, args)
+	} else if function == "readMarble" { //read a marble
+		return t.readMarble(stub, args)
+	} else if function == "queryMarblesByOwner" { //find marbles for owner X using rich query
+		return t.queryMarblesByOwner(stub, args)
+	} else if function == "queryMarbles" { //find marbles based on an ad hoc rich query
+		return t.queryMarbles(stub, args)
+	} else if function == "getHistoryForMarble" { //get history of values for a marble
+		return t.getHistoryForMarble(stub, args)
+	} else if function == "getMarblesByRange" { //get marbles based on range query
+		return t.getMarblesByRange(stub, args)
+	}
+
+	fmt.Println("invoke did not find func: " + function) //error
+	return shim.Error("Received unknown function invocation")
+}
+
+// ============================================================
+// initMarble - create a new marble, store into chaincode state
+// ============================================================
+func (t *SimpleChaincode) initMarble(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+	var err error
+
+	//   0       1       2     3
+	// "asdf", "blue", "35", "bob"
+	if len(args) != 4 {
+		return shim.Error("Incorrect number of arguments. Expecting 4")
+	}
+
+	// ==== Input sanitation ====
+	fmt.Println("- start init marble")
+	if len(args[0]) <= 0 {
+		return shim.Error("1st argument must be a non-empty string")
+	}
+	if len(args[1]) <= 0 {
+		return shim.Error("2nd argument must be a non-empty string")
+	}
+	if len(args[2]) <= 0 {
+		return shim.Error("3rd argument must be a non-empty string")
+	}
+	if len(args[3]) <= 0 {
+		return shim.Error("4th argument must be a non-empty string")
+	}
+	marbleName := args[0]
+	color := strings.ToLower(args[1])
+	owner := strings.ToLower(args[3])
+	size, err := strconv.Atoi(args[2])
+	if err != nil {
+		return shim.Error("3rd argument must be a numeric string")
+	}
+
+	// ==== Check if marble already exists ====
+	marbleAsBytes, err := stub.GetState(marbleName)
+	if err != nil {
+		return shim.Error("Failed to get marble: " + err.Error())
+	} else if marbleAsBytes != nil {
+		fmt.Println("This marble already exists: " + marbleName)
+		return shim.Error("This marble already exists: " + marbleName)
+	}
+
+	// ==== Create marble object and marshal to JSON ====
+	objectType := "marble"
+	marble := &marble{objectType, marbleName, color, size, owner}
+	marbleJSONasBytes, err := json.Marshal(marble)
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+	//Alternatively, build the marble json string manually if you don't want to use struct marshalling
+	//marbleJSONasString := `{"docType":"Marble",  "name": "` + marbleName + `", "color": "` + color + `", "size": ` + strconv.Itoa(size) + `, "owner": "` + owner + `"}`
+	//marbleJSONasBytes := []byte(str)
+
+	// === Save marble to state ===
+	err = stub.PutState(marbleName, marbleJSONasBytes)
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+
+	//  ==== Index the marble to enable color-based range queries, e.g. return all blue marbles ====
+	//  An 'index' is a normal key/value entry in state.
+	//  The key is a composite key, with the elements that you want to range query on listed first.
+	//  In our case, the composite key is based on indexName~color~name.
+	//  This will enable very efficient state range queries based on composite keys matching indexName~color~*
+	indexName := "color~name"
+	colorNameIndexKey, err := stub.CreateCompositeKey(indexName, []string{marble.Color, marble.Name})
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+	//  Save index entry to state. Only the key name is needed, no need to store a duplicate copy of the marble.
+	//  Note - passing a 'nil' value will effectively delete the key from state, therefore we pass null character as value
+	value := []byte{0x00}
+	stub.PutState(colorNameIndexKey, value)
+
+	// ==== Marble saved and indexed. Return success ====
+	fmt.Println("- end init marble")
+	return shim.Success(nil)
+}
+
+// ===============================================
+// readMarble - read a marble from chaincode state
+// ===============================================
+func (t *SimpleChaincode) readMarble(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+	var name, jsonResp string
+	var err error
+
+	if len(args) != 1 {
+		return shim.Error("Incorrect number of arguments. Expecting name of the marble to query")
+	}
+
+	name = args[0]
+	valAsbytes, err := stub.GetState(name) //get the marble from chaincode state
+	if err != nil {
+		jsonResp = "{\"Error\":\"Failed to get state for " + name + "\"}"
+		return shim.Error(jsonResp)
+	} else if valAsbytes == nil {
+		jsonResp = "{\"Error\":\"Marble does not exist: " + name + "\"}"
+		return shim.Error(jsonResp)
+	}
+
+	return shim.Success(valAsbytes)
+}
+
+// ==================================================
+// delete - remove a marble key/value pair from state
+// ==================================================
+func (t *SimpleChaincode) delete(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+	var jsonResp string
+	var marbleJSON marble
+	if len(args) != 1 {
+		return shim.Error("Incorrect number of arguments. Expecting 1")
+	}
+	marbleName := args[0]
+
+	// to maintain the color~name index, we need to read the marble first and get its color
+	valAsbytes, err := stub.GetState(marbleName) //get the marble from chaincode state
+	if err != nil {
+		jsonResp = "{\"Error\":\"Failed to get state for " + marbleName + "\"}"
+		return shim.Error(jsonResp)
+	} else if valAsbytes == nil {
+		jsonResp = "{\"Error\":\"Marble does not exist: " + marbleName + "\"}"
+		return shim.Error(jsonResp)
+	}
+
+	err = json.Unmarshal([]byte(valAsbytes), &marbleJSON)
+	if err != nil {
+		jsonResp = "{\"Error\":\"Failed to decode JSON of: " + marbleName + "\"}"
+		return shim.Error(jsonResp)
+	}
+
+	err = stub.DelState(marbleName) //remove the marble from chaincode state
+	if err != nil {
+		return shim.Error("Failed to delete state:" + err.Error())
+	}
+
+	// maintain the index
+	indexName := "color~name"
+	colorNameIndexKey, err := stub.CreateCompositeKey(indexName, []string{marbleJSON.Color, marbleJSON.Name})
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+
+	//  Delete index entry to state.
+	err = stub.DelState(colorNameIndexKey)
+	if err != nil {
+		return shim.Error("Failed to delete state:" + err.Error())
+	}
+	return shim.Success(nil)
+}
+
+// ===========================================================
+// transfer a marble by setting a new owner name on the marble
+// ===========================================================
+func (t *SimpleChaincode) transferMarble(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+
+	//   0       1
+	// "name", "bob"
+	if len(args) < 2 {
+		return shim.Error("Incorrect number of arguments. Expecting 2")
+	}
+
+	marbleName := args[0]
+	newOwner := strings.ToLower(args[1])
+	fmt.Println("- start transferMarble ", marbleName, newOwner)
+
+	marbleAsBytes, err := stub.GetState(marbleName)
+	if err != nil {
+		return shim.Error("Failed to get marble:" + err.Error())
+	} else if marbleAsBytes == nil {
+		return shim.Error("Marble does not exist")
+	}
+
+	marbleToTransfer := marble{}
+	err = json.Unmarshal(marbleAsBytes, &marbleToTransfer) //unmarshal it aka JSON.parse()
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+	marbleToTransfer.Owner = newOwner //change the owner
+
+	marbleJSONasBytes, _ := json.Marshal(marbleToTransfer)
+	err = stub.PutState(marbleName, marbleJSONasBytes) //rewrite the marble
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+
+	fmt.Println("- end transferMarble (success)")
+	return shim.Success(nil)
+}
+
+// ===========================================================================================
+// getMarblesByRange performs a range query based on the start and end keys provided.
+
+// Read-only function results are not typically submitted to ordering. If the read-only
+// results are submitted to ordering, or if the query is used in an update transaction
+// and submitted to ordering, then the committing peers will re-execute to guarantee that
+// result sets are stable between endorsement time and commit time. The transaction is
+// invalidated by the committing peers if the result set has changed between endorsement
+// time and commit time.
+// Therefore, range queries are a safe option for performing update transactions based on query results.
+// ===========================================================================================
+func (t *SimpleChaincode) getMarblesByRange(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+
+	if len(args) < 2 {
+		return shim.Error("Incorrect number of arguments. Expecting 2")
+	}
+
+	startKey := args[0]
+	endKey := args[1]
+
+	resultsIterator, err := stub.GetStateByRange(startKey, endKey)
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+	defer resultsIterator.Close()
+
+	// buffer is a JSON array containing QueryResults
+	var buffer bytes.Buffer
+	buffer.WriteString("[")
+
+	bArrayMemberAlreadyWritten := false
+	for resultsIterator.HasNext() {
+		queryResponse, err := resultsIterator.Next()
+		if err != nil {
+			return shim.Error(err.Error())
+		}
+		// Add a comma before array members, suppress it for the first array member
+		if bArrayMemberAlreadyWritten == true {
+			buffer.WriteString(",")
+		}
+		buffer.WriteString("{\"Key\":")
+		buffer.WriteString("\"")
+		buffer.WriteString(queryResponse.Key)
+		buffer.WriteString("\"")
+
+		buffer.WriteString(", \"Record\":")
+		// Record is a JSON object, so we write as-is
+		buffer.WriteString(string(queryResponse.Value))
+		buffer.WriteString("}")
+		bArrayMemberAlreadyWritten = true
+	}
+	buffer.WriteString("]")
+
+	fmt.Printf("- getMarblesByRange queryResult:\n%s\n", buffer.String())
+
+	return shim.Success(buffer.Bytes())
+}
+
+// ==== Example: GetStateByPartialCompositeKey/RangeQuery =========================================
+// transferMarblesBasedOnColor will transfer marbles of a given color to a certain new owner.
+// Uses a GetStateByPartialCompositeKey (range query) against color~name 'index'.
+// Committing peers will re-execute range queries to guarantee that result sets are stable
+// between endorsement time and commit time. The transaction is invalidated by the
+// committing peers if the result set has changed between endorsement time and commit time.
+// Therefore, range queries are a safe option for performing update transactions based on query results.
+// ===========================================================================================
+func (t *SimpleChaincode) transferMarblesBasedOnColor(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+
+	//   0       1
+	// "color", "bob"
+	if len(args) < 2 {
+		return shim.Error("Incorrect number of arguments. Expecting 2")
+	}
+
+	color := args[0]
+	newOwner := strings.ToLower(args[1])
+	fmt.Println("- start transferMarblesBasedOnColor ", color, newOwner)
+
+	// Query the color~name index by color
+	// This will execute a key range query on all keys starting with 'color'
+	coloredMarbleResultsIterator, err := stub.GetStateByPartialCompositeKey("color~name", []string{color})
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+	defer coloredMarbleResultsIterator.Close()
+
+	// Iterate through result set and for each marble found, transfer to newOwner
+	var i int
+	for i = 0; coloredMarbleResultsIterator.HasNext(); i++ {
+		// Note that we don't get the value (2nd return variable), we'll just get the marble name from the composite key
+		responseRange, err := coloredMarbleResultsIterator.Next()
+		if err != nil {
+			return shim.Error(err.Error())
+		}
+
+		// get the color and name from color~name composite key
+		objectType, compositeKeyParts, err := stub.SplitCompositeKey(responseRange.Key)
+		if err != nil {
+			return shim.Error(err.Error())
+		}
+		returnedColor := compositeKeyParts[0]
+		returnedMarbleName := compositeKeyParts[1]
+		fmt.Printf("- found a marble from index:%s color:%s name:%s\n", objectType, returnedColor, returnedMarbleName)
+
+		// Now call the transfer function for the found marble.
+		// Re-use the same function that is used to transfer individual marbles
+		response := t.transferMarble(stub, []string{returnedMarbleName, newOwner})
+		// if the transfer failed break out of loop and return error
+		if response.Status != shim.OK {
+			return shim.Error("Transfer failed: " + response.Message)
+		}
+	}
+
+	responsePayload := fmt.Sprintf("Transferred %d %s marbles to %s", i, color, newOwner)
+	fmt.Println("- end transferMarblesBasedOnColor: " + responsePayload)
+	return shim.Success([]byte(responsePayload))
+}
+
+// =======Rich queries =========================================================================
+// Two examples of rich queries are provided below (parameterized query and ad hoc query).
+// Rich queries pass a query string to the state database.
+// Rich queries are only supported by state database implementations
+//  that support rich query (e.g. CouchDB).
+// The query string is in the syntax of the underlying state database.
+// With rich queries there is no guarantee that the result set hasn't changed between
+//  endorsement time and commit time, aka 'phantom reads'.
+// Therefore, rich queries should not be used in update transactions, unless the
+// application handles the possibility of result set changes between endorsement and commit time.
+// Rich queries can be used for point-in-time queries against a peer.
+// ============================================================================================
+
+// ===== Example: Parameterized rich query =================================================
+// queryMarblesByOwner queries for marbles based on a passed in owner.
+// This is an example of a parameterized query where the query logic is baked into the chaincode,
+// and accepting a single query parameter (owner).
+// Only available on state databases that support rich query (e.g. CouchDB)
+// =========================================================================================
+func (t *SimpleChaincode) queryMarblesByOwner(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+
+	//   0
+	// "bob"
+	if len(args) < 1 {
+		return shim.Error("Incorrect number of arguments. Expecting 1")
+	}
+
+	owner := strings.ToLower(args[0])
+
+	queryString := fmt.Sprintf("{\"selector\":{\"docType\":\"marble\",\"owner\":\"%s\"}}", owner)
+
+	queryResults, err := getQueryResultForQueryString(stub, queryString)
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+	return shim.Success(queryResults)
+}
+
+// ===== Example: Ad hoc rich query ========================================================
+// queryMarbles uses a query string to perform a query for marbles.
+// Query string matching state database syntax is passed in and executed as is.
+// Supports ad hoc queries that can be defined at runtime by the client.
+// If this is not desired, follow the queryMarblesForOwner example for parameterized queries.
+// Only available on state databases that support rich query (e.g. CouchDB)
+// =========================================================================================
+func (t *SimpleChaincode) queryMarbles(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+
+	//   0
+	// "queryString"
+	if len(args) < 1 {
+		return shim.Error("Incorrect number of arguments. Expecting 1")
+	}
+
+	queryString := args[0]
+
+	queryResults, err := getQueryResultForQueryString(stub, queryString)
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+	return shim.Success(queryResults)
+}
+
+// =========================================================================================
+// getQueryResultForQueryString executes the passed in query string.
+// Result set is built and returned as a byte array containing the JSON results.
+// =========================================================================================
+func getQueryResultForQueryString(stub shim.ChaincodeStubInterface, queryString string) ([]byte, error) {
+
+	fmt.Printf("- getQueryResultForQueryString queryString:\n%s\n", queryString)
+
+	resultsIterator, err := stub.GetQueryResult(queryString)
+	if err != nil {
+		return nil, err
+	}
+	defer resultsIterator.Close()
+
+	// buffer is a JSON array containing QueryRecords
+	var buffer bytes.Buffer
+	buffer.WriteString("[")
+
+	bArrayMemberAlreadyWritten := false
+	for resultsIterator.HasNext() {
+		queryResponse, err := resultsIterator.Next()
+		if err != nil {
+			return nil, err
+		}
+		// Add a comma before array members, suppress it for the first array member
+		if bArrayMemberAlreadyWritten == true {
+			buffer.WriteString(",")
+		}
+		buffer.WriteString("{\"Key\":")
+		buffer.WriteString("\"")
+		buffer.WriteString(queryResponse.Key)
+		buffer.WriteString("\"")
+
+		buffer.WriteString(", \"Record\":")
+		// Record is a JSON object, so we write as-is
+		buffer.WriteString(string(queryResponse.Value))
+		buffer.WriteString("}")
+		bArrayMemberAlreadyWritten = true
+	}
+	buffer.WriteString("]")
+
+	fmt.Printf("- getQueryResultForQueryString queryResult:\n%s\n", buffer.String())
+
+	return buffer.Bytes(), nil
+}
+
+func (t *SimpleChaincode) getHistoryForMarble(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+
+	if len(args) < 1 {
+		return shim.Error("Incorrect number of arguments. Expecting 1")
+	}
+
+	marbleName := args[0]
+
+	fmt.Printf("- start getHistoryForMarble: %s\n", marbleName)
+
+	resultsIterator, err := stub.GetHistoryForKey(marbleName)
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+	defer resultsIterator.Close()
+
+	// buffer is a JSON array containing historic values for the marble
+	var buffer bytes.Buffer
+	buffer.WriteString("[")
+
+	bArrayMemberAlreadyWritten := false
+	for resultsIterator.HasNext() {
+		response, err := resultsIterator.Next()
+		if err != nil {
+			return shim.Error(err.Error())
+		}
+		// Add a comma before array members, suppress it for the first array member
+		if bArrayMemberAlreadyWritten == true {
+			buffer.WriteString(",")
+		}
+		buffer.WriteString("{\"TxId\":")
+		buffer.WriteString("\"")
+		buffer.WriteString(response.TxId)
+		buffer.WriteString("\"")
+
+		buffer.WriteString(", \"Value\":")
+		// if it was a delete operation on given key, then we need to set the
+		//corresponding value null. Else, we will write the response.Value
+		//as-is (as the Value itself a JSON marble)
+		if response.IsDelete {
+			buffer.WriteString("null")
+		} else {
+			buffer.WriteString(string(response.Value))
+		}
+
+		buffer.WriteString(", \"Timestamp\":")
+		buffer.WriteString("\"")
+		buffer.WriteString(time.Unix(response.Timestamp.Seconds, int64(response.Timestamp.Nanos)).String())
+		buffer.WriteString("\"")
+
+		buffer.WriteString(", \"IsDelete\":")
+		buffer.WriteString("\"")
+		buffer.WriteString(strconv.FormatBool(response.IsDelete))
+		buffer.WriteString("\"")
+
+		buffer.WriteString("}")
+		bArrayMemberAlreadyWritten = true
+	}
+	buffer.WriteString("]")
+
+	fmt.Printf("- getHistoryForMarble returning:\n%s\n", buffer.String())
+
+	return shim.Success(buffer.Bytes())
+}

--- a/src/contract/fabric/marbles/go/metadata/statedb/couchdb/indexes/indexOwner.json
+++ b/src/contract/fabric/marbles/go/metadata/statedb/couchdb/indexes/indexOwner.json
@@ -1,0 +1,1 @@
+{"index":{"fields":["docType","owner"]},"ddoc":"indexOwnerDoc", "name":"indexOwner","type":"json"}

--- a/src/contract/fabric/marbles/node/marbles.js
+++ b/src/contract/fabric/marbles/node/marbles.js
@@ -1,0 +1,486 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+* NOTE: This implementation is a derivative work of the following:
+* https://github.com/hyperledger/fabric-samples/blob/release-1.1/chaincode/marbles02/node/marbles_chaincode.js
+* The modifications include: bug fixes and refactoring for eslint compliance.
+*/
+
+/* eslint-disable no-console */
+
+'use strict';
+const shim = require('fabric-shim');
+const util = require('util');
+
+/**
+ * Marble asset management chaincode written in node.js, implementing {@link ChaincodeInterface}.
+ * @type {SimpleChaincode}
+ * @extends {ChaincodeInterface}
+ */
+let Chaincode = class {
+    /**
+     * Called during chaincode instantiate and upgrade. This method can be used
+     * to initialize asset states.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub is implemented by the fabric-shim
+     * library and passed to the {@link ChaincodeInterface} calls by the Hyperledger Fabric platform. The stub
+     * encapsulates the APIs between the chaincode implementation and the Fabric peer.
+     * @return {Promise<SuccessResponse>} Returns a promise of a response indicating the result of the invocation.
+     */
+    async Init(stub) {
+        let ret = stub.getFunctionAndParameters();
+        console.info(ret);
+        console.info('=========== Instantiated Marbles Chaincode ===========');
+        return shim.success();
+    }
+
+    /**
+     * Called throughout the life time of the chaincode to carry out business
+     * transaction logic and effect the asset states.
+     * The provided functions are the following: initMarble, delete, transferMarble, readMarble, getMarblesByRange,
+     * transferMarblesBasedOnColor, queryMarblesByOwner, queryMarbles, getHistoryForMarble.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub is implemented by the fabric-shim
+     * library and passed to the {@link ChaincodeInterface} calls by the Hyperledger Fabric platform. The stub
+     * encapsulates the APIs between the chaincode implementation and the Fabric peer.
+     * @return {Promise<SuccessResponse | ErrorResponse>} Returns a promise of a response indicating the result of the invocation.
+     */
+    async Invoke(stub) {
+        console.info('Transaction ID: ' + stub.getTxID());
+        console.info(util.format('Args: %j', stub.getArgs()));
+
+        let ret = stub.getFunctionAndParameters();
+        console.info(ret);
+
+        let method = this[ret.fcn];
+        if (!method) {
+            console.log('no function of name:' + ret.fcn + ' found');
+            throw new Error('Received unknown function ' + ret.fcn + ' invocation');
+        }
+        try {
+            let payload = await method(stub, ret.params, this);
+            return shim.success(payload);
+        } catch (err) {
+            console.log(err);
+            return shim.error(err);
+        }
+    }
+
+    /**
+     * Creates a new marble with the given attributes.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub.
+     * @param {String[]} args The arguments of the function. Index 0: marble name. Index 1: marble color.
+     * Index 2: marble size. Index 3: marble owner.
+     */
+    async initMarble(stub, args) {
+        if (args.length !== 4) {
+            throw new Error('Incorrect number of arguments. Expecting 4');
+        }
+        // ==== Input sanitation ====
+        console.info('--- start init marble ---');
+        if (args[0].length <= 0) {
+            throw new Error('1st argument must be a non-empty string');
+        }
+        if (args[1].length <= 0) {
+            throw new Error('2nd argument must be a non-empty string');
+        }
+        if (args[2].length <= 0) {
+            throw new Error('3rd argument must be a non-empty string');
+        }
+        if (args[3].length <= 0) {
+            throw new Error('4th argument must be a non-empty string');
+        }
+        let marbleName = args[0];
+        let color = args[1].toLowerCase();
+        let owner = args[3].toLowerCase();
+        let size = parseInt(args[2]);
+        if (isNaN(size)) {
+            throw new Error('3rd argument must be a numeric string');
+        }
+
+        // ==== Check if marble already exists ====
+        let marbleState = await stub.getState(marbleName);
+        if (marbleState.toString()) {
+            throw new Error('This marble already exists: ' + marbleName);
+        }
+
+        // ==== Create marble object and marshal to JSON ====
+        let marble = {};
+        marble.docType = 'marble';
+        marble.name = marbleName;
+        marble.color = color;
+        marble.size = size;
+        marble.owner = owner;
+
+        // === Save marble to state ===
+        await stub.putState(marbleName, Buffer.from(JSON.stringify(marble)));
+        let indexName = 'color~name';
+        let colorNameIndexKey = await stub.createCompositeKey(indexName, [marble.color, marble.name]);
+        console.info(colorNameIndexKey);
+        //  Save index entry to state. Only the key name is needed, no need to store a duplicate copy of the marble.
+        //  Note - passing a 'nil' value will effectively delete the key from state, therefore we pass null character as value
+        await stub.putState(colorNameIndexKey, Buffer.from('\u0000'));
+        // ==== Marble saved and indexed. Return success ====
+        console.info('- end init marble');
+    }
+
+    /**
+     * Retrieves the information about a marble.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub.
+     * @param {String[]} args The arguments of the function. Index 0: marble name.
+     * @return {Promise<Object[]>} The byte representation of the marble.
+     */
+    async readMarble(stub, args) {
+        if (args.length !== 1) {
+            throw new Error('Incorrect number of arguments. Expecting name of the marble to query');
+        }
+
+        let name = args[0];
+        if (!name) {
+            throw new Error(' marble name must not be empty');
+        }
+        let marbleAsBytes = await stub.getState(name); //get the marble from chaincode state
+        if (!marbleAsBytes.toString()) {
+            let jsonResp = {};
+            jsonResp.Error = 'Marble does not exist: ' + name;
+            throw new Error(JSON.stringify(jsonResp));
+        }
+        console.info('=======================================');
+        console.log(marbleAsBytes.toString());
+        console.info('=======================================');
+        return marbleAsBytes;
+    }
+
+    /**
+     * Deletes the given marble.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub.
+     * @param {String[]} args The arguments of the function. Index 0: marble name.
+     */
+    async delete(stub, args) {
+        if (args.length !== 1) {
+            throw new Error('Incorrect number of arguments. Expecting name of the marble to delete');
+        }
+        let marbleName = args[0];
+        if (!marbleName) {
+            throw new Error('marble name must not be empty');
+        }
+        // to maintain the color~name index, we need to read the marble first and get its color
+        let valAsBytes = await stub.getState(marbleName); //get the marble from chaincode state
+        let jsonResp = {};
+        if (!valAsBytes) {
+            jsonResp.error = 'marble does not exist: ' + marbleName;
+            throw new Error(jsonResp);
+        }
+        let marbleJSON = {};
+        try {
+            marbleJSON = JSON.parse(valAsBytes.toString());
+        } catch (err) {
+            jsonResp = {};
+            jsonResp.error = 'Failed to decode JSON of: ' + marbleName;
+            throw new Error(jsonResp);
+        }
+
+        await stub.deleteState(marbleName); //remove the marble from chaincode state
+
+        // delete the index
+        let indexName = 'color~name';
+        let colorNameIndexKey = stub.createCompositeKey(indexName, [marbleJSON.color, marbleJSON.name]);
+        if (!colorNameIndexKey) {
+            throw new Error(' Failed to create the createCompositeKey');
+        }
+        //  Delete index entry to state.
+        await stub.deleteState(colorNameIndexKey);
+    }
+
+    // ===========================================================
+    // transfer a marble by setting a new owner name on the marble
+    // ===========================================================
+    /**
+     * Transfers the given marble to a new owner.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub.
+     * @param {String[]} args The arguments of the function. Index 0: marble name. Index 1: the new owner.
+     */
+    async transferMarble(stub, args) {
+        if (args.length !== 2) {
+            throw new Error('Incorrect number of arguments. Expecting marble name and owner');
+        }
+
+        let marbleName = args[0];
+        let newOwner = args[1].toLowerCase();
+        console.info('- start transferMarble ', marbleName, newOwner);
+
+        let marbleAsBytes = await stub.getState(marbleName);
+        if (!marbleAsBytes || !marbleAsBytes.toString()) {
+            throw new Error('marble does not exist');
+        }
+        let marbleToTransfer = {};
+        try {
+            marbleToTransfer = JSON.parse(marbleAsBytes.toString()); //unmarshal
+        } catch (err) {
+            let jsonResp = {};
+            jsonResp.error = 'Failed to decode JSON of: ' + marbleName;
+            throw new Error(jsonResp);
+        }
+        console.info(marbleToTransfer);
+        marbleToTransfer.owner = newOwner; //change the owner
+
+        let marbleJSONasBytes = Buffer.from(JSON.stringify(marbleToTransfer));
+        await stub.putState(marbleName, marbleJSONasBytes); //rewrite the marble
+
+        console.info('- end transferMarble (success)');
+    }
+
+    /**
+     * Performs a range query based on the start and end keys provided.
+     *
+     * Read-only function results are not typically submitted to ordering. If the read-only
+     * results are submitted to ordering, or if the query is used in an update transaction
+     * and submitted to ordering, then the committing peers will re-execute to guarantee that
+     * result sets are stable between endorsement time and commit time. The transaction is
+     * invalidated by the committing peers if the result set has changed between endorsement
+     * time and commit time.
+     * Therefore, range queries are a safe option for performing update transactions based on query results.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub.
+     * @param {String[]} args The arguments of the function. Index 0: start key. Index 1: end key.
+     * @param {Chaincode} thisObject The chaincode object context.
+     * @return {Promise<Buffer>} The marbles in the given range.
+     */
+    async getMarblesByRange(stub, args, thisObject) {
+
+        if (args.length !== 2) {
+            throw new Error('Incorrect number of arguments. Expecting 2');
+        }
+
+        let startKey = args[0];
+        let endKey = args[1];
+
+        let resultsIterator = await stub.getStateByRange(startKey, endKey);
+        let results = await thisObject.getAllResults(resultsIterator, false);
+
+        return Buffer.from(JSON.stringify(results));
+    }
+
+    /**
+     * Transfers marbles of a given color to a certain new owner.
+     *
+     * Uses a GetStateByPartialCompositeKey (range query) against color~name 'index'.
+     * Committing peers will re-execute range queries to guarantee that result sets are stable
+     * between endorsement time and commit time. The transaction is invalidated by the
+     * committing peers if the result set has changed between endorsement time and commit time.
+     * Therefore, range queries are a safe option for performing update transactions based on query results.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub.
+     * @param {String[]} args The arguments of the function. Index 0: marble color. Index 1: new owner.
+     * @param {Chaincode} thisObject The chaincode object context.
+     */
+    async transferMarblesBasedOnColor(stub, args, thisObject) {
+        if (args.length !== 2) {
+            throw new Error('Incorrect number of arguments. Expecting color and owner');
+        }
+
+        let color = args[0];
+        let newOwner = args[1].toLowerCase();
+        console.info('- start transferMarblesBasedOnColor ', color, newOwner);
+
+        // Query the color~name index by color
+        // This will execute a key range query on all keys starting with 'color'
+        let coloredMarbleResultsIterator = await stub.getStateByPartialCompositeKey('color~name', [color]);
+
+        let hasNext = true;
+        // Iterate through result set and for each marble found, transfer to newOwner
+        while (hasNext) {
+            let responseRange;
+            try {
+                responseRange = await coloredMarbleResultsIterator.next();
+            } catch (err) {
+                hasNext = false;
+                continue;
+            }
+
+            if (!responseRange || !responseRange.value || !responseRange.value.key) {
+                return;
+            }
+            console.log(responseRange.value.key);
+
+            // let value = res.value.value.toString('utf8');
+            let objectType;
+            let attributes;
+            ({
+                objectType,
+                attributes
+            } = await stub.splitCompositeKey(responseRange.value.key));
+
+            let returnedColor = attributes[0];
+            let returnedMarbleName = attributes[1];
+            console.info(util.format('- found a marble from index:%s color:%s name:%s\n', objectType, returnedColor, returnedMarbleName));
+
+            // Now call the transfer function for the found marble.
+            // Re-use the same function that is used to transfer individual marbles
+            await thisObject.transferMarble(stub, [returnedMarbleName, newOwner]);
+        }
+
+        let responsePayload = util.format('Transferred %s marbles to %s', color, newOwner);
+        console.info('- end transferMarblesBasedOnColor: ' + responsePayload);
+    }
+
+    /**
+     * Queries for marbles based on a passed in owner.
+     * This is an example of a parameterized query where the query logic is baked into the chaincode,
+     * and accepting a single query parameter (owner).
+     * Only available on state databases that support rich query (e.g. CouchDB)
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub.
+     * @param {String[]} args The arguments of the function. Index 0: marble owner.
+     * @param {Chaincode} thisObject The chaincode object context.
+     * @return {Promise<Buffer>} The marbles of the specified owner.
+     */
+    async queryMarblesByOwner(stub, args, thisObject) {
+        if (args.length !== 1) {
+            throw new Error('Incorrect number of arguments. Expecting owner name.');
+        }
+
+        let owner = args[0].toLowerCase();
+        let queryString = {};
+        queryString.selector = {};
+        queryString.selector.docType = 'marble';
+        queryString.selector.owner = owner;
+        return await thisObject.getQueryResultForQueryString(stub, JSON.stringify(queryString), thisObject); //shim.success(queryResults);
+    }
+
+    /**
+     * Uses a query string to perform a query for marbles.
+     * Query string matching state database syntax is passed in and executed as is.
+     * Supports ad hoc queries that can be defined at runtime by the client.
+     * If this is not desired, follow the queryMarblesForOwner example for parameterized queries.
+     * Only available on state databases that support rich query (e.g. CouchDB)
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub.
+     * @param {String[]} args The arguments of the function. Index 0: query string.
+     * @param {Chaincode} thisObject The chaincode object context.
+     * @return {Promise<Buffer>} The results of the specified query.
+     */
+    async queryMarbles(stub, args, thisObject) {
+        if (args.length !== 1) {
+            throw new Error('Incorrect number of arguments. Expecting queryString');
+        }
+        let queryString = args[0];
+        if (!queryString) {
+            throw new Error('queryString must not be empty');
+        }
+
+        return await thisObject.getQueryResultForQueryString(stub, queryString, thisObject);
+    }
+
+    /**
+     * Gets the results of a specified iterator.
+     * @async
+     * @param {Object} iterator The iterator to use.
+     * @param {Boolean} isHistory Specifies whether the iterator returns history entries or not.
+     * @return {Promise<Object[]>} The array of results in JSON format.
+     */
+    async getAllResults(iterator, isHistory) {
+        let allResults = [];
+        let hasNext = true;
+        while (hasNext) {
+            let res;
+            try {
+                res = await iterator.next();
+            } catch (err) {
+                hasNext = false;
+                continue;
+            }
+
+            if (res.value && res.value.value.toString()) {
+                let jsonRes = {};
+                console.log(res.value.value.toString('utf8'));
+
+                if (isHistory && isHistory === true) {
+                    jsonRes.TxId = res.value.tx_id;
+                    jsonRes.Timestamp = res.value.timestamp;
+                    jsonRes.IsDelete = res.value.is_delete.toString();
+                    try {
+                        jsonRes.Value = JSON.parse(res.value.value.toString('utf8'));
+                    } catch (err) {
+                        console.log(err);
+                        jsonRes.Value = res.value.value.toString('utf8');
+                    }
+                } else {
+                    jsonRes.Key = res.value.key;
+                    try {
+                        jsonRes.Record = JSON.parse(res.value.value.toString('utf8'));
+                    } catch (err) {
+                        console.log(err);
+                        jsonRes.Record = res.value.value.toString('utf8');
+                    }
+                }
+                allResults.push(jsonRes);
+            }
+            if (res.done) {
+                console.log('end of data');
+                await iterator.close();
+                console.info(allResults);
+                return allResults;
+            }
+        }
+    }
+
+    /**
+     * Executes the provided query string.
+     * Result set is built and returned as a byte array containing the JSON results.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub.
+     * @param {String} queryString The query string to execute.
+     * @param {Chaincode} thisObject The chaincode object context.
+     * @return {Promise<Buffer>} The results of the specified query.
+     */
+    async getQueryResultForQueryString(stub, queryString, thisObject) {
+
+        console.info('- getQueryResultForQueryString queryString:\n' + queryString);
+        let resultsIterator = await stub.getQueryResult(queryString);
+
+        let results = await thisObject.getAllResults(resultsIterator, false);
+
+        return Buffer.from(JSON.stringify(results));
+    }
+
+    /**
+     * Retrieves the history for a marble.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub.
+     * @param {String[]} args The arguments of the function. Index 0: marble name.
+     * @param {Chaincode} thisObject The chaincode object context.
+     * @return {Promise<Buffer>} The history entries of the specified marble.
+     */
+    async getHistoryForMarble(stub, args, thisObject) {
+
+        if (args.length !== 1) {
+            throw new Error('Incorrect number of arguments. Expecting 1');
+        }
+        let marbleName = args[0];
+        console.info('- start getHistoryForMarble: %s\n', marbleName);
+
+        let resultsIterator = await stub.getHistoryForKey(marbleName);
+        let results = await thisObject.getAllResults(resultsIterator, true);
+
+        return Buffer.from(JSON.stringify(results));
+    }
+};
+
+shim.start(new Chaincode());

--- a/src/contract/fabric/marbles/node/metadata/statedb/couchdb/indexes/indexOwner.json
+++ b/src/contract/fabric/marbles/node/metadata/statedb/couchdb/indexes/indexOwner.json
@@ -1,0 +1,1 @@
+{"index":{"fields":["docType","owner"]},"ddoc":"indexOwnerDoc", "name":"indexOwner","type":"json"}

--- a/src/contract/fabric/marbles/node/package.json
+++ b/src/contract/fabric/marbles/node/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "marbles",
+	"version": "1.0.0",
+	"description": "marbles chaincode implemented in node.js",
+	"engines": {
+		"node": ">=8.4.0",
+		"npm": ">=5.3.0"
+	},
+	"scripts": {
+		"start": "node marbles.js"
+	},
+	"engine-strict": true,
+	"license": "Apache-2.0",
+	"dependencies": {
+		"fabric-shim": "~1.1.0"
+	}
+}

--- a/src/contract/fabric/simple/go/simpletest.go
+++ b/src/contract/fabric/simple/go/simpletest.go
@@ -18,7 +18,7 @@ import (
 const ERROR_SYSTEM = "{\"code\":300, \"reason\": \"system error: %s\"}"
 const ERROR_WRONG_FORMAT = "{\"code\":301, \"reason\": \"command format is wrong\"}"
 const ERROR_ACCOUNT_EXISTING = "{\"code\":302, \"reason\": \"account already exists\"}"
-const ERROR_ACCOUT_ABNORMAL = "{\"code\":303, \"reason\": \"abnormal account\"}"
+const ERROR_ACCOUNT_ABNORMAL = "{\"code\":303, \"reason\": \"abnormal account\"}"
 const ERROR_MONEY_NOT_ENOUGH = "{\"code\":304, \"reason\": \"account's money is not enough\"}"
 
 
@@ -105,34 +105,34 @@ func (t *SimpleChaincode) Query(stub shim.ChaincodeStubInterface, args []string)
 	}
 
 	if money == nil {
-		return shim.Error(ERROR_ACCOUT_ABNORMAL)
+		return shim.Error(ERROR_ACCOUNT_ABNORMAL)
 	}
 
 	return shim.Success(money)
 }
 
-// transfer money from account1 to account2, should be [transfer accout1 accout2 money]
+// transfer money from account1 to account2, should be [transfer account1 account2 money]
 func (t *SimpleChaincode) Transfer(stub shim.ChaincodeStubInterface, args []string) pb.Response {
 	if len(args) != 3 {
 		return shim.Error(ERROR_WRONG_FORMAT)
 	}
-	money, err := strconv.Atoi(args[1])
+	money, err := strconv.Atoi(args[2])
 	if err != nil {
 		return shim.Error(ERROR_WRONG_FORMAT)
 	}
 
 	moneyBytes1, err1 := stub.GetState(args[0])
-	moneyBytes2, err2 := stub.GetState(args[0])
+	moneyBytes2, err2 := stub.GetState(args[1])
 	if err1 != nil || err2 != nil {
 		s := fmt.Sprintf(ERROR_SYSTEM, err.Error())
 		return shim.Error(s)
 	}
 	if moneyBytes1 == nil || moneyBytes2 == nil {
-		return shim.Error(ERROR_ACCOUT_ABNORMAL)
+		return shim.Error(ERROR_ACCOUNT_ABNORMAL)
 	}
 
 	money1, _ := strconv.Atoi(string(moneyBytes1))
-	money2, _ := strconv.Atoi(string(moneyBytes1))
+	money2, _ := strconv.Atoi(string(moneyBytes2))
 	if money1 < money {
 		return shim.Error(ERROR_MONEY_NOT_ENOUGH)
 	}
@@ -148,7 +148,6 @@ func (t *SimpleChaincode) Transfer(stub shim.ChaincodeStubInterface, args []stri
 
 	err = stub.PutState(args[1], []byte(strconv.Itoa(money2)))
 	if err != nil {
-		stub.PutState(args[0], []byte(strconv.Itoa(money1+money)))
 		s := fmt.Sprintf(ERROR_SYSTEM, err.Error())
 		return shim.Error(s)
 	}

--- a/src/contract/fabric/simple/node/package.json
+++ b/src/contract/fabric/simple/node/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "simpletest",
+  "version": "0.0.0",
+  "description": "Simple chaincode implemented in node.js",
+  "engines": {
+    "node": ">=8.4.0",
+    "npm": ">=5.3.0"
+  },
+  "scripts": {
+    "start": "node simpletest.js"
+  },
+  "engine-strict": true,
+  "license": "Apache-2.0",
+  "dependencies": {
+    "fabric-shim": "~1.1.0"
+  }
+}

--- a/src/contract/fabric/simple/node/simpletest.js
+++ b/src/contract/fabric/simple/node/simpletest.js
@@ -1,0 +1,218 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+const shim = require('fabric-shim');
+const util = require('util');
+
+const ERROR_SYSTEM = '{"code":300, "location": "%s", "reason": "system error: %s"}';
+const ERROR_WRONG_FORMAT = '{"code":301, "location": "%s", "reason": "command format is wrong"}';
+const ERROR_ACCOUNT_EXISTING = '{"code":302, "location": "%s", "reason": "account already exists"}';
+const ERROR_ACCOUNT_ABNORMAL = '{"code":303, "location": "%s", "reason": "abnormal account"}';
+const ERROR_MONEY_NOT_ENOUGH = '{"code":304, "location": "%s", "reason": "account\'s money is not enough"}';
+
+/**
+ * Generates an {@link ErrorResponse} from the given arguments.
+ * @param {String} location Specifies the location of the error.
+ * @param {String} formatString The format string of the error.
+ * @param {Object[]} params Arbitrary values to pass to the format string.
+ * @return {ErrorResponse} The constructed error response.
+ */
+function getErrorResponse(location, formatString, ...params) {
+    return shim.error(Buffer.from(util.format(formatString, location, ...params)));
+}
+
+/**
+ * Simple money transfer chaincode written in node.js, implementing {@link ChaincodeInterface}.
+ * @type {SimpleChaincode}
+ * @extends {ChaincodeInterface}
+ */
+let SimpleChaincode = class {
+    /**
+     * Called during chaincode instantiate and upgrade. This method can be used
+     * to initialize asset states.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub is implemented by the fabric-shim
+     * library and passed to the {@link ChaincodeInterface} calls by the Hyperledger Fabric platform. The stub
+     * encapsulates the APIs between the chaincode implementation and the Fabric peer.
+     * @return {Promise<SuccessResponse>} Returns a promise of a response indicating the result of the invocation.
+     */
+    async Init(stub) {
+        return shim.success();
+    }
+
+    /**
+     * Called throughout the life time of the chaincode to carry out business
+     * transaction logic and effect the asset states.
+     * The provided functions are the following: open, delete, query, transfer.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub is implemented by the fabric-shim
+     * library and passed to the {@link ChaincodeInterface} calls by the Hyperledger Fabric platform. The stub
+     * encapsulates the APIs between the chaincode implementation and the Fabric peer.
+     * @return {Promise<SuccessResponse | ErrorResponse>} Returns a promise of a response indicating the result of the invocation.
+     */
+    async Invoke(stub) {
+        let funcAndParams = stub.getFunctionAndParameters();
+
+        let method = this[funcAndParams.fcn];
+        if (!method) {
+            return getErrorResponse('Invoke', ERROR_WRONG_FORMAT);
+        }
+
+        try {
+            return await method(stub, funcAndParams.params);
+        } catch (err) {
+            return getErrorResponse('Invoke', ERROR_SYSTEM, err);
+        }
+    }
+
+    /**
+     * Creates a new account with the given amount of money. The account must not exist!
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub object.
+     * @param {String[]} params The parameters for account creation.
+     * Index 0: account name. Index 1: initial amount of money.
+     * @return {Promise<SuccessResponse | ErrorResponse>} Returns a promise of a response indicating the result of the invocation.
+     */
+    async open(stub, params) {
+        if (params.length !== 2) {
+            return getErrorResponse('open', ERROR_WRONG_FORMAT);
+        }
+
+        let account = params[0];
+        let money = await stub.getState(account);
+
+        if (money.toString()) {
+            return getErrorResponse('open', ERROR_ACCOUNT_EXISTING);
+        }
+
+        let initMoney = parseInt(params[1]);
+        if (isNaN(initMoney)) {
+            return getErrorResponse('open', ERROR_WRONG_FORMAT);
+        }
+
+        try {
+            // expand enumerable Buffer to byte array with the ... operator
+            await stub.putState(account, Buffer.from(params[1]));
+        } catch (err) {
+            return getErrorResponse('open', ERROR_SYSTEM, err);
+        }
+
+        return shim.success();
+    }
+
+    /**
+     * Deletes an account.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub object.
+     * @param {String[]} params The parameter for account deletion. Index 0: account name.
+     * @return {Promise<SuccessResponse | ErrorResponse>} Returns a promise of a response indicating the result of the invocation.
+     */
+    async delete(stub, params) {
+        if (params.length !== 1) {
+            return getErrorResponse('delete', ERROR_WRONG_FORMAT);
+        }
+
+        try {
+            await stub.deleteState(params[0]);
+        } catch (err) {
+            return getErrorResponse('delete', ERROR_SYSTEM, err);
+        }
+
+        return shim.success();
+    }
+
+    /**
+     * Queries the amount of money of a given account.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub object.
+     * @param {String[]} params The parameter for account query. Index 0: account name.
+     * @return {Promise<SuccessResponse | ErrorResponse>} Returns a promise of a response indicating the result of the invocation.
+     */
+    async query(stub, params) {
+        if (params.length !== 1) {
+            return getErrorResponse('query', ERROR_WRONG_FORMAT);
+        }
+
+        let money;
+        try {
+            money = await stub.getState(params[0]);
+        } catch (err) {
+            return getErrorResponse('query', ERROR_SYSTEM, err);
+        }
+
+        if (!money) {
+            return getErrorResponse('query', ERROR_ACCOUNT_ABNORMAL);
+        }
+
+        return shim.success(money);
+    }
+
+    /**
+     * Transfers a given amount of money from one account to an other.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub object.
+     * @param {String[]} params The parameters for money transfer.
+     * Index 0: sending account name. Index 1: receiving account name. Index 2: amount of money to transfer.
+     * @return {Promise<SuccessResponse | ErrorResponse>} Returns a promise of a response indicating the result of the invocation.
+     */
+    async transfer(stub, params) {
+        if (params.length !== 3) {
+            return getErrorResponse('transfer', ERROR_WRONG_FORMAT);
+        }
+
+        let money = parseInt(params[2]);
+        if (isNaN(money)) {
+            return getErrorResponse('transfer', ERROR_WRONG_FORMAT);
+        }
+
+        let moneyBytes1, moneyBytes2;
+        try {
+            moneyBytes1 = await stub.getState(params[0]);
+            moneyBytes2 = await stub.getState(params[1]);
+        } catch (err) {
+            return getErrorResponse('transfer', ERROR_SYSTEM, err);
+        }
+
+        if (!moneyBytes1 || !moneyBytes2) {
+            return getErrorResponse('transfer', ERROR_ACCOUNT_ABNORMAL);
+        }
+
+        let money1 = parseInt(String.fromCharCode.apply(String, moneyBytes1));
+        let money2 = parseInt(String.fromCharCode.apply(String, moneyBytes2));
+
+        if (money1 < money) {
+            return getErrorResponse('transfer', ERROR_MONEY_NOT_ENOUGH);
+        }
+
+        money1 -= money;
+        money2 += money;
+
+        try {
+            await stub.putState(params[0], Buffer.from(money1));
+            await stub.putState(params[1], Buffer.from(money2));
+        } catch (err) {
+            return getErrorResponse('transfer', ERROR_SYSTEM, err);
+        }
+
+        return shim.success();
+    }
+};
+
+try {
+    shim.start(new SimpleChaincode());
+} catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(err);
+}

--- a/src/fabric/e2eUtils.js
+++ b/src/fabric/e2eUtils.js
@@ -108,10 +108,17 @@ function installChaincode(org, chaincode) {
     }).then((admin) => {
         the_user = admin;
 
+        let resolvedPath = chaincode.path;
+        let metadataPath = chaincode.metadataPath ? commUtils.resolvePath(chaincode.metadataPath) : chaincode.metadataPath;
+        if (chaincode.language === 'node') {
+            resolvedPath = commUtils.resolvePath(chaincode.path);
+        }
+
         // send proposal to endorser
         const request = {
             targets: targets,
-            chaincodePath: chaincode.path,
+            chaincodePath: resolvedPath,
+            metadataPath: metadataPath,
             chaincodeId: chaincode.id,
             chaincodeType: chaincode.language,
             chaincodeVersion: chaincode.version


### PR DESCRIPTION
This PR addresses the following shortcomings:
* Proper support for Node.js chaincodes (CC)
* Support for CC metadata (CouchDB indices)
* Lack of Node.js CC examples

Contribution details:
* Correctly resolving CC path (relative or absolute) in case of Node CC
* Processing `metadataPath` attribute for CC install requests
* Added Node version of the `simple` benchmark (restructured the `src/contract/fabric/simple` folder a bit, changed configs accordingly)
* Added Node and Golang versions of the `marbles` CC from the `fabric-samples` repo (included a NOTE about this derivative work and a reference to the original, hopefully, this makes it license-compatible)
* Added `marbles` benchmark files for testing the corresponding CCs
* Fixed some bugs/typos in the `simple` Golang CC
* Updated chaincode-related documentation accordingly

Signed-off-by: Attila Klenik <a.klenik@gmail.com>