### PR TITLE
Add Google Analytics and privacy policy

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,13 @@
 <head>
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-99900088-11"></script>
+  <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-99900088-11');
+  </script>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -25,7 +25,8 @@
           {%- endfor -%} -->
           <a class="page-link" href="{{ site.baseurl }}/docs/1_Getting_Started.html">Get Started</a>
           <a class="page-link" href="{{ site.baseurl }}/docs/1_Getting_Started.html">Docs</a>
-          <a class="page-link" href="https://github.com/hyperledger/caliper">Github</a>
+          <a class="page-link" href="https://github.com/hyperledger/caliper" target="_blank">Github</a>
+          <a class="page-link" href="https://www.linuxfoundation.org/privacy" target="_blank">Privacy Policy</a>
         </div>
       </nav>
     {%- endif -%}


### PR DESCRIPTION
Signed-off-by: Attila Klenik <a.klenik@gmail.com>

The PR adds:
* Google Analytics to every page of the site (through `_includes/head.html`)
* Privacy policy link to TLF privacy policy (through `_includes/header.html`)
* The GitHub and Privacy Policy links open in a new tab.

Modified site: https://aklenik.github.io/caliper/