### PR TITLE
Enable display of disc r/w

### DIFF
--- a/benchmark/composer/composer-micro/query-asset.js
+++ b/benchmark/composer/composer-micro/query-asset.js
@@ -84,6 +84,9 @@ module.exports.init = async function(blockchain, context, args) {
 module.exports.run = function() {
     let invoke_status = new TxStatus(qryRef++);
 
+    if(busNetConnection.engine) {
+        busNetConnection.engine.submitCallback(1);
+    }
     // use the pre-compiled query named 'selectAllCarsByColour' that is within the business
     // network queries file
     return busNetConnection.query('selectAllCarsByColour', { colour: matchColor})

--- a/benchmark/composer/config-composer.json
+++ b/benchmark/composer/config-composer.json
@@ -15,12 +15,11 @@
                 "callback" : "benchmark/composer/composer-samples/basic-sample-network.js"
             },
             {
-                "label" : "basic-sample-network",
-                "txNumber" : [50],
-                "trim" : 0,
-                "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 10}}],
-                "arguments": {"testAssets": 50},
-                "callback" : "benchmark/composer/composer-samples/basic-sample-network.js"
+              "label" : "vehicle-lifecycle-network",
+              "txNumber" : [100],
+              "rateControl" : [{"type": "fixed-rate", "opts": {"tps" :8}}],
+             "arguments": {"testAssets": 10, "testMatches": 5},
+              "callback" : "benchmark/composer/composer-micro/query-asset.js"
             }]
   },
   "monitor": {

--- a/benchmark/composer/main.js
+++ b/benchmark/composer/main.js
@@ -66,7 +66,7 @@ function main() {
     let absCaliperDir = path.join(__dirname, '../..');
     if(typeof networkFile === 'undefined') {
         try{
-            absNetworkFile = path.join(absCaliperDir, 'network/fabric/2org2peer/composer-tls.json');
+            absNetworkFile = path.join(absCaliperDir, 'network/fabric/2org1peer/composer-tls.json');
         }
         catch(err) {
             logger.error('failed to find blockchain.config in ' + absConfigFile);

--- a/network/fabric/2org1peer/composer-tls.json
+++ b/network/fabric/2org1peer/composer-tls.json
@@ -7,7 +7,7 @@
     }
   }, 
   "composer": {
-    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "src/contract/composer", "orgs": ["Org1", "Org2"], "loglevel": "INFO"}],
+    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "src/contract/composer", "orgs": ["Org1", "Org2"], "loglevel": "INFO"}, {"id": "vehicle-lifecycle-network", "version": "0.1.0", "path": "src/contract/composer", "orgs": ["Org1", "Org2"], "loglevel": "INFO"}],
     "cryptodir": "network/fabric/config/crypto-config",
     "network": {
       "x-type" : "hlfv1",

--- a/network/fabric/2org1peer/composer.json
+++ b/network/fabric/2org1peer/composer.json
@@ -7,7 +7,7 @@
     }
   },  
   "composer": {
-    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "src/contract/composer", "orgs": ["Org1", "Org2"], "loglevel": "INFO"}],
+    "chaincodes": [{"id": "basic-sample-network", "version": "0.1.0", "path": "src/contract/composer", "orgs": ["Org1", "Org2"], "loglevel": "INFO"}, {"id": "vehicle-lifecycle-network", "version": "0.1.0", "path": "src/contract/composer", "orgs": ["Org1", "Org2"], "loglevel": "INFO"}],
     "cryptodir": "network/fabric/config/crypto-config",
     "network": {
       "x-type" : "hlfv1",

--- a/package.json
+++ b/package.json
@@ -12,11 +12,10 @@
     "lint": "npx eslint .",
     "list": "node ./scripts/list.js",
     "startclient": "node ./src/comm/client/zoo-client.js",
-    "composer-deps": "npm install --no-save composer-admin@0.20.0 composer-client@0.20.0 composer-common@0.20.0 fabric-ca-client@1.2.0 fabric-client@1.2.0",
+    "composer-deps": "npm install --no-save composer-admin@0.19.18 composer-client@0.19.18 composer-common@0.19.18 fabric-ca-client@1.2.0 fabric-client@1.2.0",
     "fabric-deps": "npm install --no-save grpc@1.10.1 fabric-ca-client@1.1.0 fabric-client@1.1.0",
     "iroha-deps": "npm install --no-save iroha-lib@0.1.7",
     "sawtooth-deps": "npm install --no-save protocol-buffers sawtooth-sdk"
-
   },
   "engines": {
     "node": ">=8.10.0",

--- a/src/comm/bench-flow.js
+++ b/src/comm/bench-flow.js
@@ -15,7 +15,7 @@ const exec = childProcess.exec;
 const path = require('path');
 const table = require('table');
 const Blockchain = require('./blockchain.js');
-const Monitor = require('./monitor.js');
+const Monitor = require('./monitor/monitor.js');
 const Report  = require('./report.js');
 const Client  = require('./client/client.js');
 const Util = require('./util.js');
@@ -77,7 +77,7 @@ function createReport() {
  */
 function printTable(value) {
     let t = table.table(value, {border: table.getBorderCharacters('ramac')});
-    logger.info(t);
+    logger.info('\n' + t);
 }
 
 /**
@@ -101,7 +101,7 @@ function getResultValue(r) {
         row.push(r.label);
         row.push(r.succ);
         row.push(r.fail);
-        (r.create.max === r.create.min) ? row.push((r.succ + r.fail) + ' tps') : row.push(((r.succ + r.fail) / (r.create.max - r.create.min)).toFixed(0) + ' tps');
+        (r.create.max === r.create.min) ? row.push((r.succ + r.fail) + ' tps') : row.push(((r.succ + r.fail) / (r.create.max - r.create.min)).toFixed(1) + ' tps');
         row.push(r.delay.max.toFixed(2) + ' s');
         row.push(r.delay.min.toFixed(2) + ' s');
         row.push((r.delay.sum / r.succ).toFixed(2) + ' s');

--- a/src/comm/monitor/monitor-docker.js
+++ b/src/comm/monitor/monitor-docker.js
@@ -8,7 +8,7 @@
 
 'use strict';
 
-const Util = require('./util.js');
+const Util = require('../util.js');
 const logger = Util.getLogger('monitor-docker.js');
 const MonitorInterface = require('./monitor-interface');
 
@@ -150,7 +150,7 @@ class MonitorDocker extends MonitorInterface {
         /* this.stats : record statistics of each container
             {
                 'time' : [] // time slot
-                'container_id" : {              // refer to https://www.npmjs.com/package/systeminformatioin
+                'container_id" : {              // refer to https://www.npmjs.com/package/systeminformation
                     'mem_usage'   : [],
                     'mem_percent' : [],
                     'cpu_percent' : [],
@@ -336,6 +336,15 @@ class MonitorDocker extends MonitorInterface {
      */
     getNetworkHistory(key) {
         return {'in': this.stats[key].netIO_rx, 'out':this.stats[key].netIO_tx};
+    }
+
+    /**
+     * Get history of disc usage as {read, wrtie}
+     * @param {String} key key of the container
+     * @return {Array} array of disc usage
+     */
+    getDiscHistory(key) {
+        return {'read': this.stats[key].blockIO_rx, 'write':this.stats[key].blockIO_wx};
     }
 
     /**

--- a/src/comm/monitor/monitor-interface.js
+++ b/src/comm/monitor/monitor-interface.js
@@ -72,7 +72,15 @@ class MonitorInterface{
     * @param {String} key Lookup key
     */
     getNetworkHistory(key) {
-        throw new Error('getCpuHistory is not implemented for this monitor');
+        throw new Error('getNetworkHistory is not implemented for this monitor');
+    }
+
+    /**
+     * Get history of disc usage as {read, wrtie}
+     * @param {String} key Lookup key
+     */
+    getDiscHistory(key) {
+        throw new Error('getDiscHistory is not implemented for this monitor');
     }
 }
 module.exports = MonitorInterface;

--- a/src/comm/monitor/monitor-process.js
+++ b/src/comm/monitor/monitor-process.js
@@ -11,7 +11,7 @@
 const ps = require('ps-node');
 const usage = require('pidusage');
 const MonitorInterface = require('./monitor-interface');
-const Util = require('./util.js');
+const Util = require('../util.js');
 const logger = Util.getLogger('monitor-process.js');
 
 /**
@@ -307,6 +307,16 @@ class MonitorProcess extends MonitorInterface {
     getNetworkHistory(key) {
         // not supported now return {'in': this.stats[key].netIO_rx, 'out':this.stats[key].netIO_tx};
         return {'in': [], 'out': []};
+    }
+
+    /**
+     * Get history of disc usage as {read, wrtie}
+     * @param {String} key key of the container
+     * @return {Array} array of disc usage
+     */
+    getDiscHistory(key) {
+        // not supported now return {'in': this.stats[key].netIO_rx, 'out':this.stats[key].netIO_tx};
+        return {'read': [], 'write': []};
     }
 }
 module.exports = MonitorProcess;


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

Targets #140 

This PR enables hooking into the the disc r/w portion of dockerstats output for local tests, and updates the output tables in the console.

It was not needed to update the html file for test output as the template deals with the additional column.

I have noticed in the output that disc read remains at zero, but this corresponds to the actual dockerstats output during the test run
