### PR TITLE
Update js-yaml version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
   ],
   "dependencies": {
     "cbor": "^3.0.3",
-    "compare-versions": "^3.4.0",
     "commander": "^2.19.0",
+    "compare-versions": "^3.4.0",
     "dockerode": "^2.5.0",
     "fs-extra": "^4.0.2",
-    "js-yaml": "^3.12.0",
+    "js-yaml": "^3.13.0",
     "jsrsasign": "^8.0.4",
     "moment": "^2.22.2",
     "mustache": "^2.3.0",


### PR DESCRIPTION
With js-yaml@3.12.0, benchmarks for Fabric-v1.4 fails while
instantiating chaincode.

Signed-off-by: Jinwoo Hwang <hnan1118@ajou.ac.kr>