### PR TITLE
fix the total send transactions according to configuration file

### DIFF
--- a/src/comm/bench-flow.js
+++ b/src/comm/bench-flow.js
@@ -117,7 +117,7 @@ function getResultValue(r) {
             row.push(r.delay.detail[Math.floor(r.delay.detail.length * 0.75)].toFixed(2) + ' s');
         }*/
 
-        (r.final.max === r.final.min) ? row.push(r.succ + ' tps') : row.push(((r.succ / (r.final.max - r.create.min)).toFixed(0)) + ' tps');
+        (r.final.max === r.final.min) ? row.push(r.succ + ' tps') : row.push(((r.succ / (r.final.max - r.create.min)).toFixed(1)) + ' tps');
     }
     catch (err) {
         // temporarily remove percentile row = [r.label, 0, 0, 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A'];

--- a/src/comm/client/client-util.js
+++ b/src/comm/client/client-util.js
@@ -113,6 +113,7 @@ async function startTest(number, message, clientArgs, updates, results) {
     }
 
     let txPerClient;
+    let totalTx = message.numb;
     if (message.numb) {
         // Run specified number of transactions
         txPerClient  = Math.floor(message.numb / number);
@@ -151,6 +152,10 @@ async function startTest(number, message, clientArgs, updates, results) {
         client.updates = updates;
         message.clientargs = clientArgs[idx];
         message.clientIdx = idx;
+
+        if(totalTx % number !== 0 && idx === number-1){
+            message.numb = totalTx - txPerClient*(number - 1);
+        }
 
         // send message to client and update idx
         client.obj.send(message);


### PR DESCRIPTION
Signed-off-by: panyu4 <PY.panyu@huawei.com>

<!--- Provide a general summary of the pull request in the Title above -->


## Issue/User story
<!--- What issue / user story is this for -->
When txNumber set in the configuration file can't be divisible by clients' number, the total transactions' quantity is less than txNumber which the user expected. 

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->
Add the remainder transactions to one client.
