### PR TITLE
Add linear, record and replay rate controllers

### DIFF
--- a/benchmark/simple/config-linear-rate.json
+++ b/benchmark/simple/config-linear-rate.json
@@ -1,0 +1,46 @@
+{
+  "blockchain": {
+    "type": "fabric",
+    "config": "benchmark/simple/fabric.json"
+  },
+  "command" : {
+    "start": "docker-compose -f network/fabric/simplenetwork/docker-compose.yaml up -d",
+    "end" : "docker-compose -f network/fabric/simplenetwork/docker-compose.yaml down;docker rm $(docker ps -aq);docker rmi $(docker images dev* -q)"
+  },
+  "test": {
+    "name": "simple",
+    "description" : "This is an example benchmark for caliper, to test the backend DLT's performance with simple account opening & querying transactions",
+    "clients": {
+      "type": "local",
+      "number": 5
+    },
+    "rounds": [{
+        "label" : "open",
+        "txDuration" : [15],
+        "rateControl" : [
+          {
+            "type": "linear-rate",
+            "opts": {
+              "startingTps": 25,
+              "finishingTps": 75
+            }
+          }],
+        "arguments": { "money": 10000 },
+        "callback" : "benchmark/simple/open.js"
+      }]
+  },
+  "monitor": {
+    "type": ["docker", "process"],
+    "docker":{
+      "name": ["all"]
+    },
+    "process": [
+      {
+        "command" : "node",
+        "arguments" : "local-client.js",
+        "multiOutput" : "avg"
+      }
+    ],
+    "interval": 1
+  }
+}

--- a/benchmark/simple/config-record-replay-rate.json
+++ b/benchmark/simple/config-record-replay-rate.json
@@ -1,0 +1,93 @@
+{
+  "blockchain": {
+    "type": "fabric",
+    "config": "benchmark/simple/fabric.json"
+  },
+  "command" : {
+    "start": "docker-compose -f network/fabric/simplenetwork/docker-compose.yaml up -d",
+    "end" : "docker-compose -f network/fabric/simplenetwork/docker-compose.yaml down;docker rm $(docker ps -aq);docker rmi $(docker images dev* -q)"
+  },
+  "test": {
+    "name": "simple",
+    "description" : "This is an example benchmark for caliper, to test the backend DLT's performance with simple account opening & querying transactions",
+    "clients": {
+      "type": "local",
+      "number": 5
+    },
+    "rounds": [{
+        "label" : "open",
+        "txDuration" : [15, 15, 15, 15, 15, 15],
+        "rateControl" : [
+          {
+            "type": "record-rate",
+            "opts": {
+              "rateController": {"type": "fixed-rate", "opts": {"tps" : 50}},
+              "pathTemplate": "../tx_records_client<C>.txt",
+              "outputFormat": "TEXT",
+              "logEnd": true
+            }
+          },
+          {
+            "type": "record-rate",
+            "opts": {
+              "rateController": {"type": "fixed-rate", "opts": {"tps" : 50}},
+              "pathTemplate": "../tx_records_client<C>.be.bin",
+              "outputFormat": "BIN_BE",
+              "logEnd": true
+            }
+          },
+          {
+            "type": "record-rate",
+            "opts": {
+              "rateController": {"type": "fixed-rate", "opts": {"tps" : 50}},
+              "pathTemplate": "../tx_records_client<C>.le.bin",
+              "outputFormat": "BIN_LE",
+              "logEnd": true
+            }
+          },
+          {
+            "type": "replay-rate",
+            "opts": {
+              "pathTemplate": "../tx_records_client<C>.txt",
+              "inputFormat": "TEXT",
+              "logWarnings": true,
+              "defaultSleepTime": 50
+            }
+          },
+          {
+            "type": "replay-rate",
+            "opts": {
+              "pathTemplate": "../tx_records_client<C>.be.bin",
+              "inputFormat": "BIN_BE",
+              "logWarnings": true,
+              "defaultSleepTime": 50
+            }
+          },
+          {
+            "type": "replay-rate",
+            "opts": {
+              "pathTemplate": "../tx_records_client<C>.le.bin",
+              "inputFormat": "BIN_LE",
+              "logWarnings": true,
+              "defaultSleepTime": 50
+            }
+          }],
+        "arguments": { "money": 10000 },
+        "callback" : "benchmark/simple/open.js"
+      }]
+  },
+  "monitor": {
+    "type": ["docker", "process"],
+    "docker":{
+      "name": ["all"]
+    },
+    "process": [
+      {
+        "command" : "node",
+        "arguments" : "local-client.js",
+        "multiOutput" : "avg"
+      }
+    ],
+    "interval": 1
+  }
+}

--- a/docs/RateControllers.md
+++ b/docs/RateControllers.md
@@ -1,16 +1,19 @@
 # Rate Controllers
 
-The rate at which transactions are input to the blockchain system is a key factor within performance tests. It may be desired to send transactions at a specified rate or follow a specified profile. Caliper permits the specification of custom rate controllers to enable a user to perform testing under a custom loading mechanism. A user may specify their own rate controller or use one of the defualt options:
+The rate at which transactions are input to the blockchain system is a key factor within performance tests. It may be desired to send transactions at a specified rate or follow a specified profile. Caliper permits the specification of custom rate controllers to enable a user to perform testing under a custom loading mechanism. A user may specify their own rate controller or use one of the default options:
 
 * [Fixed rate](#fixed-rate)
 * [PID rate](#pid-rate)
 * [Composite rate](#composite-rate)
+* [Linear rate](#linear-rate)
 * [Zero rate](#zero-rate)
+* [Record rate](#record-rate)
+* [Replay rate](#replay-rate)
 
 ## Fixed Rate
 The fixed rate controller is the most basic controller, and also the default option if no controller is specified. It will send input transactions at a fixed interval that is specified as TPS (transactions per second).
 
-The fixed rate controller, driving at 10 TPS, is specifed through the following controller option: 
+The fixed rate controller, driving at 10 TPS, is specified through the following controller option: 
 
 ```json
 {
@@ -34,7 +37,7 @@ There are numerous methods to tune the control parameters. A good starting point
 5. Set P and D to the last stable values.
 6. Increase the I gain until it brings you to the setpoint with the number of oscillations desired (normally zero but a quicker response can be had if you don't mind a couple oscillations of overshoot)
 
-The PID rate controller, targeting a backlog of 5 transactions and seeded with and intial TPS of 2, and enabling viewing of the control parameters, is specified through the following controller option: 
+The PID rate controller, targeting a backlog of 5 transactions and seeded with an initial TPS of 2, and enabling viewing of the control parameters, is specified through the following controller option: 
 
 ```json
 {
@@ -99,7 +102,7 @@ The composite rate controller can be specified by setting the rate controller `t
     
 * `logChange`: a `boolean` value indicating whether the switches between the specified rate controllers should be logged or not.
 
-**Important!** The existence of the composite rate controller is completely transparent to the specified "sub-controllers." This is achieved by essentially placing the controllers in a "virtualized" round, i.e., "lying" to the them about: 
+**Important!** The existence of the composite rate controller is completely transparent to the specified "sub-controllers." This is achieved by essentially placing the controllers in a "virtualized" round, i.e., "lying" to them about: 
 * the duration of the round (for duration-based rounds),
 * the total number of transactions to submit (for transaction number-based rounds),
 * the starting time of the round,
@@ -108,9 +111,33 @@ The composite rate controller can be specified by setting the rate controller `t
 
 This "virtualization" does not affect the memoryless controllers, i.e., the controllers whose control logic does not depend on global round properties or past transaction results. However, other controllers might exhibit some strange (but hopefully transient) behavior due to this "virtualized" round approach. The logic of the [PID controller](#pid-rate) for example depends on the transaction backlog, but the (possibly pending) transactions submitted in the previous phase (with a different controller) are not visible to the controller.
 
+## Linear Rate
+
+Exploring the performance limits of a system usually consists of performing multiple measurements with increasing load intensity. However, finding the tipping point of the system this way is not easy, it is more like a trial-and-error method.
+
+The linear rate controller can gradually (linearly) change the TPS rate between a starting and finishing TPS value (both in increasing and decreasing manner). This makes it easier to find the workload rates that affect the system performance in an interesting way.
+
+The linear rate controller can be used in both duration-based and transaction number-based rounds. The following example specifies a rate controller that gradually changes the transaction load from 25 TPS to 75 TPS during the benchmark round. 
+
+```json
+{
+  "type": "linear-rate",
+  "opts": {
+    "startingTps": 25,
+    "finishingTps": 75
+    }
+}
+```
+
+The linear rate controller can be specified by setting the rate controller `type` to the `linear-rate` string. The available options (`opts` property) are the following:
+* `startingTps`: the TPS at the beginning of the round.
+* `finishingTps`: the TPS at the end of the round.
+
+**Note:** similarly to the [fixed rate controller](#fixed-rate), this controller also divides the workload between the available client, so the specified rates in the configuration are cumulative rates, and not the rates of individual clients. Using the above configuration with 5 clients results in clients that start at 5 TPS and finish at 15 TPS. Together they generate a [25-75] TPS load.
+
 ## Zero Rate
 
-This controller stops the workload generation for the duration of the round. Using the controller on its own for a round is meaningless. However, it can be used as a building block inside a [composite rate](#composite-rate) controller. The zero rate controller can be used only in _duration-based_ rounds!
+This controller stops the workload generation for the duration of the round. Using the controller on its own for a round is meaningless. However, it can be used as a building block inside a [composite rate](#composite-rate) controller. **The zero rate controller can be used only in duration-based rounds!**
 
 ```json
 {
@@ -144,7 +171,102 @@ Let's assume, that the above example is placed in a round definition with an 80 
 
 The controller is identified by the `zero-rate` string as the value of the `type` property and requires no additional configuration.
 
-## Custom Controllers
+## Record Rate
+
+This rate controller serves as a decorator around an other (arbitrary) controller. Its purpose is to record the times (relative to the start of the round) when each transaction was submitted, i.e., when the transaction was "enabled" by the "sub-controller."
+
+The following example records the times when the underlying [fixed rate](#fixed-rate) controller enabled the transactions (for details, see the available options below the example):
+
+```json
+{
+  "type": "record-rate", 
+  "opts": { 
+    "rateController": {
+      "type": "fixed-rate", 
+      "opts": {"tps" : 100}
+    },
+    "pathTemplate": "../tx_records_client<C>_round<R>.txt",
+    "outputFormat": "TEXT",
+    "logEnd": true
+  }
+}
+```
+
+The record rate controller can be specified by setting the rate controller `type` to the `record-rate` string. The available options (`opts` property) are the following:
+* `rateController`: the specification of an arbitrary rate controller.
+* `pathTemplate`: the template for the file path where the recorded times will be saved. The path can be either an absolute path or relative to the root Caliper directory.
+    
+    The template can (**and should**) contain special "variables/placeholders" that can refer to special environment properties (see the remarks below). The available placeholders are the following:
+    * `<C>`: placeholder for the 1-based index of the current client that uses this rate controller.
+    * `<R>`: placeholder for the 1-based index of the current round that uses this rate controller.
+* `outputFormat`: optional. Determines the format in which the recording will be saved. Defaults to `"TEXT"`. The currently supported formats are the following:
+    * `"TEXT"`: each recorded timing is encoded as text on separate lines.
+    * `"BIN_BE"`: binary format with Big Endian encoding.
+    * `"BIN_LE"`: binary format with Little Endian encoding.
+* `logEnd`: optional. Indicates whether to log that the recordings are written to the file(s). Defaults to `false`.
+
+**Template placeholders:** since Caliper provides a concise way to define multiple rounds and multiple clients with the same behavior, it is essential to differentiate between the recordings of the clients and rounds. Accordingly, the output file paths can contain placeholders for the round and client indices that will be resolved automatically at each client in each round. Otherwise, every client would write the same file, resulting in a serious conflict between timings and transaction IDs. 
+
+**Text format:** the rate controller saves the recordings in the following format (assuming a constant 10 TPS rate and ignoring the noise in the actual timings), row `i` corresponding to the `i`th transaction:
+```csv
+100
+200
+300
+...
+```
+
+**Binary format:** Both binary representations encode the `X` number of recordings as a series of `X+1` UInt32 numbers (1 number for the array length, the rest for the array elements), either in Little Endian or Big Endian encoding:
+```
+Offset: |0      |4      |8      |12      |16      |...     
+Data:   |length |1st    |2nd    |3rd     |4th     |...      
+```
+
+## Replay Rate
+
+One of the most important aspect of a good benchmark is its repeatability, i.e., it can be re-executed in a deterministic way whenever necessary. However, some benchmarks define the workload (e.g., user behavior) as a function of probabilistic distribution(s). This presents two problems from a practical point of view:
+
+1. Repeatability: The random sampling of the given probability distribution(s) can differ between benchmark (re-)executions. This makes the comparison of different platforms questionable. 
+1. Efficiency: Sampling a complex probability distribution incurs an additional runtime overhead, which can limit the rate of the load, distorting the originally specified workload.
+
+This rate controller aims to mitigate these problems by replaying a fix transaction load profile that was created "offline." This way the profile is generated once, outside of the benchmark execution, and can be replayed any time with the same timing constraints with minimal overhead.
+
+A trivial use case of this controller is to play back a transaction recording created by the [record controller](#record-rate). However, a well-formed trace file is the only requirement for this controller, hence any tool/method can be used to generate the transaction load profile.
+
+The following example specifies a rate controller that replays some client-dependent workload profiles (for details, see the available options below the example):
+
+```json
+{
+  "type": "replay-rate",
+  "opts": {
+    "pathTemplate": "../tx_records_client<C>.txt",
+    "inputFormat": "TEXT",
+    "logWarnings": true,
+    "defaultSleepTime": 50
+    }
+}
+```
+
+The replay rate controller can be specified by setting the rate controller type to the `replay-rate` string. The available options (`opts` property) are the following:
+
+* `pathTemplate`: the template for the file path where the transaction timings will be replayed from. The path can be either an absolute path or relative to the root Caliper directory.
+    
+    The template can (**and should**) contain special "variables/placeholders" that can refer to special environment properties (see the remarks at the [record rate controller](#record-rate)). The available placeholders are the following:
+    * `<C>`: placeholder for the 1-based index of the current client that uses this rate controller.
+    * `<R>`: placeholder for the 1-based index of the current round that uses this rate controller.
+* `inputFormat`: optional. Determines the format in which the transaction timings are stored (see the details at the [record rate controller](#record-rate)). Defaults to `"TEXT"`. The currently supported formats are the following:
+    * `"TEXT"`: each recorded timing is encoded as text on separate lines.
+    * `"BIN_BE"`: binary format with Big Endian encoding.
+    * `"BIN_LE"`: binary format with Little Endian encoding.
+* `logWarnings`: optional. Indicates whether to log that there are no more recordings to replay, so the `defaultSleepTime` is used between consecutive transactions. Defaults to `false`.
+* `defaultSleepTime`: optional. Determines the sleep time between transactions for the case when the benchmark execution is longer than the specified recording. Defaults to `20` ms.
+
+**About the recordings:** 
+
+Special care must be taken, when using duration-based benchmark execution, as it is possible to issue more transactions than specified in the recording. A safety measure for this case is the `defaultSleepTime` option. This should only occur in the last few moments of the execution, affecting only a few transactions, that can be discarded before performing additional performance analyses on the results.
+
+The recommended approach is to use transaction number-based round configurations, since the number of transactions to replay is known beforehand. Note, that the number of clients affects the actual number of transactions submitted by a client.
+
+# Custom Controllers
 
 Rate controllers must extend `/src/comm/rate-control/rateInterface.js`, providing concrete implementations for `init`, `applyRateControl`, and optionally for `end`. Once created it must be listed within `/src/comm/rate-control/rateControl.js` as an available controller within the constructor.
 

--- a/src/comm/bench-flow.js
+++ b/src/comm/bench-flow.js
@@ -233,6 +233,7 @@ function defaultTest(args, clientArgs, final) {
                 log('----test round ' + round + '----');
                 round++;
                 testIdx++;
+                item.roundIdx = round; // propagate round ID to clients
                 demo.startWatch(client);
 
                 return client.startTest(item, clientArgs, processResult, testLabel).then( () => {

--- a/src/comm/rate-control/compositeRate.js
+++ b/src/comm/rate-control/compositeRate.js
@@ -205,11 +205,12 @@ class CompositeRateController extends RateInterface{
      * @param {number} msg.totalClients The number of clients executing the round.
      * @param {number} msg.clients The number of clients executing the round.
      * @param {object} msg.clientargs Arguments for the client.
-     * @param {number} msg.clientIdx The index of the current client.
+     * @param {number} msg.clientIdx The 0-based index of the current client.
+     * @param {number} msg.roundIdx The 1-based index of the current round.
      */
     async init(msg) {
         let currentSum = 0;
-        this.clientIdx = msg.clientIdx;
+        this.clientIdx = msg.clientIdx + 1;
 
         // pre-set switch logic to avoid an other condition check during rate control
         this.controllerSwitch = msg.numb ? this.__controllerSwitchForTxNumber : this.__controllerSwitchForDuration;

--- a/src/comm/rate-control/linearRate.js
+++ b/src/comm/rate-control/linearRate.js
@@ -15,26 +15,25 @@
 'use strict';
 
 const RateInterface = require('./rateInterface.js');
-const Util = require('../util');
+const util = require('../util');
 
 /**
- * Rate controller for pausing load generation for a given time.
- *
- * Can only be applied for duration-based rounds!
+ * Rate controller for generating a linearly changing workload.
  *
  * @property {Blockchain} blockchain The initialized blockchain object.
  * @property {object} options The user-supplied options for the controller.
+ * @property {number} startingSleepTime The sleep time for the first transaction in milliseconds.
+ * @property {number} gradient The gradient of the line.
  */
-class NoRateController extends RateInterface{
+class LinearRateController extends RateInterface{
     /**
-     * Creates a new instance of the {NoRateController} class.
+     * Creates a new instance of the {LinearRateController} class.
      * @constructor
      * @param {Blockchain} blockchain The initialized blockchain object.
      * @param {object} opts Options for the rate controller.
      */
     constructor(blockchain, opts) {
         super(blockchain, opts);
-        this.sleepTime = 0;
     }
 
     /**
@@ -57,11 +56,18 @@ class NoRateController extends RateInterface{
      * @param {number} msg.roundIdx The 1-based index of the current round.
      */
     async init(msg) {
-        if (msg.numb) {
-            throw new Error('This rate controller can only be applied for duration-based rounds');
-        }
+        // distributing TPS among clients
+        let startingTps = Number(this.options.startingTps) / msg.totalClients;
+        let finishingTps = Number(this.options.finishingTps) / msg.totalClients;
+        this.startingSleepTime = 1000 / startingTps;
+        let finishingSleepTime = 1000 / finishingTps;
 
-        this.sleepTime = msg.txDuration * 1000;
+        // based on linear interpolation between two points with (time/index, sleep time) axes
+        let duration = msg.numb? msg.numb : msg.txDuration * 1000;
+        this.gradient = (finishingSleepTime - this.startingSleepTime) / duration;
+
+        // to avoid constant if/else check with the same result
+        this._interpolate = msg.numb ? this._interpolateFromIndex : this._interpolateFromTime;
     }
 
     /**
@@ -72,8 +78,31 @@ class NoRateController extends RateInterface{
      * @return {Promise} A promise that will resolve after the necessary time to keep the defined Tx rate.
      */
     async applyRateControl(start, idx, currentResults) {
-        return Util.sleep(this.sleepTime);
+        let currentSleepTime = this._interpolate(start, idx);
+        return currentSleepTime > 5 ? util.sleep(currentSleepTime) : Promise.resolve();
+    }
+
+    /**
+     * Interpolates the current sleep time from the transaction index.
+     * @param {number} start The epoch time at the start of the round (ms precision).
+     * @param {number} idx Sequence number of the current transaction.
+     * @return {number} The interpolated sleep time.
+     * @private
+     */
+    _interpolateFromIndex(start, idx) {
+        return this.startingSleepTime + idx * this.gradient;
+    }
+
+    /**
+     * Interpolates the current sleep time from the elapsed time.
+     * @param {number} start The epoch time at the start of the round (ms precision).
+     * @param {number} idx Sequence number of the current transaction.
+     * @return {number} The interpolated sleep time.
+     * @private
+     */
+    _interpolateFromTime(start, idx) {
+        return this.startingSleepTime + (Date.now() - start) * this.gradient;
     }
 }
 
-module.exports = NoRateController;
+module.exports = LinearRateController;

--- a/src/comm/rate-control/rateControl.js
+++ b/src/comm/rate-control/rateControl.js
@@ -45,6 +45,21 @@ let RateControl = class {
             this.controller = new NoRateController(blockchain, rateControl.opts);
             break;
         }
+        case 'record-rate': {
+            const RecordRateController = require('./recordRate.js');
+            this.controller = new RecordRateController(blockchain, rateControl.opts);
+            break;
+        }
+        case 'replay-rate': {
+            const ReplayRateController = require('./replayRate.js');
+            this.controller = new ReplayRateController(blockchain, rateControl.opts);
+            break;
+        }
+        case 'linear-rate': {
+            const LinearRateController = require('./linearRate.js');
+            this.controller = new LinearRateController(blockchain, rateControl.opts);
+            break;
+        }
         default:
             throw new Error('Unknown rate control type ' + rateControl.type);
         }

--- a/src/comm/rate-control/recordRate.js
+++ b/src/comm/rate-control/recordRate.js
@@ -1,0 +1,203 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const RateInterface = require('./rateInterface.js');
+const RateControl = require('./rateControl');
+const path = require('path');
+const fs = require('fs');
+const util = require('../util');
+
+const TEXT_FORMAT = 'TEXT';
+const BINARY_BE_FORMAT = 'BIN_BE';
+const BINARY_LE_FORMAT = 'BIN_LE';
+const supportedFormats = [TEXT_FORMAT, BINARY_BE_FORMAT, BINARY_LE_FORMAT];
+
+const rootDir = '../../..';
+
+/**
+ * Decorator rate controller for recording the rate of an other controller.
+ *
+ * @property {Blockchain} blockchain The initialized blockchain object.
+ * @property {object} options The user-supplied options for the controller.
+ * @property {object[]} records The record of times for submitted transactions.
+ * @property {RateControl} rateController The rate controller to record.
+ * @property {string} pathTemplate The template path for the file to record to.
+ * @property {number} roundIdx The index of the current round.
+ * @property {number} clientIdx The index of the current client.
+ * @property {string} outputFormat Specifies the output format for the recordings.
+ * @property {boolean} logEnd Indicates whether log when the records are written to file.
+ */
+class RecordRateController extends RateInterface{
+    /**
+     * Creates a new instance of the {RecordRateController} class.
+     * @constructor
+     * @param {Blockchain} blockchain The initialized blockchain object.
+     * @param {object} opts Options for the rate controller.
+     */
+    constructor(blockchain, opts) {
+        super(blockchain, opts);
+        this.records = [];
+
+        if (typeof opts.pathTemplate === 'undefined') {
+            throw new Error('The path to save the recording to is undefined');
+        }
+
+        if (typeof opts.rateController === 'undefined') {
+            throw new Error('The rate controller to record is undefined');
+        }
+
+        this.logEnd = Boolean(opts.logEnd || false);
+
+        // check for supported output formats
+        if (typeof opts.outputFormat === 'undefined') {
+            util.log(`[RecordRateController] Output format is undefined. Defaulting to ${TEXT_FORMAT} format`);
+            this.outputFormat = TEXT_FORMAT;
+        } else if (supportedFormats.includes(opts.outputFormat.toUpperCase())) {
+            this.outputFormat = opts.outputFormat.toUpperCase();
+        } else {
+            util.log(`[RecordRateController] Output format ${opts.outputFormat} is not supported. Defaulting to CSV format`);
+            this.outputFormat = TEXT_FORMAT;
+        }
+
+        this.pathTemplate = opts.pathTemplate;
+        this.rateController = new RateControl(opts.rateController, blockchain);
+    }
+
+    /**
+     * Initializes the rate controller.
+     *
+     * @param {object} msg Client options with adjusted per-client load settings.
+     * @param {string} msg.type The type of the message. Currently always 'test'
+     * @param {string} msg.label The label of the round.
+     * @param {object} msg.rateControl The rate control to use for the round.
+     * @param {number} msg.trim The number/seconds of transactions to trim from the results.
+     * @param {object} msg.args The user supplied arguments for the round.
+     * @param {string} msg.cb The path of the user's callback module.
+     * @param {string} msg.config The path of the network's configuration file.
+     * @param {number} msg.numb The number of transactions to generate during the round.
+     * @param {number} msg.txDuration The length of the round in SECONDS.
+     * @param {number} msg.totalClients The number of clients executing the round.
+     * @param {number} msg.clients The number of clients executing the round.
+     * @param {object} msg.clientargs Arguments for the client.
+     * @param {number} msg.clientIdx The 0-based index of the current client.
+     * @param {number} msg.roundIdx The 1-based index of the current round.
+     */
+    async init(msg) {
+        this.roundIdx = msg.roundIdx;
+        this.clientIdx = msg.clientIdx + 1;
+
+        // if we know the number of transactions beforehand, pre-allocate the array
+        if (msg.numb) {
+            this.records = new Array(msg.numb);
+            this.records.fill(0);
+        }
+
+        // resolve template path placeholders
+        this.pathTemplate = this.pathTemplate.replace(/<R>/gi, this.roundIdx.toString());
+        this.pathTemplate = this.pathTemplate.replace(/<C>/gi, this.clientIdx.toString());
+
+        if (!path.isAbsolute(this.pathTemplate)) {
+            this.pathTemplate = path.join(__dirname, rootDir, this.pathTemplate);
+        }
+
+        await this.rateController.init(msg);
+    }
+
+    /**
+     * Perform the rate control by sleeping through the round.
+     * @param {number} start The epoch time at the start of the round (ms precision).
+     * @param {number} idx Sequence number of the current transaction.
+     * @param {object[]} currentResults The list of results of finished transactions.
+     */
+    async applyRateControl(start, idx, currentResults) {
+        await this.rateController.applyRateControl(start, idx, currentResults);
+        this.records[idx] = Date.now() - start;
+    }
+
+    /**
+     * Notify the rate controller about the end of the round.
+     */
+    async end() {
+        await this.rateController.end();
+
+        try {
+            switch (this.outputFormat) {
+            case TEXT_FORMAT:
+                this.exportToText();
+                break;
+            case BINARY_LE_FORMAT:
+                this.exportToBinaryLittleEndian();
+                break;
+            case BINARY_BE_FORMAT:
+                this.exportToBinaryBigEndian();
+                break;
+            default:
+                util.log(`[RecordRateController] Output format ${this.outputFormat} is not supported.`);
+                break;
+            }
+
+            if (this.logEnd) {
+                util.log(`[RecordRateController] Recorded Tx submission times for Client#${this.clientIdx} in Round#${this.roundIdx} to ${this.pathTemplate}`);
+            }
+        } catch (err) {
+            util.log(`[RecordRateController] An error occured while writing records to ${this.pathTemplate}: ${err.stack ? err.stack : err}`);
+        }
+    }
+
+    /**
+     * Exports the recorded results in text format.
+     */
+    exportToText() {
+        fs.writeFileSync(this.pathTemplate, '', 'utf-8');
+        this.records.forEach(submitTime => fs.appendFileSync(this.pathTemplate, `${submitTime}\n`));
+    }
+
+    /**
+     * Exports the recorded results in little endian binary format.
+     */
+    exportToBinaryLittleEndian() {
+        // 4 bytes for array length, and 4 bytes for every array element
+        let buffer = Buffer.alloc((this.records.length + 1) * 4);
+        let offset = 0; // offset will be maintained by the buffer return value
+
+        offset = buffer.writeUInt32LE(this.records.length, offset);
+
+        for (let i = 0; i < this.records.length; i++) {
+            offset = buffer.writeUInt32LE(this.records[i], offset);
+        }
+
+        fs.writeFileSync(this.pathTemplate, buffer, 'binary');
+    }
+
+    /**
+     * Exports the recorded results in big endian binary format.
+     */
+    exportToBinaryBigEndian() {
+        // 4 bytes for array length, and 4 bytes for every array element
+        let buffer = Buffer.alloc((this.records.length + 1) * 4);
+        let offset = 0; // offset will be maintained by the buffer return value
+
+        offset = buffer.writeUInt32BE(this.records.length, offset);
+
+        for (let i = 0; i < this.records.length; i++) {
+            offset = buffer.writeUInt32BE(this.records[i], offset);
+        }
+
+        fs.writeFileSync(this.pathTemplate, buffer, 'binary');
+    }
+}
+
+module.exports = RecordRateController;

--- a/src/comm/rate-control/replayRate.js
+++ b/src/comm/rate-control/replayRate.js
@@ -1,0 +1,179 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const RateInterface = require('./rateInterface.js');
+const path = require('path');
+const fs = require('fs');
+const util = require('../util');
+
+const TEXT_FORMAT = 'TEXT';
+const BINARY_BE_FORMAT = 'BIN_BE';
+const BINARY_LE_FORMAT = 'BIN_LE';
+const supportedFormats = [TEXT_FORMAT, BINARY_BE_FORMAT, BINARY_LE_FORMAT];
+
+const rootDir = '../../..';
+
+/**
+ * Rate controller for replaying a previously recorded transaction trace.
+ *
+ * @property {Blockchain} blockchain The initialized blockchain object.
+ * @property {object} options The user-supplied options for the controller.
+ * @property {object[]} records The record of times for submitted transactions.
+ * @property {string} pathTemplate The template path for the file to record to.
+ * @property {number} roundIdx The index of the current round.
+ * @property {number} clientIdx The index of the current client.
+ * @property {string} inputFormat Specifies the input format for the recordings.
+ * @property {number} defaultSleepTime The default sleep time between extra transactions.
+ * @property {string} delimiter The delimiter character for the CSV format.
+ * @property {boolean} logWarnings Indicates whether to log extra transaction warnings.
+ */
+class ReplayRateController extends RateInterface{
+    /**
+     * Creates a new instance of the {ReplayRateController} class.
+     * @constructor
+     * @param {Blockchain} blockchain The initialized blockchain object.
+     * @param {object} opts Options for the rate controller.
+     */
+    constructor(blockchain, opts) {
+        super(blockchain, opts);
+        this.records = [];
+
+        if (typeof opts.pathTemplate === 'undefined') {
+            throw new Error('The path to load the recording from is undefined');
+        }
+
+        this.pathTemplate = opts.pathTemplate;
+        this.logWarnings = Boolean(opts.logWarnings || false);
+        this.defaultSleepTime = Number(opts.defaultSleepTime || 20);
+
+        // check for supported input formats
+        if (typeof opts.inputFormat === 'undefined') {
+            util.log(`[ReplayRateController] Input format is undefined. Defaulting to ${TEXT_FORMAT} format`);
+            this.inputFormat = TEXT_FORMAT;
+        } else if (supportedFormats.includes(opts.inputFormat.toUpperCase())) {
+            this.inputFormat = opts.inputFormat.toUpperCase();
+        } else {
+            util.log(`[ReplayRateController] Input format ${opts.inputFormat} is not supported. Defaulting to CSV format`);
+            this.inputFormat = TEXT_FORMAT;
+        }
+    }
+
+    /**
+     * Initializes the rate controller.
+     *
+     * @param {object} msg Client options with adjusted per-client load settings.
+     * @param {string} msg.type The type of the message. Currently always 'test'
+     * @param {string} msg.label The label of the round.
+     * @param {object} msg.rateControl The rate control to use for the round.
+     * @param {number} msg.trim The number/seconds of transactions to trim from the results.
+     * @param {object} msg.args The user supplied arguments for the round.
+     * @param {string} msg.cb The path of the user's callback module.
+     * @param {string} msg.config The path of the network's configuration file.
+     * @param {number} msg.numb The number of transactions to generate during the round.
+     * @param {number} msg.txDuration The length of the round in SECONDS.
+     * @param {number} msg.totalClients The number of clients executing the round.
+     * @param {number} msg.clients The number of clients executing the round.
+     * @param {object} msg.clientargs Arguments for the client.
+     * @param {number} msg.clientIdx The 0-based index of the current client.
+     * @param {number} msg.roundIdx The 1-based index of the current round.
+     */
+    async init(msg) {
+        this.roundIdx = msg.roundIdx;
+        this.clientIdx = msg.clientIdx + 1;
+
+        // resolve template path placeholders
+        this.pathTemplate = this.pathTemplate.replace(/<R>/gi, this.roundIdx.toString());
+        this.pathTemplate = this.pathTemplate.replace(/<C>/gi, this.clientIdx.toString());
+
+        if (!path.isAbsolute(this.pathTemplate)) {
+            this.pathTemplate = path.join(__dirname, rootDir, this.pathTemplate);
+        }
+
+        if (!fs.existsSync(this.pathTemplate)) {
+            throw new Error(`Trace file does not exist: ${this.pathTemplate}`);
+        }
+
+        switch (this.inputFormat) {
+        case TEXT_FORMAT:
+            this.importFromText();
+            break;
+        case BINARY_BE_FORMAT:
+            this.importFromBinaryBigEndian();
+            break;
+        case BINARY_LE_FORMAT:
+            this.importFromBinaryLittleEndian();
+            break;
+        default:
+            throw new Error(`Unsupported replay rate controller input format: ${this.inputFormat}`);
+        }
+    }
+
+    /**
+     * Perform the rate control by sleeping through the round.
+     * @param {number} start The epoch time at the start of the round (ms precision).
+     * @param {number} idx Sequence number of the current transaction.
+     * @param {object[]} currentResults The list of results of finished transactions.
+     * @return {Promise} The return promise.
+     */
+    async applyRateControl(start, idx, currentResults) {
+        if (idx <= this.records.length - 1) {
+            let sleepTime = this.records[idx] - (Date.now() - start);
+            return sleepTime > 5 ? util.sleep(sleepTime) : Promise.resolve();
+        } else {
+            if (this.logWarnings) {
+                util.log(`[ReplayRateController] Using default sleep time of ${this.defaultSleepTime}ms for Tx#${idx}`);
+            }
+            return util.sleep(this.defaultSleepTime);
+        }
+    }
+
+    /**
+     * Imports the timings from a one-column CSV format.
+     */
+    importFromText() {
+        this.records = fs.readFileSync(this.pathTemplate, 'utf-8').split('\n').map(line => parseInt(line));
+    }
+
+    /**
+     * Imports the timings from a little endian binary format.
+     */
+    importFromBinaryLittleEndian() {
+        let buffer = fs.readFileSync(this.pathTemplate);
+        let length = buffer.readUInt32LE(0);
+        this.records = new Array(length);
+
+        for (let i = 1; i <= length; i++) {
+            // because of the first 4 byte, the i-th record starts after i*4 bytes
+            this.records[i - 1] = buffer.readUInt32LE(i * 4);
+        }
+    }
+
+    /**
+     * Imports the timings from a big endian binary format.
+     */
+    importFromBinaryBigEndian() {
+        let buffer = fs.readFileSync(this.pathTemplate);
+        let length = buffer.readUInt32BE(0);
+        this.records = new Array(length);
+
+        for (let i = 1; i <= length; i++) {
+            // because of the first 4 byte, the i-th record starts after i*4 bytes
+            this.records[i - 1] = buffer.readUInt32BE(i * 4);
+        }
+    }
+}
+
+module.exports = ReplayRateController;


### PR DESCRIPTION
This PR adds three additional rate controller to Caliper:
1. Linear rate controller for gradually increasing the TPS rate
2. Record rate controller for recording the timings of a rate controller
3. Replay rate controller for replaying an arbitrary timing trace

For details, see the documentation.
Another minor change: the clients now receive the round index in the message, which is propagated to the controllers (and soon also for the callbacks, but that's an other PR).

Signed-off-by: Attila Klenik <a.klenik@gmail.com>