### PR TITLE
Reject an error instead of undefined

### DIFF
--- a/src/fabric/e2eUtils.js
+++ b/src/fabric/e2eUtils.js
@@ -650,7 +650,7 @@ async function invokebycontext(context, id, version, args, timeout){
         const eventPromises = [];
         eventHubs.forEach((eh) => {
             eventPromises.push(new Promise((resolve, reject) => {
-                let handle = setTimeout(reject, newTimeout);
+                let handle = setTimeout(() => reject(new Error('Timeout')), newTimeout);
 
                 eh.registerTxEvent(txId,
                     (tx, code) => {


### PR DESCRIPTION
Reject an error instead of undefined, otherwise it will log like this:

```
Failed to complete transaction [8c3b9...]:undefined
```

This got me confused.

Signed-off-by: modood modood@qq.com