### PR TITLE
Fix TPS computation for batch mode

### DIFF
--- a/packages/caliper-core/lib/blockchain.js
+++ b/packages/caliper-core/lib/blockchain.js
@@ -129,6 +129,7 @@ class Blockchain {
     getDefaultTxStats(results, detail) {
         let succ = 0, fail = 0, delay = 0;
         let minFinal, maxFinal, minCreate, maxCreate;
+        let maxLastFinal;
         let minDelay = 100000, maxDelay = 0;
         let delays = [];
         let sTPTotal = 0;
@@ -186,13 +187,23 @@ class Blockchain {
             else {
                 fail++;
             }
+
+            let curFinal = stat.GetTimeFinal();
+            if(typeof maxLastFinal === 'undefined') {
+                maxLastFinal = curFinal;
+            }
+            else{
+                if(curFinal > maxLastFinal){
+                    maxLastFinal = curFinal;
+                }
+            }
         }
 
         let stats = {
             'succ' : succ,
             'fail' : fail,
             'create' : {'min' : minCreate/1000, 'max' : maxCreate/1000},    // convert to second
-            'final'  : {'min' : minFinal/1000,  'max' : maxFinal/1000 },
+            'final'  : {'min' : minFinal/1000,  'max' : maxFinal/1000, 'last' : maxLastFinal/1000 },
             'delay'  : {'min' : minDelay,  'max' : maxDelay, 'sum' : delay, 'detail': (detail?delays:[]) },
             'out' : [],
             'sTPTotal': sTPTotal,
@@ -256,6 +267,9 @@ class Blockchain {
                 }
                 if(v.final.max > r.final.max) {
                     r.final.max = v.final.max;
+                }
+                if(v.final.last > r.final.last){
+                    r.final.last = v.final.last;
                 }
                 if(v.delay.min < r.delay.min) {
                     r.delay.min = v.delay.min;

--- a/packages/caliper-core/lib/caliper-flow.js
+++ b/packages/caliper-core/lib/caliper-flow.js
@@ -123,8 +123,9 @@ function getResultValue(r) {
             row.push(r.delay.detail[Math.floor(r.delay.detail.length * 0.75)].toFixed(2) + ' s');
         }*/
 
-        (r.final.max === r.create.min) ? row.push(r.succ + ' tps') : row.push(((r.succ / (r.final.max - r.create.min)).toFixed(1)) + ' tps');
-        logger.debug('r.create.max: '+ r.create.max + ' r.create.min: ' + r.create.min + ' r.final.max: ' + r.final.max + ' r.final.min: '+ r.final.min);
+        (r.final.last === r.create.min) ? row.push(r.succ + ' tps') : row.push((r.succ / (r.final.last - r.create.min)).toFixed(1) + ' tps');
+        logger.debug('r.create.max: '+ r.create.max + ' r.create.min: ' + r.create.min + ' r.final.max: ' + r.final.max + ' r.final.min: '+ r.final.min + ' r.final.last: ' + r.final.last);
+        logger.debug(' throughput for only success time computed: '+  (r.succ / (r.final.max - r.create.min)).toFixed(1));
     }
     catch (err) {
         // temporarily remove percentile row = [r.label, 0, 0, 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A'];

--- a/packages/caliper-core/lib/rate-control/fixedRate.js
+++ b/packages/caliper-core/lib/rate-control/fixedRate.js
@@ -76,7 +76,7 @@ class FixedRate extends RateInterface {
             return;
         }
         let diff = (this.sleepTime * idx - (Date.now() - start));
-        if(idx % 100 === 0) {
+        if(diff<=5 && idx % 100 === 0) {
             await Sleep(5);
             return;
         }


### PR DESCRIPTION
Signed-off-by: panyu2 <PY.panyu@huawei.com>


## Issue/User story
<!--- What issue / user story is this for -->
When the  transactions are not sent evenly eg. sending several transactions with one workload, current TPS may give some strange throughtput since in some situations the time used for transactions is not accurately computed. 


## Existing issues
#226 

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->
1. record the maximum final time of all successful and failed transactions;
2. modify the computation of successful transactions time to the all transactions used time 

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->
1. start Caliper normally with 'open' test module and 'txnPerBatch' set larger than TPS ;
2. open another terminal and stop the running blockchain network.