### PR TITLE
Minor fix: pidRate should return the Sleep promise not just create it. 

### DIFF
--- a/src/comm/rate-control/pidRate.js
+++ b/src/comm/rate-control/pidRate.js
@@ -101,7 +101,7 @@ class PidRate extends RateInterface {
         }
 
         if (this.sleep > 5) {
-            Sleep(this.sleep);
+            return Sleep(this.sleep);
         } else {
             return Promise.resolve();
         }


### PR DESCRIPTION
This is a minor problem I spotted well taking the pidRate controller for a spin.  Obviously the pidRate controller should return the Sleep promise rather than just leaving it, otherwise the test goes into a very tight loop and the rate isn't controlled at all.

Signed-off-by: Kevin O'Donnell <kevin@blockchaintp.com>