### PR TITLE
Fixed setting key renaming

### DIFF
--- a/packages/caliper-core/lib/config/Config.js
+++ b/packages/caliper-core/lib/config/Config.js
@@ -26,7 +26,12 @@ nconf.formats.yaml = require('nconf-yaml');
  * @return {{key: string, value: any}} The setting with the modified key.
  */
 function normalizeSettingKey(kvPair) {
-    kvPair.key = kvPair.key.toLowerCase().replace(/[_]/g, '-');
+    let newKey = kvPair.key.toLowerCase().replace(/[_]/g, '-');
+    // only change the command line argument or environment variable name for Caliper settings
+    if (newKey.startsWith('caliper-')) {
+        kvPair.key = newKey;
+    }
+
     return kvPair;
 }
 


### PR DESCRIPTION
Signed-off-by: Attila Klenik <a.klenik@gmail.com>

### Context
The [config doc states](https://hyperledger.github.io/caliper/docs/Runtime_Configuration.html#command-line-arguments) that command line argument and environment variable names are "normalized" to lower-case letters separated with dashes to be more robust and convenient to set.

### Bug
Currently, this transformation is performed for every setting, which might not be desirable.

### Fix
Only the setting names starting with `caliper-` (after normalization) are actually changed.