### PR TITLE
Fix the versions of composer and fabric mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "bench": "node ./scripts/main.js",
     "startclient": "node ./src/comm/client/zoo-client.js",
     "burrow-deps": "npm install --no-save @monax/burrow@0.23.0 grpc@1.16.1",
+    "composer-v0.19-deps": "npm install --no-save composer-admin@0.19.18 composer-client@0.19.18 composer-common@0.19.18 fabric-ca-client@1.1.0 fabric-client@1.1.0",
     "composer-deps": "npm install --no-save composer-admin@0.19.18 composer-client@0.19.18 composer-common@0.19.18 fabric-ca-client@1.2.0 fabric-client@1.2.0",
     "fabric-v1.0-deps": "npm install --no-save grpc@1.10.1 fabric-ca-client@1.1.0 fabric-client@1.1.0",
     "fabric-v1.1-deps": "npm install --no-save grpc@1.10.1 fabric-ca-client@1.1.0 fabric-client@1.1.0",


### PR DESCRIPTION
Signed-off-by: feihujiang <jiangfeihu@huawei.com>

When I did a composer test, The error "SyntaxError: Unexpected end of JSON input" occured. The error  is  because I'm using composer 0.19 with a fabric 1.2 environment and they are mismatch. So we need to fix this.


