### PR TITLE
Added lightweight dev network

### DIFF
--- a/benchmark/composer/config-composer-dev.json
+++ b/benchmark/composer/config-composer-dev.json
@@ -1,0 +1,48 @@
+{
+  "blockchain": {
+    "type": "composer",
+    "config": "network/fabric/dev/composer-tls.json"
+  },
+  "command" : {
+    "start": "docker-compose -f network/fabric/dev/docker-compose-tls.yaml up -d",
+    "end": "docker-compose -f network/fabric/dev/docker-compose-tls.yaml down;docker rm $(docker ps -aq);docker rmi $(docker images dev-* -q)"
+  },
+  "test": {
+    "name": "Composer Performance test",
+    "description" : "This is an example Composer perf test",
+    "clients": {
+      "type": "local",
+      "number": 1
+    },
+    "rounds": [{
+                "label" : "basic-sample-network",
+                "txNumber" : [25],
+                "trim" : 0,
+                "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 5}}],
+                "arguments": {"testAssets": 25},
+                "callback" : "benchmark/composer/composer-samples/basic-sample-network.js"
+            },
+            {
+                "label" : "basic-sample-network",
+                "txNumber" : [50],
+                "trim" : 0,
+                "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 10}}],
+                "arguments": {"testAssets": 50},
+                "callback" : "benchmark/composer/composer-samples/basic-sample-network.js"
+            }]
+  },
+  "monitor": {
+    "type": ["docker", "process"],
+    "docker":{
+      "name": ["all"]
+    },
+    "process": [
+      {
+        "command" : "node",
+        "arguments" : "bench-client.js",
+        "multiOutput" : "avg"
+      }
+    ],
+    "interval": 1
+  }
+}

--- a/benchmark/simple/config-dev.json
+++ b/benchmark/simple/config-dev.json
@@ -1,0 +1,45 @@
+{
+  "blockchain": {
+    "type": "fabric",
+    "config": "benchmark/simple/fabric-dev.json"
+  },
+  "command" : {
+    "start": "docker-compose -f network/fabric/dev/docker-compose-tls.yaml up -d",
+    "end" : "docker-compose -f network/fabric/dev/docker-compose-tls.yaml down;docker rm $(docker ps -aq);docker rmi $(docker images dev* -q)"
+  },
+  "test": {
+    "name": "simple",
+    "description" : "This is an example benchmark for caliper, to test the backend DLT's performance with simple account opening & querying transactions",
+    "clients": {
+      "type": "local",
+      "number": 1
+    },
+    "rounds": [{
+        "label" : "open",
+        "txNumber" : [250],
+        "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 25}}],
+        "arguments": { "money": 10000 },
+        "callback" : "benchmark/simple/open.js"
+      },
+      {
+        "label" : "query",
+        "txNumber" : [500],
+        "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 50}}],
+        "callback" : "benchmark/simple/query.js"
+      }]
+  },
+  "monitor": {
+    "type": ["docker", "process"],
+    "docker":{
+      "name": ["all"]
+    },
+    "process": [
+      {
+        "command" : "node",
+        "arguments" : "local-client.js",
+        "multiOutput" : "avg"
+      }
+    ],
+    "interval": 1
+  }
+}

--- a/benchmark/simple/fabric-dev.json
+++ b/benchmark/simple/fabric-dev.json
@@ -1,0 +1,73 @@
+{
+  "fabric": {
+    "cryptodir": "network/fabric/config/crypto-config",
+    "network": {
+      "orderer": {
+        "url": "grpcs://localhost:7050",
+        "mspid": "OrdererMSP",
+        "domain": "example.com",
+        "user": {
+          "key": "network/fabric/config/crypto-config/ordererOrganizations/example.com/users/Admin@example.com/msp/keystore/key.pem",
+          "cert": "network/fabric/config/crypto-config/ordererOrganizations/example.com/users/Admin@example.com/msp/signcerts/Admin@example.com-cert.pem"
+        },
+        "server-hostname": "orderer.example.com",
+        "tls_cacerts": "network/fabric/config/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt"
+      },
+      "org1": {
+        "name": "peerOrg1",
+        "mspid": "Org1MSP",
+        "domain": "org1.example.com",
+        "user": {
+          "key": "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
+          "cert": "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem"
+        },
+        "ca": {
+          "url": "https://localhost:7054",
+          "name": "ca-org1"
+        },
+        "peer1": {
+          "requests": "grpcs://localhost:7051",
+          "events": "grpcs://localhost:7053",
+          "server-hostname": "peer0.org1.example.com",
+          "tls_cacerts": "network/fabric/config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt"
+        }
+      }
+    },
+    "channel": [
+      {
+        "name": "mychannel",
+        "config": "network/fabric/config/mychannel.tx",
+        "organizations": ["org1"],
+        "deployed": false
+      }
+    ],
+    "chaincodes": [{"id": "simple", "path": "contract/fabric/simple/go", "language":"golang", "version": "v0", "channel": "mychannel"}],
+    "endorsement-policy": {
+      "identities": [
+        {
+          "role": {
+            "name": "member",
+            "mspId": "Org1MSP"
+          }
+        },
+        {
+          "role": {
+            "name": "admin",
+            "mspId": "Org1MSP"
+          }
+        }
+      ],
+      "policy": { "1-of": [{"signed-by": 0}]}
+    },
+    "context": {
+      "open": "mychannel",
+      "query": "mychannel"
+    }
+  },
+  "info" : {
+    "Version": "1.1.0",
+    "Size": "1 Peer",
+    "Orderer": "Solo",
+    "Distribution": "Single Host"
+  }
+}

--- a/network/fabric/dev/README.md
+++ b/network/fabric/dev/README.md
@@ -1,0 +1,3 @@
+# Development network
+
+This network only contains one organization with one peer and uses GoLevelDB as state storage. This is supposed to be a lightweight network for quickly testing new features even on weaker machine configurations.

--- a/network/fabric/dev/composer-tls.json
+++ b/network/fabric/dev/composer-tls.json
@@ -1,0 +1,67 @@
+{  
+  "composer": {
+    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "contract/composer", "orgs": ["Org1"], "loglevel": "INFO"}],
+    "cryptodir": "network/fabric/config/crypto-config",
+    "network": {
+      "x-type" : "hlfv1",
+      "timeout": 3000,
+      "version": "1.0.0",
+      "tls": true,
+      "orderers": {
+        "orderer.example.com": {
+          "url": "grpcs://localhost:7050",
+          "mspid": "OrdererMSP",
+          "mspconfig": "/etc/hyperledger/msp/orderer/tls/ca.crt",
+          "cert": "/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt",
+          "hostname": "orderer.example.com",
+          "hosturl": "orderer.example.com:7050"
+        }
+      },
+      "certificateAuthorities": {
+        "ca.org1.example.com": {
+          "url": "https://localhost:7054",
+          "name": "ca.org1.example.com"
+        }
+      },
+      "organizations": [
+        {
+          "name": "Org1",
+          "mspid": "Org1MSP",
+          "mspconfig": "/etc/hyperledger/msp/users/Admin@org1.example.com/msp",
+          "adminCert": "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
+          "adminKey" : "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
+          "certificateAuthorities": [
+            "ca.org1.example.com"
+          ],
+          "peers": [
+            "peer0.org1.example.com"
+          ]
+        }
+      ],
+      "peers": {
+        "peer0.org1.example.com": {
+          "url": "grpcs://localhost:7051",
+          "eventUrl": "grpcs://localhost:7053",
+          "hostname": "peer0.org1.example.com",
+          "cert" : "/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt",
+          "channels":[
+            "mychannel"
+          ]
+        }
+      },
+      "channels": {
+        "mychannel": {
+          "config": "/etc/hyperledger/configtx/mychannel.tx",          
+          "mspconfig": "/etc/hyperledger/msp/users/Admin@org1.example.com/msp",
+          "cafile": "/etc/hyperledger/msp/orderer/tls/ca.crt",
+          "orderers": [
+            "orderer.example.com"
+          ],
+          "peers": [
+            "peer0.org1.example.com"
+          ]
+        }
+      }
+    }            
+  }
+}

--- a/network/fabric/dev/composer.json
+++ b/network/fabric/dev/composer.json
@@ -1,0 +1,64 @@
+{  
+  "composer": {
+    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "contract/composer", "orgs": ["Org1"], "loglevel": "INFO"}],
+    "cryptodir": "network/fabric/config/crypto-config",
+    "network": {
+      "x-type" : "hlfv1",
+      "timeout": 3000,
+      "version": "1.0.0",
+      "tls": false,
+      "orderers": {
+        "orderer.example.com": {
+          "url": "grpc://localhost:7050",
+          "mspid": "OrdererMSP",
+          "mspconfig": "/etc/hyperledger/msp/orderer/tls/ca.crt",
+          "hostname": "orderer.example.com",
+          "hosturl": "orderer.example.com:7050"
+        }
+      },
+      "certificateAuthorities": {
+        "ca.org1.example.com": {
+          "url": "http://localhost:7054",
+          "name": "ca.org1.example.com"
+        }
+      },
+      "organizations": [
+        {
+          "name": "Org1",
+          "mspid": "Org1MSP",
+          "mspconfig": "/etc/hyperledger/msp/users/Admin@org1.example.com/msp",
+          "adminCert": "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem",
+          "adminKey" : "/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem",
+          "certificateAuthorities": [
+            "ca.org1.example.com"
+          ],
+          "peers": [
+            "peer0.org1.example.com"
+          ]
+        }
+      ],
+      "peers": {
+        "peer0.org1.example.com": {
+          "url": "grpc://localhost:7051",
+          "eventUrl": "grpc://localhost:7053",
+          "hostname": "peer0.org1.example.com",          
+          "channels":[
+            "mychannel"
+          ]
+        }
+      },
+      "channels": {
+        "mychannel": {
+          "config": "/etc/hyperledger/configtx/mychannel.tx",          
+          "mspconfig": "/etc/hyperledger/msp/users/Admin@org1.example.com/msp",
+          "orderers": [
+            "orderer.example.com"
+          ],
+          "peers": [
+            "peer0.org1.example.com"
+          ]
+        }
+      }
+    }            
+  }
+}

--- a/network/fabric/dev/docker-compose-tls.yaml
+++ b/network/fabric/dev/docker-compose-tls.yaml
@@ -1,0 +1,77 @@
+version: '2'
+
+services:
+  ca.org1.example.com:
+    image: hyperledger/fabric-ca:x86_64-1.1.0
+    environment:
+      - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
+      - FABRIC_CA_SERVER_CA_NAME=ca.org1.example.com
+      - FABRIC_CA_SERVER_CA_CERTFILE=/etc/hyperledger/fabric-ca-server-config/ca.org1.example.com-cert.pem
+      - FABRIC_CA_SERVER_CA_KEYFILE=/etc/hyperledger/fabric-ca-server-config/key.pem
+      - FABRIC_CA_SERVER_TLS_ENABLED=true
+      - FABRIC_CA_SERVER_TLS_CERTFILE=/etc/hyperledger/fabric-ca-server-config/ca.org1.example.com-cert.pem
+      - FABRIC_CA_SERVER_TLS_KEYFILE=/etc/hyperledger/fabric-ca-server-config/key.pem
+    ports:
+      - "7054:7054"
+    command: sh -c 'fabric-ca-server start -b admin:adminpw -d --ca.certfile /etc/hyperledger/fabric-ca-server-config/ca.org1.example.com-cert.pem --ca.keyfile /etc/hyperledger/fabric-ca-server-config/key.pem'
+    volumes:
+      - ../config/crypto-config/peerOrganizations/org1.example.com/ca/:/etc/hyperledger/fabric-ca-server-config
+      - ../config/crypto-config/peerOrganizations/org1.example.com/tlsca/:/etc/hyperledger/fabric-ca-server-tls
+    container_name: ca.org1.example.com
+
+  orderer.example.com:
+    container_name: orderer.example.com
+    image: hyperledger/fabric-orderer:x86_64-1.1.0
+    environment:
+      - ORDERER_GENERAL_LOGLEVEL=debug
+      - ORDERER_GENERAL_LISTENADDRESS=0.0.0.0
+      - ORDERER_GENERAL_GENESISMETHOD=file
+      - ORDERER_GENERAL_GENESISFILE=/etc/hyperledger/configtx/orgs.genesis.block
+      - ORDERER_GENERAL_LOCALMSPID=OrdererMSP
+      - ORDERER_GENERAL_LOCALMSPDIR=/etc/hyperledger/msp/orderer/msp
+      - ORDERER_GENERAL_TLS_ENABLED=true
+      - ORDERER_GENERAL_TLS_PRIVATEKEY=/etc/hyperledger/msp/orderer/tls/server.key
+      - ORDERER_GENERAL_TLS_CERTIFICATE=/etc/hyperledger/msp/orderer/tls/server.crt
+      - ORDERER_GENERAL_TLS_ROOTCAS=[/etc/hyperledger/msp/orderer/tls/ca.crt, /etc/hyperledger/msp/peerOrg1/tls/ca.crt]
+    working_dir: /opt/gopath/src/github.com/hyperledger/fabric
+    command: orderer
+    ports:
+      - 7050:7050
+    volumes:
+        - ../config:/etc/hyperledger/configtx
+        - ../config/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/:/etc/hyperledger/msp/orderer
+        - ../config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/:/etc/hyperledger/msp/peerOrg1
+
+  peer0.org1.example.com:
+    container_name: peer0.org1.example.com
+    image: hyperledger/fabric-peer:x86_64-1.1.0
+    environment:
+      - CORE_LOGGING_PEER=debug
+      - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
+      - CORE_PEER_ID=peer0.org1.example.com
+      - CORE_PEER_ENDORSER_ENABLED=true
+      - CORE_PEER_LOCALMSPID=Org1MSP
+      - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/peer/msp/
+      - CORE_PEER_ADDRESS=peer0.org1.example.com:7051
+      - CORE_PEER_GOSSIP_USELEADERELECTION=true
+      - CORE_PEER_GOSSIP_ORGLEADER=false
+      - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer0.org1.example.com:7051
+      - CORE_PEER_TLS_ENABLED=true
+      - CORE_PEER_TLS_KEY_FILE=/etc/hyperledger/msp/peer/tls/server.key
+      - CORE_PEER_TLS_CERT_FILE=/etc/hyperledger/msp/peer/tls/server.crt
+      - CORE_PEER_TLS_ROOTCERT_FILE=/etc/hyperledger/msp/peer/tls/ca.crt
+      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=dev_default
+    working_dir: /opt/gopath/src/github.com/hyperledger/fabric
+    command: peer node start
+    ports:
+      - 7051:7051
+      - 7053:7053
+    volumes:
+        - /var/run/:/host/var/run/
+        - ../config/mychannel.tx:/etc/hyperledger/configtx/mychannel.tx
+        - ../config/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/:/etc/hyperledger/msp/orderer
+        - ../config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/:/etc/hyperledger/msp/peer
+        - ../config/crypto-config/peerOrganizations/org1.example.com/users/:/etc/hyperledger/msp/users
+    depends_on:
+      - orderer.example.com

--- a/network/fabric/dev/docker-compose.yaml
+++ b/network/fabric/dev/docker-compose.yaml
@@ -1,0 +1,61 @@
+version: '2'
+
+services:
+  ca.org1.example.com:
+    image: hyperledger/fabric-ca:x86_64-1.1.0
+    environment:
+      - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
+      - FABRIC_CA_SERVER_CA_NAME=ca.org1.example.com
+    ports:
+      - "7054:7054"
+    command: sh -c 'fabric-ca-server start --ca.certfile /etc/hyperledger/fabric-ca-server-config/ca.org1.example.com-cert.pem --ca.keyfile /etc/hyperledger/fabric-ca-server-config/key.pem -b admin:adminpw -d'
+    volumes:
+      - ../config/crypto-config/peerOrganizations/org1.example.com/ca/:/etc/hyperledger/fabric-ca-server-config
+    container_name: ca.org1.example.com
+
+  orderer.example.com:
+    container_name: orderer.example.com
+    image: hyperledger/fabric-orderer:x86_64-1.1.0
+    environment:
+      - ORDERER_GENERAL_LOGLEVEL=debug
+      - ORDERER_GENERAL_LISTENADDRESS=0.0.0.0
+      - ORDERER_GENERAL_GENESISMETHOD=file
+      - ORDERER_GENERAL_GENESISFILE=/etc/hyperledger/configtx/orgs.genesis.block
+      - ORDERER_GENERAL_LOCALMSPID=OrdererMSP
+      - ORDERER_GENERAL_LOCALMSPDIR=/etc/hyperledger/msp/orderer/msp
+    working_dir: /opt/gopath/src/github.com/hyperledger/fabric
+    command: orderer
+    ports:
+      - 7050:7050
+    volumes:
+        - ../config/:/etc/hyperledger/configtx
+        - ../config/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/msp:/etc/hyperledger/msp/orderer/msp
+
+  peer0.org1.example.com:
+    container_name: peer0.org1.example.com
+    image: hyperledger/fabric-peer:x86_64-1.1.0
+    environment:
+      - CORE_LOGGING_PEER=debug
+      - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
+      - CORE_PEER_ID=peer0.org1.example.com
+      - CORE_PEER_ENDORSER_ENABLED=true
+      - CORE_PEER_ADDRESS=peer0.org1.example.com:7051
+      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=dev_default
+      - CORE_PEER_LOCALMSPID=Org1MSP
+      - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/peer/msp
+      - CORE_PEER_GOSSIP_USELEADERELECTION=true
+      - CORE_PEER_GOSSIP_ORGLEADER=false
+      - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer0.org1.example.com:7051
+    working_dir: /opt/gopath/src/github.com/hyperledger/fabric
+    command: peer node start
+    ports:
+      - 7051:7051
+      - 7053:7053
+    volumes:
+        - /var/run/:/host/var/run/
+        - ../config/mychannel.tx:/etc/hyperledger/configtx/mychannel.tx
+        - ../config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp:/etc/hyperledger/peer/msp
+        - ../config/crypto-config/peerOrganizations/org1.example.com/users:/etc/hyperledger/msp/users
+    depends_on:
+      - orderer.example.com


### PR DESCRIPTION
Experimenting with benchmarks on a locally run multi-node network requires considerable resources. This PR adds a lightweight development network with an orderer node, a CA and a peer (and not using CouchDB). Corresponding config files are also added for the simple benchmark.

Signed-off-by: Attila Klenik <a.klenik@gmail.com>