### PR TITLE
[updated] Fix conflicts between smallbank benchmark and fabric-ccp configuration

### DIFF
--- a/packages/caliper-application/benchmark/smallbank/query.js
+++ b/packages/caliper-application/benchmark/smallbank/query.js
@@ -25,7 +25,7 @@ module.exports.run = function() {
     if (bc.bcType === 'fabric-ccp') {
         let args = {
             chaincodeFunction: 'query',
-            chaincodeArguments: [acc_num],
+            chaincodeArguments: [acc_num.toString()],
         };
         return bc.bcObj.querySmartContract(contx, 'smallbank', '1.0', args, 3);
     } else {

--- a/packages/caliper-application/benchmark/smallbank/smallbankOperations.js
+++ b/packages/caliper-application/benchmark/smallbank/smallbankOperations.js
@@ -171,9 +171,8 @@ module.exports.run = function() {
     if (bc.bcType === 'fabric-ccp') {
         let ccpArgs = [];
         for (let arg of args) {
-            let functionArgs = Object.values(arg);
-            functionArgs.pop(); // remove the transaction_type value from the end
-
+            let tempArgs = Object.values(arg);
+            let functionArgs = [tempArgs[0].toString(), tempArgs[1].toString(), tempArgs[2].toString(), tempArgs[3].toString()];
             ccpArgs.push({
                 chaincodeFunction: arg.transaction_type,
                 chaincodeArguments: functionArgs,


### PR DESCRIPTION
Signed-off-by: quangtdn <nmquang229@yahoo.com.vn>

Please refer to #395  .
In the benchmarking methods smallbankOperations.js and query.js, for fabric-ccp type the test should convert transactions' arguments into Strings before sending the transactions.