### PR TITLE
Using user tmp dir

### DIFF
--- a/src/adapters/fabric/constant.js
+++ b/src/adapters/fabric/constant.js
@@ -18,7 +18,7 @@
 const os = require('os');
 const path = require('path');
 
-const tempdir = path.join(os.tmpdir(), 'hfc');
+const tempdir = path.join(os.homedir(), 'tmp/hfc');
 
 const TxErrorEnum = {
     NoError: 0,


### PR DESCRIPTION
Signed-off-by: feihujiang <jiangfeihu@huawei.com>

When multi-users in one host use caliper to test, the directory '/tmp/hfc/ ' permission is denied for the sake of using the same directory.
