### PR TITLE
Fixed composite rate controller logic and docs.

### DIFF
--- a/docs/RateControllers.md
+++ b/docs/RateControllers.md
@@ -102,14 +102,15 @@ The composite rate controller can be specified by setting the rate controller `t
     
 * `logChange`: a `boolean` value indicating whether the switches between the specified rate controllers should be logged or not.
 
-**Important!** The existence of the composite rate controller is completely transparent to the specified "sub-controllers." This is achieved by essentially placing the controllers in a "virtualized" round, i.e., "lying" to them about: 
+**Important!** The existence of the composite rate controller is almost transparent to the specified "sub-controllers." This is achieved by essentially placing the controllers in a "virtualized" round, i.e., "lying" to them about: 
 * the duration of the round (for duration-based rounds),
 * the total number of transactions to submit (for transaction number-based rounds),
-* the starting time of the round,
-* the index of the next transaction to submit, and
-* the set of previously executed transactions.
+* the starting time of the round, and
+* the index of the next transaction to submit.
 
-This "virtualization" does not affect the memoryless controllers, i.e., the controllers whose control logic does not depend on global round properties or past transaction results. However, other controllers might exhibit some strange (but hopefully transient) behavior due to this "virtualized" round approach. The logic of the [PID controller](#pid-rate) for example depends on the transaction backlog, but the (possibly pending) transactions submitted in the previous phase (with a different controller) are not visible to the controller.
+The results of recently finished transactions are propagated to the sub-controllers as-is, so for the first few call of a newly activated sub-controller it can receive recent results that don't belong to its virtualized round. 
+
+This virtualization does not affect the memoryless controllers, i.e., the controllers whose control logic does not depend on global round properties or past transaction results. However, other controllers might exhibit some strange (but hopefully transient) behavior due to this "virtualized" round approach. For example, the logic of the [PID controller](#pid-rate) for example depends on the transaction backlog.
 
 ## Linear Rate
 

--- a/src/comm/rate-control/linearRate.js
+++ b/src/comm/rate-control/linearRate.js
@@ -74,10 +74,10 @@ class LinearRateController extends RateInterface{
      * Perform the rate control by sleeping through the round.
      * @param {number} start The epoch time at the start of the round (ms precision).
      * @param {number} idx Sequence number of the current transaction.
-     * @param {object[]} currentResults The list of results of finished transactions.
+     * @param {object[]} recentResults The list of results of recent transactions.
      * @return {Promise} A promise that will resolve after the necessary time to keep the defined Tx rate.
      */
-    async applyRateControl(start, idx, currentResults) {
+    async applyRateControl(start, idx, recentResults) {
         let currentSleepTime = this._interpolate(start, idx);
         return currentSleepTime > 5 ? util.sleep(currentSleepTime) : Promise.resolve();
     }

--- a/src/comm/rate-control/noRate.js
+++ b/src/comm/rate-control/noRate.js
@@ -68,10 +68,10 @@ class NoRateController extends RateInterface{
      * Perform the rate control by sleeping through the round.
      * @param {number} start The epoch time at the start of the round (ms precision).
      * @param {number} idx Sequence number of the current transaction.
-     * @param {object[]} currentResults The list of results of finished transactions.
+     * @param {object[]} recentResults The list of results of recent transactions.
      * @return {Promise} A promise that will resolve after the necessary time to keep the defined Tx rate.
      */
-    async applyRateControl(start, idx, currentResults) {
+    async applyRateControl(start, idx, recentResults) {
         return Util.sleep(this.sleepTime);
     }
 }

--- a/src/comm/rate-control/recordRate.js
+++ b/src/comm/rate-control/recordRate.js
@@ -114,10 +114,10 @@ class RecordRateController extends RateInterface{
      * Perform the rate control by sleeping through the round.
      * @param {number} start The epoch time at the start of the round (ms precision).
      * @param {number} idx Sequence number of the current transaction.
-     * @param {object[]} currentResults The list of results of finished transactions.
+     * @param {object[]} recentResults The list of results of recent transactions.
      */
-    async applyRateControl(start, idx, currentResults) {
-        await this.rateController.applyRateControl(start, idx, currentResults);
+    async applyRateControl(start, idx, recentResults) {
+        await this.rateController.applyRateControl(start, idx, recentResults);
         this.records[idx] = Date.now() - start;
     }
 

--- a/src/comm/rate-control/replayRate.js
+++ b/src/comm/rate-control/replayRate.js
@@ -119,10 +119,10 @@ class ReplayRateController extends RateInterface{
      * Perform the rate control by sleeping through the round.
      * @param {number} start The epoch time at the start of the round (ms precision).
      * @param {number} idx Sequence number of the current transaction.
-     * @param {object[]} currentResults The list of results of finished transactions.
+     * @param {object[]} recentResults The list of results of recent transactions.
      * @return {Promise} The return promise.
      */
-    async applyRateControl(start, idx, currentResults) {
+    async applyRateControl(start, idx, recentResults) {
         if (idx <= this.records.length - 1) {
             let sleepTime = this.records[idx] - (Date.now() - start);
             return sleepTime > 5 ? util.sleep(sleepTime) : Promise.resolve();


### PR DESCRIPTION
Adjusted the composite rate controller to the new environment semantics as detailed by Issue #142.
The virtualization mechanism is not totally transparent now, but without passing more information to the rate controllers, this is the only way. Updated the docs accordingly.

@panyu4 since Nick has already fixed the PID controller, if this PR is accepted, then the issue can be closed.

Signed-off-by: Attila Klenik <a.klenik@gmail.com>