### PR TITLE
Use common utility for path resolution

### DIFF
--- a/network/fabric/2-org-1-peer/composer-tls.json
+++ b/network/fabric/2-org-1-peer/composer-tls.json
@@ -1,6 +1,6 @@
 {  
   "composer": {
-    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "contract/composer", "orgs": ["Org1", "Org2"], "loglevel": "INFO"}],
+    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "src/contract/composer", "orgs": ["Org1", "Org2"], "loglevel": "INFO"}],
     "cryptodir": "network/fabric/config/crypto-config",
     "network": {
       "x-type" : "hlfv1",
@@ -12,7 +12,7 @@
           "url": "grpcs://localhost:7050",
           "mspid": "OrdererMSP",
           "mspconfig": "/etc/hyperledger/msp/orderer/tls/ca.crt",
-          "cert": "/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt",
+          "cert": "network/fabric/config/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt",
           "hostname": "orderer.example.com",
           "hosturl": "orderer.example.com:7050"
         }
@@ -32,8 +32,8 @@
           "name": "Org1",
           "mspid": "Org1MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org1.example.com/msp",
-          "adminCert": "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org1.example.com"
           ],
@@ -45,8 +45,8 @@
           "name": "Org2",
           "mspid": "Org2MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org2.example.com/msp",
-          "adminCert": "/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org2.example.com"
           ],
@@ -60,7 +60,7 @@
           "url": "grpcs://localhost:7051",
           "eventUrl": "grpcs://localhost:7053",
           "hostname": "peer0.org1.example.com",
-          "cert" : "/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]
@@ -69,7 +69,7 @@
           "url": "grpcs://localhost:8051",
           "eventUrl": "grpcs://localhost:8053",
           "hostname": "peer0.org2.example.com",
-          "cert" : "/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]

--- a/network/fabric/2-org-1-peer/composer.json
+++ b/network/fabric/2-org-1-peer/composer.json
@@ -1,6 +1,6 @@
 {  
   "composer": {
-    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "contract/composer", "orgs": ["Org1", "Org2"], "loglevel": "INFO"}],
+    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "src/contract/composer", "orgs": ["Org1", "Org2"], "loglevel": "INFO"}],
     "cryptodir": "network/fabric/config/crypto-config",
     "network": {
       "x-type" : "hlfv1",
@@ -31,8 +31,8 @@
           "name": "Org1",
           "mspid": "Org1MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org1.example.com/msp",
-          "adminCert": "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org1.example.com"
           ],
@@ -44,8 +44,8 @@
           "name": "Org2",
           "mspid": "Org2MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org2.example.com/msp",
-          "adminCert": "/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org2.example.com"
           ],

--- a/network/fabric/2-org-2-peer/composer-tls.json
+++ b/network/fabric/2-org-2-peer/composer-tls.json
@@ -1,6 +1,6 @@
 {  
   "composer": {
-    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "contract/composer", "orgs": ["Org1", "Org2"], "loglevel": "INFO"}],
+    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "src/contract/composer", "orgs": ["Org1", "Org2"], "loglevel": "INFO"}],
     "cryptodir": "network/fabric/config/crypto-config",
     "network": {
       "x-type" : "hlfv1",
@@ -12,7 +12,7 @@
           "url": "grpcs://localhost:7050",
           "mspid": "OrdererMSP",
           "mspconfig": "/etc/hyperledger/msp/orderer/tls/ca.crt",
-          "cert": "/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt",
+          "cert": "network/fabric/config/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt",
           "hostname": "orderer.example.com",
           "hosturl": "orderer.example.com:7050"
         }
@@ -32,8 +32,8 @@
           "name": "Org1",
           "mspid": "Org1MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org1.example.com/msp",
-          "adminCert": "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org1.example.com"
           ],
@@ -46,8 +46,8 @@
           "name": "Org2",
           "mspid": "Org2MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org2.example.com/msp",
-          "adminCert": "/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org2.example.com"
           ],
@@ -62,7 +62,7 @@
           "url": "grpcs://localhost:7051",
           "eventUrl": "grpcs://localhost:7053",
           "hostname": "peer0.org1.example.com",
-          "cert" : "/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]
@@ -71,7 +71,7 @@
           "url": "grpcs://localhost:7057",
           "eventUrl": "grpcs://localhost:7059",
           "hostname": "peer1.org1.example.com",
-          "cert" : "/peerOrganizations/org1.example.com/peers/peer1.org1.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/peers/peer1.org1.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]
@@ -80,7 +80,7 @@
           "url": "grpcs://localhost:8051",
           "eventUrl": "grpcs://localhost:8053",
           "hostname": "peer0.org2.example.com",
-          "cert" : "/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]
@@ -89,7 +89,7 @@
           "url": "grpcs://localhost:8057",
           "eventUrl": "grpcs://localhost:8059",
           "hostname": "peer1.org2.example.com",
-          "cert" : "/peerOrganizations/org2.example.com/peers/peer1.org2.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/peers/peer1.org2.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]

--- a/network/fabric/2-org-2-peer/composer.json
+++ b/network/fabric/2-org-2-peer/composer.json
@@ -1,6 +1,6 @@
 {  
   "composer": {
-    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "contract/composer", "orgs": ["Org1", "Org2"], "loglevel": "INFO"}],
+    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "src/contract/composer", "orgs": ["Org1", "Org2"], "loglevel": "INFO"}],
     "cryptodir": "network/fabric/config/crypto-config",
     "network": {
       "x-type" : "hlfv1",
@@ -31,8 +31,8 @@
           "name": "Org1",
           "mspid": "Org1MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org1.example.com/msp",
-          "adminCert": "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org1.example.com"
           ],
@@ -45,8 +45,8 @@
           "name": "Org2",
           "mspid": "Org2MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org2.example.com/msp",
-          "adminCert": "/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org2.example.com"
           ],

--- a/network/fabric/2-org-3-peer/composer-tls.json
+++ b/network/fabric/2-org-3-peer/composer-tls.json
@@ -1,6 +1,6 @@
 {  
   "composer": {
-    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "contract/composer", "orgs": ["Org1", "Org2"], "loglevel": "INFO"}],
+    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "src/contract/composer", "orgs": ["Org1", "Org2"], "loglevel": "INFO"}],
     "cryptodir": "network/fabric/config/crypto-config",
     "network": {
       "x-type" : "hlfv1",
@@ -12,7 +12,7 @@
           "url": "grpcs://localhost:7050",
           "mspid": "OrdererMSP",
           "mspconfig": "/etc/hyperledger/msp/orderer/tls/ca.crt",
-          "cert": "/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt",
+          "cert": "network/fabric/config/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt",
           "hostname": "orderer.example.com",
           "hosturl": "orderer.example.com:7050"
         }
@@ -32,8 +32,8 @@
           "name": "Org1",
           "mspid": "Org1MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org1.example.com/msp",
-          "adminCert": "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org1.example.com"
           ],
@@ -47,8 +47,8 @@
           "name": "Org2",
           "mspid": "Org2MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org2.example.com/msp",
-          "adminCert": "/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org2.example.com"
           ],
@@ -64,7 +64,7 @@
           "url": "grpcs://localhost:7051",
           "eventUrl": "grpcs://localhost:7053",
           "hostname": "peer0.org1.example.com",
-          "cert" : "/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]
@@ -73,7 +73,7 @@
           "url": "grpcs://localhost:7057",
           "eventUrl": "grpcs://localhost:7059",
           "hostname": "peer1.org1.example.com",
-          "cert" : "/peerOrganizations/org1.example.com/peers/peer1.org1.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/peers/peer1.org1.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]
@@ -82,7 +82,7 @@
           "url": "grpcs://localhost:7063",
           "eventUrl": "grpcs://localhost:7065",
           "hostname": "peer2.org1.example.com",
-          "cert" : "/peerOrganizations/org1.example.com/peers/peer2.org1.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/peers/peer2.org1.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]
@@ -91,7 +91,7 @@
           "url": "grpcs://localhost:8051",
           "eventUrl": "grpcs://localhost:8053",
           "hostname": "peer0.org2.example.com",
-          "cert" : "/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]
@@ -100,7 +100,7 @@
           "url": "grpcs://localhost:8057",
           "eventUrl": "grpcs://localhost:8059",
           "hostname": "peer1.org2.example.com",
-          "cert" : "/peerOrganizations/org2.example.com/peers/peer1.org2.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/peers/peer1.org2.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]
@@ -109,7 +109,7 @@
           "url": "grpcs://localhost:8063",
           "eventUrl": "grpcs://localhost:8065",
           "hostname": "peer2.org2.example.com",
-          "cert" : "/peerOrganizations/org2.example.com/peers/peer2.org2.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/peers/peer2.org2.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]

--- a/network/fabric/2-org-3-peer/composer.json
+++ b/network/fabric/2-org-3-peer/composer.json
@@ -1,6 +1,6 @@
 {  
   "composer": {
-    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "contract/composer", "orgs": ["Org1", "Org2"], "loglevel": "INFO"}],
+    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "src/contract/composer", "orgs": ["Org1", "Org2"], "loglevel": "INFO"}],
     "cryptodir": "network/fabric/config/crypto-config",
     "network": {
       "x-type" : "hlfv1",
@@ -31,8 +31,8 @@
           "name": "Org1",
           "mspid": "Org1MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org1.example.com/msp",
-          "adminCert": "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org1.example.com"
           ],
@@ -46,8 +46,8 @@
           "name": "Org2",
           "mspid": "Org2MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org2.example.com/msp",
-          "adminCert": "/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org2.example.com"
           ],

--- a/network/fabric/3-org-1-peer/composer-tls.json
+++ b/network/fabric/3-org-1-peer/composer-tls.json
@@ -1,6 +1,6 @@
 {  
   "composer": {
-    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "contract/composer", "orgs": ["Org1", "Org2", "Org3"], "loglevel": "INFO"}],
+    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "src/contract/composer", "orgs": ["Org1", "Org2", "Org3"], "loglevel": "INFO"}],
     "cryptodir": "network/fabric/config/crypto-config",
     "network": {
       "x-type" : "hlfv1",
@@ -12,7 +12,7 @@
           "url": "grpcs://localhost:7050",
           "mspid": "OrdererMSP",
           "mspconfig": "/etc/hyperledger/msp/orderer/tls/ca.crt",
-          "cert": "/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt",
+          "cert": "network/fabric/config/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt",
           "hostname": "orderer.example.com",
           "hosturl": "orderer.example.com:7050"
         }
@@ -36,8 +36,8 @@
           "name": "Org1",
           "mspid": "Org1MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org1.example.com/msp",
-          "adminCert": "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org1.example.com"
           ],
@@ -49,8 +49,8 @@
           "name": "Org2",
           "mspid": "Org2MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org2.example.com/msp",
-          "adminCert": "/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org2.example.com"
           ],
@@ -62,8 +62,8 @@
           "name": "Org3",
           "mspid": "Org3MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org3.example.com/msp",
-          "adminCert": "/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/signcerts/Admin@org3.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/signcerts/Admin@org3.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org3.example.com"
           ],
@@ -77,7 +77,7 @@
           "url": "grpcs://localhost:7051",
           "eventUrl": "grpcs://localhost:7053",
           "hostname": "peer0.org1.example.com",
-          "cert" : "/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]
@@ -86,7 +86,7 @@
           "url": "grpcs://localhost:8051",
           "eventUrl": "grpcs://localhost:8053",
           "hostname": "peer0.org2.example.com",
-          "cert" : "/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]
@@ -95,7 +95,7 @@
           "url": "grpcs://localhost:9051",
           "eventUrl": "grpcs://localhost:9053",
           "hostname": "peer0.org3.example.com",
-          "cert" : "/peerOrganizations/org3.example.com/peers/peer0.org3.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org3.example.com/peers/peer0.org3.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]

--- a/network/fabric/3-org-1-peer/composer.json
+++ b/network/fabric/3-org-1-peer/composer.json
@@ -1,6 +1,6 @@
 {  
   "composer": {
-    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "contract/composer", "orgs": ["Org1", "Org2", "Org3"], "loglevel": "INFO"}],
+    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "src/contract/composer", "orgs": ["Org1", "Org2", "Org3"], "loglevel": "INFO"}],
     "cryptodir": "network/fabric/config/crypto-config",
     "network": {
       "x-type" : "hlfv1",
@@ -35,8 +35,8 @@
           "name": "Org1",
           "mspid": "Org1MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org1.example.com/msp",
-          "adminCert": "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org1.example.com"
           ],
@@ -48,8 +48,8 @@
           "name": "Org2",
           "mspid": "Org2MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org2.example.com/msp",
-          "adminCert": "/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org2.example.com"
           ],
@@ -61,8 +61,8 @@
           "name": "Org3",
           "mspid": "Org3MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org3.example.com/msp",
-          "adminCert": "/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/signcerts/Admin@org3.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/signcerts/Admin@org3.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org3.example.com"
           ],

--- a/network/fabric/3-org-2-peer/composer-tls.json
+++ b/network/fabric/3-org-2-peer/composer-tls.json
@@ -1,6 +1,6 @@
 {  
   "composer": {
-    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "contract/composer", "orgs": ["Org1", "Org2", "Org3"], "loglevel": "INFO"}],
+    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "src/contract/composer", "orgs": ["Org1", "Org2", "Org3"], "loglevel": "INFO"}],
     "cryptodir": "network/fabric/config/crypto-config",
     "network": {
       "x-type" : "hlfv1",
@@ -12,7 +12,7 @@
           "url": "grpcs://localhost:7050",
           "mspid": "OrdererMSP",
           "mspconfig": "/etc/hyperledger/msp/orderer/tls/ca.crt",
-          "cert": "/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt",
+          "cert": "network/fabric/config/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt",
           "hostname": "orderer.example.com",
           "hosturl": "orderer.example.com:7050"
         }
@@ -36,8 +36,8 @@
           "name": "Org1",
           "mspid": "Org1MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org1.example.com/msp",
-          "adminCert": "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org1.example.com"
           ],
@@ -50,8 +50,8 @@
           "name": "Org2",
           "mspid": "Org2MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org2.example.com/msp",
-          "adminCert": "/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org2.example.com"
           ],
@@ -64,8 +64,8 @@
           "name": "Org3",
           "mspid": "Org3MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org3.example.com/msp",
-          "adminCert": "/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/signcerts/Admin@org3.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/signcerts/Admin@org3.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org3.example.com"
           ],
@@ -80,7 +80,7 @@
           "url": "grpcs://localhost:7051",
           "eventUrl": "grpcs://localhost:7053",
           "hostname": "peer0.org1.example.com",
-          "cert" : "/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]
@@ -89,7 +89,7 @@
           "url": "grpcs://localhost:7057",
           "eventUrl": "grpcs://localhost:7059",
           "hostname": "peer1.org1.example.com",
-          "cert" : "/peerOrganizations/org1.example.com/peers/peer1.org1.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/peers/peer1.org1.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]
@@ -98,7 +98,7 @@
           "url": "grpcs://localhost:8051",
           "eventUrl": "grpcs://localhost:8053",
           "hostname": "peer0.org2.example.com",
-          "cert" : "/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]
@@ -107,7 +107,7 @@
           "url": "grpcs://localhost:8057",
           "eventUrl": "grpcs://localhost:8059",
           "hostname": "peer1.org2.example.com",
-          "cert" : "/peerOrganizations/org2.example.com/peers/peer1.org2.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/peers/peer1.org2.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]
@@ -116,7 +116,7 @@
           "url": "grpcs://localhost:9051",
           "eventUrl": "grpcs://localhost:9053",
           "hostname": "peer0.org3.example.com",
-          "cert" : "/peerOrganizations/org3.example.com/peers/peer0.org3.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org3.example.com/peers/peer0.org3.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]
@@ -125,7 +125,7 @@
           "url": "grpcs://localhost:9057",
           "eventUrl": "grpcs://localhost:9059",
           "hostname": "peer1.org3.example.com",
-          "cert" : "/peerOrganizations/org3.example.com/peers/peer1.org3.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org3.example.com/peers/peer1.org3.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]

--- a/network/fabric/3-org-2-peer/composer.json
+++ b/network/fabric/3-org-2-peer/composer.json
@@ -1,6 +1,6 @@
 {  
   "composer": {
-    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "contract/composer", "orgs": ["Org1", "Org2", "Org3"], "loglevel": "INFO"}],
+    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "src/contract/composer", "orgs": ["Org1", "Org2", "Org3"], "loglevel": "INFO"}],
     "cryptodir": "network/fabric/config/crypto-config",
     "network": {
       "x-type" : "hlfv1",
@@ -35,8 +35,8 @@
           "name": "Org1",
           "mspid": "Org1MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org1.example.com/msp",
-          "adminCert": "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org1.example.com"
           ],
@@ -49,8 +49,8 @@
           "name": "Org2",
           "mspid": "Org2MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org2.example.com/msp",
-          "adminCert": "/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org2.example.com"
           ],
@@ -63,8 +63,8 @@
           "name": "Org3",
           "mspid": "Org3MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org3.example.com/msp",
-          "adminCert": "/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/signcerts/Admin@org3.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/signcerts/Admin@org3.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org3.example.com"
           ],

--- a/network/fabric/3-org-3-peer/composer-tls.json
+++ b/network/fabric/3-org-3-peer/composer-tls.json
@@ -1,6 +1,6 @@
 {  
   "composer": {
-    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "contract/composer", "orgs": ["Org1", "Org2", "Org3"], "loglevel": "INFO"}],
+    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "src/contract/composer", "orgs": ["Org1", "Org2", "Org3"], "loglevel": "INFO"}],
     "cryptodir": "network/fabric/config/crypto-config",
     "network": {
       "x-type" : "hlfv1",
@@ -12,7 +12,7 @@
           "url": "grpcs://localhost:7050",
           "mspid": "OrdererMSP",
           "mspconfig": "/etc/hyperledger/msp/orderer/tls/ca.crt",
-          "cert": "/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt",
+          "cert": "network/fabric/config/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt",
           "hostname": "orderer.example.com",
           "hosturl": "orderer.example.com:7050"
         }
@@ -36,8 +36,8 @@
           "name": "Org1",
           "mspid": "Org1MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org1.example.com/msp",
-          "adminCert": "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org1.example.com"
           ],
@@ -51,8 +51,8 @@
           "name": "Org2",
           "mspid": "Org2MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org2.example.com/msp",
-          "adminCert": "/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org2.example.com"
           ],
@@ -66,8 +66,8 @@
           "name": "Org3",
           "mspid": "Org3MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org3.example.com/msp",
-          "adminCert": "/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/signcerts/Admin@org3.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/signcerts/Admin@org3.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org3.example.com"
           ],
@@ -83,7 +83,7 @@
           "url": "grpcs://localhost:7051",
           "eventUrl": "grpcs://localhost:7053",
           "hostname": "peer0.org1.example.com",
-          "cert" : "/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]
@@ -92,7 +92,7 @@
           "url": "grpcs://localhost:7057",
           "eventUrl": "grpcs://localhost:7059",
           "hostname": "peer1.org1.example.com",
-          "cert" : "/peerOrganizations/org1.example.com/peers/peer1.org1.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/peers/peer1.org1.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]
@@ -101,7 +101,7 @@
           "url": "grpcs://localhost:7063",
           "eventUrl": "grpcs://localhost:7065",
           "hostname": "peer2.org1.example.com",
-          "cert" : "/peerOrganizations/org1.example.com/peers/peer2.org1.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/peers/peer2.org1.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]
@@ -110,7 +110,7 @@
           "url": "grpcs://localhost:8051",
           "eventUrl": "grpcs://localhost:8053",
           "hostname": "peer0.org2.example.com",
-          "cert" : "/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]
@@ -119,7 +119,7 @@
           "url": "grpcs://localhost:8057",
           "eventUrl": "grpcs://localhost:8059",
           "hostname": "peer1.org2.example.com",
-          "cert" : "/peerOrganizations/org2.example.com/peers/peer1.org2.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/peers/peer1.org2.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]
@@ -128,7 +128,7 @@
           "url": "grpcs://localhost:8063",
           "eventUrl": "grpcs://localhost:8065",
           "hostname": "peer2.org2.example.com",
-          "cert" : "/peerOrganizations/org2.example.com/peers/peer2.org2.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/peers/peer2.org2.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]
@@ -137,7 +137,7 @@
           "url": "grpcs://localhost:9051",
           "eventUrl": "grpcs://localhost:9053",
           "hostname": "peer0.org3.example.com",
-          "cert" : "/peerOrganizations/org3.example.com/peers/peer0.org3.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org3.example.com/peers/peer0.org3.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]
@@ -146,7 +146,7 @@
           "url": "grpcs://localhost:9057",
           "eventUrl": "grpcs://localhost:9059",
           "hostname": "peer1.org3.example.com",
-          "cert" : "/peerOrganizations/org3.example.com/peers/peer1.org3.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org3.example.com/peers/peer1.org3.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]
@@ -155,7 +155,7 @@
           "url": "grpcs://localhost:9063",
           "eventUrl": "grpcs://localhost:9065",
           "hostname": "peer2.org3.example.com",
-          "cert" : "/peerOrganizations/org3.example.com/peers/peer2.org3.example.com/tls/ca.crt",
+          "cert" : "network/fabric/config/crypto-config/peerOrganizations/org3.example.com/peers/peer2.org3.example.com/tls/ca.crt",
           "channels":[
             "mychannel"
           ]

--- a/network/fabric/3-org-3-peer/composer.json
+++ b/network/fabric/3-org-3-peer/composer.json
@@ -1,6 +1,6 @@
 {  
   "composer": {
-    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "contract/composer", "orgs": ["Org1", "Org2", "Org3"], "loglevel": "INFO"}],
+    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "src/contract/composer", "orgs": ["Org1", "Org2", "Org3"], "loglevel": "INFO"}],
     "cryptodir": "network/fabric/config/crypto-config",
     "network": {
       "x-type" : "hlfv1",
@@ -35,8 +35,8 @@
           "name": "Org1",
           "mspid": "Org1MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org1.example.com/msp",
-          "adminCert": "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org1.example.com"
           ],
@@ -50,8 +50,8 @@
           "name": "Org2",
           "mspid": "Org2MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org2.example.com/msp",
-          "adminCert": "/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org2.example.com"
           ],
@@ -65,8 +65,8 @@
           "name": "Org3",
           "mspid": "Org3MSP",
           "mspconfig": "/etc/hyperledger/msp/users/Admin@org3.example.com/msp",
-          "adminCert": "/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/signcerts/Admin@org3.example.com-cert.pem",
-          "adminKey" : "/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/keystore/key.pem",
+          "adminCert": "network/fabric/config/crypto-config/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/signcerts/Admin@org3.example.com-cert.pem",
+          "adminKey" : "network/fabric/config/crypto-config/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/keystore/key.pem",
           "certificateAuthorities": [
             "ca.org3.example.com"
           ],

--- a/src/comm/bench-flow.js
+++ b/src/comm/bench-flow.js
@@ -28,7 +28,7 @@ let resultsbyround = [];    // results table for each test round
 let round = 0;              // test round
 let demo = require('../gui/src/demo.js');
 let absConfigFile, absNetworkFile;
-let absCaliperDir = path.join(__dirname, '../..');
+let absCaliperDir = path.join(__dirname, '..', '..');
 
 /**
  * Generate mustache template for test report
@@ -275,8 +275,8 @@ function defaultTest(args, clientArgs, final) {
 module.exports.run = function(configFile, networkFile) {
     test('#######Caliper Test######', (t) => {
         global.tapeObj = t;
-        absConfigFile  = configFile;
-        absNetworkFile = networkFile;
+        absConfigFile  = Util.resolvePath(configFile);
+        absNetworkFile = Util.resolvePath(networkFile);
         blockchain = new Blockchain(absNetworkFile);
         monitor = new Monitor(absConfigFile);
         client  = new Client(absConfigFile);

--- a/src/comm/client/local-client.js
+++ b/src/comm/client/local-client.js
@@ -8,7 +8,6 @@
 'use strict';
 
 // global variables
-const path = require('path');
 const bc   = require('../blockchain.js');
 const RateControl = require('../rate-control/rateControl.js');
 const Util = require('../util.js');
@@ -186,8 +185,8 @@ async function runDuration(msg, cb, context) {
  */
 function doTest(msg) {
     log('doTest() with:', msg);
-    let cb = require(path.join(__dirname, '../../..', msg.cb));
-    blockchain = new bc(path.join(__dirname, '../../..', msg.config));
+    let cb = require(Util.resolvePath(msg.cb));
+    blockchain = new bc(Util.resolvePath(msg.config));
 
     beforeTest(msg);
     // start an interval to report results repeatedly

--- a/src/comm/rate-control/recordRate.js
+++ b/src/comm/rate-control/recordRate.js
@@ -16,7 +16,6 @@
 
 const RateInterface = require('./rateInterface.js');
 const RateControl = require('./rateControl');
-const path = require('path');
 const fs = require('fs');
 const util = require('../util');
 
@@ -24,8 +23,6 @@ const TEXT_FORMAT = 'TEXT';
 const BINARY_BE_FORMAT = 'BIN_BE';
 const BINARY_LE_FORMAT = 'BIN_LE';
 const supportedFormats = [TEXT_FORMAT, BINARY_BE_FORMAT, BINARY_LE_FORMAT];
-
-const rootDir = '../../..';
 
 /**
  * Decorator rate controller for recording the rate of an other controller.
@@ -108,10 +105,7 @@ class RecordRateController extends RateInterface{
         // resolve template path placeholders
         this.pathTemplate = this.pathTemplate.replace(/<R>/gi, this.roundIdx.toString());
         this.pathTemplate = this.pathTemplate.replace(/<C>/gi, this.clientIdx.toString());
-
-        if (!path.isAbsolute(this.pathTemplate)) {
-            this.pathTemplate = path.join(__dirname, rootDir, this.pathTemplate);
-        }
+        this.pathTemplate = util.resolvePath(this.pathTemplate);
 
         await this.rateController.init(msg);
     }

--- a/src/comm/rate-control/replayRate.js
+++ b/src/comm/rate-control/replayRate.js
@@ -15,7 +15,6 @@
 'use strict';
 
 const RateInterface = require('./rateInterface.js');
-const path = require('path');
 const fs = require('fs');
 const util = require('../util');
 
@@ -23,8 +22,6 @@ const TEXT_FORMAT = 'TEXT';
 const BINARY_BE_FORMAT = 'BIN_BE';
 const BINARY_LE_FORMAT = 'BIN_LE';
 const supportedFormats = [TEXT_FORMAT, BINARY_BE_FORMAT, BINARY_LE_FORMAT];
-
-const rootDir = '../../..';
 
 /**
  * Rate controller for replaying a previously recorded transaction trace.
@@ -97,10 +94,7 @@ class ReplayRateController extends RateInterface{
         // resolve template path placeholders
         this.pathTemplate = this.pathTemplate.replace(/<R>/gi, this.roundIdx.toString());
         this.pathTemplate = this.pathTemplate.replace(/<C>/gi, this.clientIdx.toString());
-
-        if (!path.isAbsolute(this.pathTemplate)) {
-            this.pathTemplate = path.join(__dirname, rootDir, this.pathTemplate);
-        }
+        this.pathTemplate = util.resolvePath(this.pathTemplate);
 
         if (!fs.existsSync(this.pathTemplate)) {
             throw new Error(`Trace file does not exist: ${this.pathTemplate}`);

--- a/src/composer/composer_utils.js
+++ b/src/composer/composer_utils.js
@@ -190,7 +190,6 @@ async function joinChannels(config) {
  * @returns {Object} the common connection profile
  */
 function createCommonConnectionProfile(orgName, config) {
-    let cryptodir = config.composer.cryptodir;
     let profile = {};
 
     // Header information
@@ -253,7 +252,7 @@ function createCommonConnectionProfile(orgName, config) {
             orderer.grpcOptions = grpcOptions;
 
             let tlsCACerts = {};
-            let certPath = path.join(__dirname, '/../../', cryptodir, configOrderer.cert);
+            let certPath = Util.resolvePath(configOrderer.cert);
             tlsCACerts.path = certPath;
             orderer.tlsCACerts = tlsCACerts;
         }
@@ -276,7 +275,7 @@ function createCommonConnectionProfile(orgName, config) {
             peer.grpcOptions = grpcOptions;
 
             let tlsCACerts = {};
-            let certPath =  path.join(__dirname, '/../../', cryptodir, configPeer.cert);
+            let certPath =  Util.resolvePath(configPeer.cert);
             tlsCACerts.path = certPath;
             peer.tlsCACerts = tlsCACerts;
         }
@@ -309,7 +308,6 @@ function createCommonConnectionProfile(orgName, config) {
  * @param {Object} config Configuration data in Json format
  */
 async function createAdminBusNetCards(config) {
-    let cryptodir = config.composer.cryptodir;
     let orgs = config.composer.network.organizations;
     let adminConnection = await new AdminConnection();
 
@@ -329,8 +327,8 @@ async function createAdminBusNetCards(config) {
         let idCard = new IdCard(metadata, profile);
 
         // certificates & privateKey
-        let certpath = path.join(__dirname, '/../../', cryptodir, org.adminCert);
-        let keyPath = path.join(__dirname, '/../../', cryptodir, org.adminKey);
+        let certpath = Util.resolvePath(org.adminCert);
+        let keyPath = Util.resolvePath(org.adminKey);
         let cert = fs.readFileSync(certpath).toString();
         let key = fs.readFileSync(keyPath).toString();
 
@@ -362,7 +360,7 @@ async function runtimeInstall(businessNetwork, installOptions, cardName) {
     let businessNetworkDefinition;
 
     //check the file is there
-    let filePath = path.join(__dirname, '..', businessNetwork.path, businessNetwork.id);
+    let filePath = path.join(Util.resolvePath(businessNetwork.path), businessNetwork.id);
     if (fs.existsSync(filePath)) {
         businessNetworkDefinition = await BusinessNetworkDefinition.fromDirectory(filePath);
     } else {

--- a/src/fabric/create-channel.js
+++ b/src/fabric/create-channel.js
@@ -32,7 +32,6 @@ const utils = require('fabric-client/lib/utils.js');
 const Client = require('fabric-client');
 //const util = require('util');
 const fs = require('fs');
-const path = require('path');
 //const grpc = require('grpc');
 
 const testUtil = require('./util.js');
@@ -54,7 +53,7 @@ function run(config_path) {
         const t = global.tapeObj;
         let ORGS = fabric.network;
         let caRootsPath = ORGS.orderer.tls_cacerts;
-        let data = fs.readFileSync(path.join(__dirname, '../..', caRootsPath));
+        let data = fs.readFileSync(commUtils.resolvePath(caRootsPath));
         let caroots = Buffer.from(data).toString();
         utils.setConfigSetting('key-value-store', 'fabric-client/lib/impl/FileKeyValueStore.js');
 
@@ -90,7 +89,7 @@ function run(config_path) {
                     })
                     .then((admin) =>{
                         // use the config update created by the configtx tool
-                        let envelope_bytes = fs.readFileSync(path.join(__dirname, '../..', channel.config));
+                        let envelope_bytes = fs.readFileSync(commUtils.resolvePath(channel.config));
                         config = client.extractChannelConfig(envelope_bytes);
 
                         // TODO: read from channel config instead of binary tx file

--- a/src/fabric/e2eUtils.js
+++ b/src/fabric/e2eUtils.js
@@ -31,9 +31,6 @@ const Client = require('fabric-client');
 const testUtil = require('./util.js');
 
 let ORGS;
-const rootPath = '../..';
-
-//const grpc = require('grpc');
 
 let tx_id = null;
 let the_user = null;
@@ -67,7 +64,7 @@ function installChaincode(org, chaincode) {
     client.setCryptoSuite(cryptoSuite);
 
     const caRootsPath = ORGS.orderer.tls_cacerts;
-    let data = fs.readFileSync(path.join(__dirname, rootPath, caRootsPath));
+    let data = fs.readFileSync(commUtils.resolvePath(caRootsPath));
     let caroots = Buffer.from(data).toString();
 
     channel.addOrderer(
@@ -84,7 +81,7 @@ function installChaincode(org, chaincode) {
     for (let key in ORGS[org]) {
         if (ORGS[org].hasOwnProperty(key)) {
             if (key.indexOf('peer') === 0) {
-                let data = fs.readFileSync(path.join(__dirname, rootPath, ORGS[org][key].tls_cacerts));
+                let data = fs.readFileSync(commUtils.resolvePath(ORGS[org][key].tls_cacerts));
                 let peer = client.newPeer(
                     ORGS[org][key].requests,
                     {
@@ -233,7 +230,7 @@ function instantiateChaincode(chaincode, endorsement_policy, upgrade){
     client.setCryptoSuite(cryptoSuite);
 
     const caRootsPath = ORGS.orderer.tls_cacerts;
-    let data = fs.readFileSync(path.join(__dirname, rootPath, caRootsPath));
+    let data = fs.readFileSync(commUtils.resolvePath(caRootsPath));
     let caroots = Buffer.from(data).toString();
 
     channel.addOrderer(
@@ -261,10 +258,10 @@ function instantiateChaincode(chaincode, endorsement_policy, upgrade){
 
         let eventPeer = null;
         for(let org in ORGS) {
-            if(org.indexOf('org') === 0) {
+            if(ORGS.hasOwnProperty(org) && org.indexOf('org') === 0) {
                 for (let key in ORGS[org]) {
-                    if(key.indexOf('peer') === 0) {
-                        let data = fs.readFileSync(path.join(__dirname, rootPath, ORGS[org][key].tls_cacerts));
+                    if(ORGS[org].hasOwnProperty(key) && key.indexOf('peer') === 0) {
+                        let data = fs.readFileSync(commUtils.resolvePath(ORGS[org][key].tls_cacerts));
                         let peer = client.newPeer(
                             ORGS[org][key].requests,
                             {
@@ -282,7 +279,7 @@ function instantiateChaincode(chaincode, endorsement_policy, upgrade){
         }
 
         // an event listener can only register with a peer in its own org
-        let data = fs.readFileSync(path.join(__dirname, rootPath, ORGS[userOrg][eventPeer].tls_cacerts));
+        let data = fs.readFileSync(commUtils.resolvePath(ORGS[userOrg][eventPeer].tls_cacerts));
         let eh = client.newEventHub();
         eh.setPeerAddr(
             ORGS[userOrg][eventPeer].events,
@@ -440,7 +437,7 @@ function getcontext(channelConfig) {
     client.setCryptoSuite(cryptoSuite);
 
     const caRootsPath = ORGS.orderer.tls_cacerts;
-    let data = fs.readFileSync(path.join(__dirname, rootPath, caRootsPath));
+    let data = fs.readFileSync(commUtils.resolvePath(caRootsPath));
     let caroots = Buffer.from(data).toString();
 
     channel.addOrderer(
@@ -474,7 +471,7 @@ function getcontext(channelConfig) {
                 }
 
                 let peerInfo = peers[Math.floor(Math.random() * peers.length)];
-                let data = fs.readFileSync(path.join(__dirname, rootPath, peerInfo.tls_cacerts));
+                let data = fs.readFileSync(commUtils.resolvePath(peerInfo.tls_cacerts));
                 let peer = client.newPeer(
                     peerInfo.requests,
                     {

--- a/src/fabric/join-channel.js
+++ b/src/fabric/join-channel.js
@@ -25,17 +25,16 @@
 //const test = _test(tape);
 
 //const util = require('util');
-const path = require('path');
 const fs = require('fs');
 
 const Client = require('fabric-client');
 const EventHub = require('fabric-client/lib/EventHub.js');
 
 const testUtil = require('./util.js');
+const commUtils = require('../comm/util');
 
 //let the_user = null;
 let tx_id = null;
-const rootpath = '../..';
 let ORGS;
 const allEventhubs = [];
 
@@ -67,7 +66,7 @@ function joinChannel(org, channelName) {
     const targets = [], eventhubs = [];
 
     const caRootsPath = ORGS.orderer.tls_cacerts;
-    let data = fs.readFileSync(path.join(__dirname, rootpath, caRootsPath));
+    let data = fs.readFileSync(commUtils.resolvePath(caRootsPath));
     let caroots = Buffer.from(data).toString();
     let genesis_block = null;
 
@@ -106,7 +105,7 @@ function joinChannel(org, channelName) {
         for (let key in ORGS[org]) {
             if (ORGS[org].hasOwnProperty(key)) {
                 if(key.indexOf('peer') === 0) {
-                    data = fs.readFileSync(path.join(__dirname, rootpath, ORGS[org][key].tls_cacerts));
+                    data = fs.readFileSync(commUtils.resolvePath(ORGS[org][key].tls_cacerts));
                     targets.push(
                         client.newPeer(
                             ORGS[org][key].requests,

--- a/src/iroha/iroha.js
+++ b/src/iroha/iroha.js
@@ -10,7 +10,6 @@
 'use strict';
 
 const fs = require('fs');
-const path = require('path');
 const grpc = require('grpc');
 const {
     ModelCrypto,
@@ -192,8 +191,8 @@ class Iroha extends BlockchainInterface {
             let admin        = config.iroha.admin;
             let domain       = admin.domain;
             let adminAccount = admin.account + '@' + admin.domain;
-            let privPath     = path.join(__dirname, '../..', admin['key-priv']);
-            let pubPath      = path.join(__dirname, '../..', admin['key-pub']);
+            let privPath     = util.resolvePath(admin['key-priv']);
+            let pubPath      = util.resolvePath(admin['key-pub']);
             let adminPriv    = fs.readFileSync(privPath).toString();
             let adminPub     = fs.readFileSync(pubPath).toString();
             let adminKeys    = crypto.convertFromExisting(adminPub, adminPriv);
@@ -331,7 +330,7 @@ class Iroha extends BlockchainInterface {
                 let fakeContracts = {};
                 for(let i = 0 ; i < fc.length ; i++) {
                     let contract = fc[i];
-                    let facPath  = path.join(__dirname, '../..', contract.factory);
+                    let facPath  = util.resolvePath(contract.factory);
                     let factory  = require(facPath);
                     for(let j = 0 ; j < contract.id.length ; j++) {
                         let id = contract.id[j];


### PR DESCRIPTION
Related to Issue #95, this PR unifies the path resolution of different modules, by using [the following](https://github.com/hyperledger/caliper/blob/6cf2891736c60dfd5c0a3221f36b1841dc79318d/src/comm/util.js#L51) utility function.

Now every path in the config files can be set either as a relative path to the Caliper root directory or as an absolute path.

@nklincoln I successfully run a Composer sample benchmark, but could you review the Composer-related part just in case?
@haojun Can you tag someone from the Iroha contributors to review the Iroha-related part? Although those were (I hope) straightforward modifications.

Signed-off-by: Attila Klenik <a.klenik@gmail.com>