### PR TITLE
Fix cross-process error message format

### DIFF
--- a/src/comm/client/local-client.js
+++ b/src/comm/client/local-client.js
@@ -229,7 +229,7 @@ process.on('message', function(message) {
             }
         }
         catch(err) {
-            process.send({type: 'error', data: err});
+            process.send({type: 'error', data: err.toString()});
         }
     }
     else {


### PR DESCRIPTION
If an unhandled exception occurred in a client process, the main process printed the received error object as the following, obscuring the original error. Set an invalid callback name to reproduce it:

```
not ok 5 failed 'open' testing, Error: Client encountered error:[object Object] at ChildProcess.<anonymous>
```

Now it receives the `string` version of the error and prints it correctly:

```
not ok 5 failed 'open' testing, Error: Client encountered error:Error: Cannot find module '/home/klenik/projects/caliper-single-org/benchmark/simple/opennn.js' at ChildProcess.<anonymous>
```

Signed-off-by: Attila Klenik <a.klenik@gmail.com>