### PR TITLE
Modify report template to list based on test label

### DIFF
--- a/benchmark/simple/config.yaml
+++ b/benchmark/simple/config.yaml
@@ -8,6 +8,7 @@ test:
     number: 5
   rounds:
   - label: open
+    description: Test description for the opening of an account through the deployed chaincode
     txNumber:
     - 1000
     - 1000
@@ -26,6 +27,7 @@ test:
       money: 10000
     callback: benchmark/simple/open.js
   - label: query
+    description: Test description for the query performance of the deployed chaincode
     txNumber:
     - 1000
     - 1000

--- a/src/comm/bench-flow.js
+++ b/src/comm/bench-flow.js
@@ -34,7 +34,6 @@ let absCaliperDir = path.join(__dirname, '..', '..');
  * Generate mustache template for test report
  */
 function createReport() {
-    //let config = require(absConfigFile);
     let config = Util.parseYaml(absConfigFile);
     report  = new Report();
     report.addMetadata('DLT', blockchain.gettype());
@@ -73,6 +72,8 @@ function createReport() {
             report.addSUTInfo(key, sut.info[key]);
         }
     }
+
+    report.addLabelDescriptionMap(config.test.rounds);
 }
 
 /**
@@ -187,12 +188,12 @@ function processResult(results, label){
         logger.info('###test result:###');
         printTable(resultTable);
         let idx = report.addBenchmarkRound(label);
-        report.setRoundPerformance(idx, resultTable);
+        report.setRoundPerformance(label, idx, resultTable);
         let resourceTable = monitor.getDefaultStats();
         if(resourceTable.length > 0) {
             logger.info('### resource stats ###');
             printTable(resourceTable);
-            report.setRoundResource(idx, resourceTable);
+            report.setRoundResource(label, idx, resourceTable);
         }
         return Promise.resolve();
     }

--- a/src/comm/template/report.html
+++ b/src/comm/template/report.html
@@ -103,9 +103,9 @@
         <ul>
             <h3>&nbspBenchmark results</h3>
             <li><a href="#benchmarksummary">Summary</a></li>
-            {{#rounds}}
-            <li><a href="#{{id}}">{{id}}</a></li>
-            {{/rounds}}
+            {{#tests}}
+                <li><a href="#{{label}}">{{label}}</a></li>
+            {{/tests}}
         </ul>
         <ul>
             <h3>&nbspSystem Under Test</h3>
@@ -133,35 +133,39 @@
             </table>
             {{/summary}}
         </div>
-        {{#rounds}}
-        <div id="{{id}}">
-            <h3>{{id}}&nbsp-&nbsp{{description}}</h3>
-            <strong class="tag">performance metrics</strong>
-            {{#performance}}
-            <table>
-                <tr>
-                    {{#head}} <th>{{.}}</th>{{/head}}
-                </tr>
-                <tr>
-                    {{#result}} <td>{{.}}</td>{{/result}}
-                </tr>
-            </table>
-            {{/performance}}
-            <strong class="tag">resource consumption</strong>
-            {{#resource}}
-            <table>
-                <tr>
-                    {{#head}} <th>{{.}}</th>{{/head}}
-                </tr>
-                {{#results}}
-                <tr>
-                    {{#result}} <td>{{.}}</td>{{/result}}
-                </tr>
-                {{/results}}
-            </table>
-            {{/resource}}
+        {{#tests}}
+        <div id="{{label}}">
+            <h3>{{label}}</h3>
+            <p>{{description}}</p>                
+                {{#rounds}}
+                <h3>{{id}}</h3>
+                <strong class="tag">performance metrics</strong>
+                {{#performance}}
+                <table>
+                    <tr>
+                        {{#head}} <th>{{.}}</th>{{/head}}
+                    </tr>
+                    <tr>
+                        {{#result}} <td>{{.}}</td>{{/result}}
+                    </tr>
+                </table>
+                {{/performance}}
+                <strong class="tag">resource consumption</strong>
+                {{#resource}}
+                <table>
+                    <tr>
+                        {{#head}} <th>{{.}}</th>{{/head}}
+                    </tr>
+                    {{#results}}
+                    <tr>
+                        {{#result}} <td>{{.}}</td>{{/result}}
+                    </tr>
+                    {{/results}}
+                </table>
+                {{/resource}}
+                {{/rounds}}
         </div>
-        {{/rounds}}
+        {{/tests}}
         <div>
             <h3>Test Environment</h3>
             <strong class="tag">benchmark config</strong>


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

Suggested fix for #382

Following the generation of some Caliper reports, I noticed that the report structure could be enhanced. I have changed the template and associated report code to follow the config file more closely and make the report more readable by:
- Group test rounds under each test label, with each round starting at zero for each label.
- Link to test labels instead of test rounds from the metadata side navigation (this is a more meaningful link)
- Enable the provision of a description for each test label that is taken from the config file.

I have attached a file that is generated by the code.


[report-20190320T153655.html.zip](https://github.com/hyperledger/caliper/files/2991612/report-20190320T153655.html.zip)
