### PR TITLE
Replace EventHub by the much improved Channel Event Service

### DIFF
--- a/src/fabric/join-channel.js
+++ b/src/fabric/join-channel.js
@@ -28,7 +28,6 @@
 const fs = require('fs');
 
 const Client = require('fabric-client');
-const EventHub = require('fabric-client/lib/EventHub.js');
 
 const testUtil = require('./util.js');
 const commUtils = require('../comm/util');
@@ -116,14 +115,14 @@ function joinChannel(org, channelName) {
                         )
                     );
 
-                    let eh = new EventHub(client);  //client.newEventHub();
-                    eh.setPeerAddr(
+                    const peer = client.newPeer(
                         ORGS[org][key].events,
                         {
                             pem: Buffer.from(data).toString(),
                             'ssl-target-name-override': ORGS[org][key]['server-hostname']
                         }
                     );
+                    const eh = channel.newChannelEventHub(peer);
                     eh.connect();
                     eventhubs.push(eh);
                     allEventhubs.push(eh);


### PR DESCRIPTION
Since 'old' event hub is removed in fabric v1.3.0, The EventHub functionality was replaced by the much improved Channel Event Service in fabric v1.1.0. (Refer to [FAB-11122](https://jira.hyperledger.org/browse/FAB-11122))

So we must switch to the channel event service before upgrading peers or sdk.

Signed-off-by: modood <modood@qq.com>