### PR TITLE
Fix project path for Sawtooth example build

### DIFF
--- a/network/sawtooth/simplenetwork/sawtooth-simple.yaml
+++ b/network/sawtooth/simplenetwork/sawtooth-simple.yaml
@@ -40,7 +40,7 @@ services:
     expose:
       - 4004
     volumes:
-      - '../../../../caliper/:/project/'
+      - '../../../:/project/'
     entrypoint: simple-tp-python -vv -C tcp://validator:4004
     stop_signal: SIGKILL
 


### PR DESCRIPTION
Signed-off-by: Attila Klenik <a.klenik@gmail.com>

The Docker build script assumes that the Caliper repo is cloned into a `caliper` folder. But actually, the last `../caliper/` directory change is unnecessary. 

## Steps to Reproduce
```
git clone https://github.com/hyperledger/caliper.git caliper-fork
# remove the previous image to trigger a rebuild
docker rmi simple-tp-python
npm i
npm run sawtooth-deps
npm run bench -- -c benchmark/simple/config-sawtooth.yaml -n network/sawtooth/simplenetwork/sawtooth.json
```

## Design of the fix
The path reference is simplified in the build script, thus completely avoiding the Caliper directory name.

## Validation of the fix
Repeat the above steps to reproduce.
