### PR TITLE
fix a bug of monitor.js

### DIFF
--- a/src/comm/monitor.js
+++ b/src/comm/monitor.js
@@ -109,7 +109,7 @@ class Monitor {
         }
 
         let monitorTypes = m.type;
-        if(typeof m === 'undefined') {
+        if(typeof monitorTypes === 'undefined') {
             return Promise.reject(new Error('Failed to find monitor type in config file'));
         }
         if(!Array.isArray(monitorTypes)) {


### PR DESCRIPTION
in line 112 of file `src/comm/monitor.js`, it should check whether  `monitorTypes` is not defined, not the `m` which has been checked in line 107.