### PR TITLE
remove report build and default test from caliper-flow

### DIFF
--- a/packages/caliper-core/lib/caliper-flow.js
+++ b/packages/caliper-core/lib/caliper-flow.js
@@ -12,349 +12,49 @@
  * limitations under the License.
  */
 
-
 'use strict';
 
-// global variables
-const childProcess = require('child_process');
-const exec = childProcess.exec;
-const path = require('path');
-const table = require('table');
 const Blockchain = require('./blockchain');
-const Monitor = require('./monitor/monitor');
-const Report  = require('./report/report');
-const ClientOrchestrator  = require('./client/client-orchestrator');
 const CaliperUtils = require('./utils/caliper-utils');
+const ClientOrchestrator  = require('./client/client-orchestrator');
+const Config = require('./config/config-util');
+const Monitor = require('./monitor/monitor');
+const Report = require('./report/report');
+const Test = require('./test/defaultTest');
+
+const demo = require('./gui/src/demo.js');
+const path = require('path');
+
 const logger = CaliperUtils.getLogger('caliper-flow');
-const config = require('./config/config-util');
-
-let monitor, report, clientOrchestrator;
-let success = 0, failure = 0;
-let resultsbyround = [];    // results table for each test round
-let round = 0;              // test round
-let demo = require('./gui/src/demo.js');
-let absCaliperDir = path.join(__dirname, '..', '..');
 
 /**
- * Generate mustache template for test report
- * @param {String} absConfigFile the config file used by this flow
- * @param {String} absNetworkFile the network config file used by this flow
- * @param {String} blockchainType the blockchain target type
- */
-function createReport(absConfigFile, absNetworkFile, blockchainType) {
-    let config = CaliperUtils.parseYaml(absConfigFile);
-    report  = new Report();
-    report.addMetadata('DLT', blockchainType);
-    try{
-        report.addMetadata('Benchmark', config.test.name);
-    }
-    catch(err) {
-        report.addMetadata('Benchmark', ' ');
-    }
-    try{
-        report.addMetadata('Description', config.test.description);
-    }
-    catch(err) {
-        report.addMetadata('Description', ' ');
-    }
-    try{
-        let r = 0;
-        for(let i = 0 ; i < config.test.rounds.length ; i++) {
-            if(config.test.rounds[i].hasOwnProperty('txNumber')) {
-                r += config.test.rounds[i].txNumber.length;
-            } else if (config.test.rounds[i].hasOwnProperty('txDuration')) {
-                r += config.test.rounds[i].txDuration.length;
-            }
-        }
-        report.addMetadata('Test Rounds', r);
-
-        report.setBenchmarkInfo(JSON.stringify(config.test, null, 2));
-    }
-    catch(err) {
-        report.addMetadata('Test Rounds', ' ');
-    }
-
-    let sut = CaliperUtils.parseYaml(absNetworkFile);
-    if(sut.hasOwnProperty('info')) {
-        for(let key in sut.info) {
-            report.addSUTInfo(key, sut.info[key]);
-        }
-    }
-
-    report.addLabelDescriptionMap(config.test.rounds);
-}
-
-/**
- * print table
- * @param {Array} value rows of the table
- */
-function printTable(value) {
-    let t = table.table(value, {border: table.getBorderCharacters('ramac')});
-    logger.info('\n' + t);
-}
-
-/**
- * get the default result table's title
- * @return {Array} row of the title
- */
-function getResultTitle() {
-    // temporarily remove percentile return ['Name', 'Succ', 'Fail', 'Send Rate', 'Max Latency', 'Min Latency', 'Avg Latency', '75%ile Latency', 'Throughput'];
-    return ['Name', 'Succ', 'Fail', 'Send Rate', 'Max Latency', 'Min Latency', 'Avg Latency', 'Throughput'];
-}
-
-/**
- * get rows of the default result table
- * @param {Array} r array of txStatistics JSON objects
- * @return {Array} rows of the default result table
- */
-function getResultValue(r) {
-
-    let row = [];
-    try {
-        row.push(r.label);
-        row.push(r.succ);
-        row.push(r.fail);
-        (r.create.max === r.create.min) ? row.push((r.succ + r.fail) + ' tps') : row.push(((r.succ + r.fail) / (r.create.max - r.create.min)).toFixed(1) + ' tps');
-        row.push(r.delay.max.toFixed(2) + ' s');
-        row.push(r.delay.min.toFixed(2) + ' s');
-        row.push((r.delay.sum / r.succ).toFixed(2) + ' s');
-        // temporarily remove percentile
-        /*if(r.delay.detail.length === 0) {
-            row.push('N/A');
-        }
-        else{
-            r.delay.detail.sort(function(a, b) {
-                return a-b;
-            });
-            row.push(r.delay.detail[Math.floor(r.delay.detail.length * 0.75)].toFixed(2) + ' s');
-        }*/
-
-        (r.final.last === r.create.min) ? row.push(r.succ + ' tps') : row.push((r.succ / (r.final.last - r.create.min)).toFixed(1) + ' tps');
-        logger.debug('r.create.max: '+ r.create.max + ' r.create.min: ' + r.create.min + ' r.final.max: ' + r.final.max + ' r.final.min: '+ r.final.min + ' r.final.last: ' + r.final.last);
-        logger.debug(' throughput for only success time computed: '+  (r.succ / (r.final.max - r.create.min)).toFixed(1));
-    }
-    catch (err) {
-        // temporarily remove percentile row = [r.label, 0, 0, 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A'];
-        row = [r.label, 0, 0, 'N/A', 'N/A', 'N/A', 'N/A', 'N/A'];
-    }
-
-    return row;
-}
-
-/**
- * print the performance testing results of all test rounds
- */
-function printResultsByRound() {
-    resultsbyround[0].unshift('Test');
-    for(let i = 1 ; i < resultsbyround.length ; i++) {
-        resultsbyround[i].unshift(i.toFixed(0));
-    }
-    logger.info('###all test results:###');
-    printTable(resultsbyround);
-
-    report.setSummaryTable(resultsbyround);
-}
-
-/**
- * merge testing results from various clients and store the merged result in the global result array
- * txStatistics = {
- *     succ   : ,                        // number of committed txns
- *     fail   : ,                        // number of failed txns
- *     create : {min:, max: },            // min/max time when txns were created/submitted
- *     final  : {min:, max: },            // min/max time when txns were committed
- *     delay  : {min:, max: , sum:, detail:[]},     // min/max/sum of txns' end2end delay, as well as all txns' delay
- * }
- * @param {Array} results array of txStatistics
- * @param {String} label label of the test round
- * @return {Promise} promise object
- */
-function processResult(results, label){
-    try{
-        let resultTable = [];
-        resultTable[0] = getResultTitle();
-        let r;
-        if(Blockchain.mergeDefaultTxStats(results) === 0) {
-            r = Blockchain.createNullDefaultTxStats();
-            r.label = label;
-        }
-        else {
-            r = results[0];
-            r.label = label;
-            resultTable[1] = getResultValue(r);
-        }
-
-        let sTP = r.sTPTotal / r.length;
-        let sT = r.sTTotal / r.length;
-        logger.debug('sendTransactionProposal: ' + sTP + 'ms length: ' + r.length);
-        logger.debug('sendTransaction: ' + sT + 'ms');
-        logger.debug('invokeLantency: ' + r.invokeTotal / r.length + 'ms');
-        if(resultsbyround.length === 0) {
-            resultsbyround.push(resultTable[0].slice(0));
-        }
-        if(resultTable.length > 1) {
-            resultsbyround.push(resultTable[1].slice(0));
-        }
-        logger.info('###test result:###');
-        printTable(resultTable);
-        let idx = report.addBenchmarkRound(label);
-        report.setRoundPerformance(label, idx, resultTable);
-        let resourceTable = monitor.getDefaultStats();
-        if(resourceTable.length > 0) {
-            logger.info('### resource stats ###');
-            printTable(resourceTable);
-            report.setRoundResource(label, idx, resourceTable);
-        }
-        return Promise.resolve();
-    }
-    catch(err) {
-        logger.error(err);
-        return Promise.reject(err);
-    }
-}
-
-/**
- * load client(s) to do performance tests
- * @param {JSON} args testing arguments
- * @param {Array} clientArgs arguments for clients
- * @param {Boolean} final =true, the last test round; otherwise, =false
- * @param {String} absNetworkFile the network config file patch
- * @param {Object} clientFactory factory used to spawn test clients
- * @param {String} networkRoot the root location
- * @async
- */
-async function defaultTest(args, clientArgs, final, absNetworkFile, clientFactory, networkRoot) {
-    logger.info(`####### Testing '${args.label}' #######`);
-    let testLabel   = args.label;
-    let testRounds  = args.txDuration ? args.txDuration : args.txNumber;
-    let tests = []; // array of all test rounds
-    let configPath = path.relative(absCaliperDir, absNetworkFile);
-
-    for(let i = 0 ; i < testRounds.length ; i++) {
-        let msg = {
-            type: 'test',
-            label : args.label,
-            rateControl: args.rateControl[i] ? args.rateControl[i] : {type:'fixed-rate', 'opts' : {'tps': 1}},
-            trim: args.trim ? args.trim : 0,
-            args: args.arguments,
-            cb  : args.callback,
-            config: configPath,
-            root: networkRoot
-        };
-        // condition for time based or number based test driving
-        if (args.txNumber) {
-            msg.numb = testRounds[i];
-            // File information for reading or writing transaction request
-            msg.txFile = {roundLength: testRounds.length, roundCurrent: i, txMode: args.txMode};
-            if(args.txMode && args.txMode.type === 'file-write') {
-                logger.info('------ Prepare(file-write) waiting ------');
-                msg.txFile.readWrite = 'write';
-                msg.rateControl = {type: 'fixed-rate', opts: {tps: 400}};
-                try {
-                    await clientOrchestrator.startTest(msg, clientArgs, function(){}, testLabel, clientFactory);
-                    msg.numb = testRounds[i];
-                    msg.txFile.readWrite = 'read';
-                    msg.rateControl = args.rateControl[i] ? args.rateControl[i] : {type:'fixed-rate', 'opts' : {'tps': 1}};
-                    if(i === (testRounds.length - 1)) {
-                        logger.info('Waiting 5 seconds...');
-                        logger.info('------ Prepare(file-write) success------');
-                        await CaliperUtils.sleep(5000);
-                    }
-                } catch (err) {
-                    logger.error('------Prepare(file-write) failed------');
-                    args.txMode.type = 'file-no';
-                }
-
-            }else if(args.txMode && args.txMode.type === 'file-read'){
-                msg.txFile.readWrite = 'read';
-            }else {
-                msg.txFile.readWrite = 'no';
-            }
-        } else if (args.txDuration) {
-            msg.txDuration = testRounds[i];
-        } else {
-            throw new Error('Unspecified test driving mode');
-        }
-        tests.push(msg);
-    }
-
-    let testIdx = 0;
-
-    for (let test of tests) {
-        logger.info(`------ Test round ${round + 1} ------`);
-        round++;
-        testIdx++;
-
-        test.roundIdx = round; // propagate round ID to clients
-        demo.startWatch(clientOrchestrator);
-        try {
-            await clientOrchestrator.startTest(test, clientArgs, processResult, testLabel, clientFactory);
-
-            demo.pauseWatch();
-            success++;
-            logger.info(`------ Passed '${testLabel}' testing ------`);
-
-            // prepare for the next round
-            if(!final || testIdx !== tests.length) {
-                logger.info('Waiting 5 seconds for the next round...');
-                await CaliperUtils.sleep(5000);
-                await monitor.restart();
-            }
-        } catch (err) {
-            demo.pauseWatch();
-            failure++;
-            logger.error(`------ Failed '${testLabel}' testing with the following error ------
-${err.stack ? err.stack : err}`);
-            // continue with next round
-        }
-    }
-}
-
-/**
- * Executes the given command asynchronously.
- * @param {string} command The command to execute through a newly spawn shell.
- * @return {Promise} The return promise is resolved upon the successful execution of the command, or rejected with an Error instance.
- * @async
- */
-function execAsync(command) {
-    return new Promise((resolve, reject) => {
-        logger.info(`Executing command: ${command}`);
-        let child = exec(command, {cwd: absCaliperDir}, (err, stdout, stderr) => {
-            if (err) {
-                logger.error(`Unsuccessful command execution. Error code: ${err.code}. Terminating signal: ${err.signal}`);
-                return reject(err);
-            }
-            return resolve();
-        });
-        child.stdout.pipe(process.stdout);
-        child.stderr.pipe(process.stderr);
-    });
-}
-
-/**
- * Start a default test flow to run the tests
+ * Run the benchmark based on passed arguments
  * @param {String} absConfigFile fully qualified path of the test configuration file
  * @param {String} absNetworkFile fully qualified path of the blockchain configuration file
- * @param {Object} admin a constructed admin client blockchain object
- * @param {Object} user a constructed user client blockchain object
- * @param {String} networkRoot fully qualified path to the root location of network files
+ * @param {AdminClient} admin a constructed Caliper Admin Client
+ * @param {ClientFactory} clientFactory a Caliper Client Factory
+ * @param {String} workspace fully qualified path to the root location of network files
  * @returns {Integer} the error status of the run
  */
-module.exports.run = async function(absConfigFile, absNetworkFile, admin, user, networkRoot) {
+module.exports.run = async function(absConfigFile, absNetworkFile, admin, clientFactory, workspace) {
 
     let errorStatus = 0;
-    const adminClient = new Blockchain(admin);
+    let successes = 0;
+    let failures = 0;
 
     logger.info('####### Caliper Test #######');
-    monitor = new Monitor(absConfigFile);
-    clientOrchestrator  = new ClientOrchestrator(absConfigFile);
-    createReport(absConfigFile, absNetworkFile, adminClient.gettype());
+    const adminClient = new Blockchain(admin);
+    const clientOrchestrator  = new ClientOrchestrator(absConfigFile);
+    const monitor = new Monitor(absConfigFile);
+    const report = new Report(monitor);
+    report.createReport(absConfigFile, absNetworkFile, adminClient.gettype());
     demo.init();
 
     let configObject = CaliperUtils.parseYaml(absConfigFile);
     let networkObject = CaliperUtils.parseYaml(absNetworkFile);
 
-    let skipStart = config.get(config.keys.CoreSkipStartScript, false);
-    let skipEnd = config.get(config.keys.CoreSkipEndScript, false);
+    let skipStart = Config.get(Config.keys.CoreSkipStartScript, false);
+    let skipEnd = Config.get(Config.keys.CoreSkipEndScript, false);
 
     try {
         if (networkObject.hasOwnProperty('caliper') && networkObject.caliper.hasOwnProperty('command') && networkObject.caliper.command.hasOwnProperty('start')) {
@@ -362,7 +62,8 @@ module.exports.run = async function(absConfigFile, absNetworkFile, admin, user, 
                 throw new Error('Start command is specified but it is empty');
             }
             if(!skipStart){
-                await execAsync('cd ' + networkRoot + ';' + networkObject.caliper.command.start);
+                const cmd = 'cd ' + workspace + ';' + networkObject.caliper.command.start;
+                await CaliperUtils.execAsync(cmd);
             }
         }
 
@@ -378,24 +79,25 @@ module.exports.run = async function(absConfigFile, absNetworkFile, admin, user, 
             logger.error('Could not start monitor, ' + (err.stack ? err.stack : err));
         }
 
-        let allTests = configObject.test.rounds;
         let testIdx = 0;
-        let testNum = allTests.length;
 
+        const tester = new Test(clientArgs, absNetworkFile, clientOrchestrator, clientFactory, workspace, report, demo);
+        const allTests = configObject.test.rounds;
         for (let test of allTests) {
             ++testIdx;
-            await defaultTest(test, clientArgs, (testIdx === testNum), absNetworkFile, user, networkRoot);
+            const response = await tester.runTestRounds(test, (testIdx === allTests.length));
+            successes += response.successes;
+            failures += response.failures;
         }
 
         logger.info('---------- Finished Test ----------\n');
-        printResultsByRound();
+        report.printResultsByRound();
         monitor.printMaxStats();
         await monitor.stop();
 
-        let date = new Date().toISOString().replace(/-/g,'').replace(/:/g,'').substr(0,15);
-        let output = path.join(process.cwd(), `report-${date}.html`);
-        await report.generate(output);
-        logger.info(`Generated report at ${output}`);
+        const date = new Date().toISOString().replace(/-/g,'').replace(/:/g,'').substr(0,15);
+        const outFile = path.join(process.cwd(), `report-${date}.html`);
+        await report.finalize(outFile);
 
         clientOrchestrator.stop();
 
@@ -410,13 +112,14 @@ module.exports.run = async function(absConfigFile, absNetworkFile, admin, user, 
                 logger.error('End command is specified but it is empty');
             } else {
                 if(!skipEnd){
-                    await execAsync('cd ' + networkRoot + ';' + networkObject.caliper.command.end);
+                    const cmd = 'cd ' + workspace + ';' + networkObject.caliper.command.end;
+                    await CaliperUtils.execAsync(cmd);
                 }
             }
         }
 
         // NOTE: keep the below multi-line formatting intact, otherwise the indents will interfere with the template literal
-        let testSummary = `# Test summary: ${success} succeeded, ${failure} failed #`;
+        let testSummary = `# Test summary: ${successes} succeeded, ${failures} failed #`;
         logger.info(`
 
 ${'#'.repeat(testSummary.length)}

--- a/packages/caliper-core/lib/client/client-orchestrator.js
+++ b/packages/caliper-core/lib/client/client-orchestrator.js
@@ -141,12 +141,12 @@ class ClientOrchestrator {
     *            };
     * @param {JSON} message start message
     * @param {Array} clientArgs each element of the array contains arguments that should be passed to corresponding test client
-    * @param {function} finishCB callback after the test finished
+    * @param {Report} report the report being built
     * @param {any} finishArgs arguments that should be passed to finishCB, the callback is invoke as finishCB(this.results, finshArgs)
     * @param {Object} clientFactory a factor used to spawn test clients
     * @async
     */
-    async startTest(message, clientArgs, finishCB, finishArgs, clientFactory) {
+    async startTest(message, clientArgs, report, finishArgs, clientFactory) {
         this.results = [];
         this.updates.data = [];
         this.updates.id++;
@@ -162,7 +162,7 @@ class ClientOrchestrator {
             throw new Error(`Unknown client type: ${this.type}`);
         }
 
-        await finishCB(this.results, finishArgs);
+        await report.processResult(this.results, finishArgs);
     }
 
     /**

--- a/packages/caliper-core/lib/report/report-builder.js
+++ b/packages/caliper-core/lib/report/report-builder.js
@@ -1,0 +1,301 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+'use strict';
+
+const logger = require('../utils/caliper-utils').getLogger('caliper-flow');
+const fs = require('fs');
+const Mustache = require('mustache');
+const path = require('path');
+
+/**
+ * Convert an object to string
+ * @param {Object} value object to be converted
+ * @return {String} returned string
+ */
+function stringify(value) {
+    if(typeof value === 'object'){
+        if(Array.isArray(value)) {
+            return value.toString();
+        }
+        else {
+            return JSON.stringify(value, null, 2);
+        }
+    }
+    else {
+        return value;
+    }
+}
+
+/**
+ * Report class for generating test report
+ */
+class ReportBuilder {
+    /**
+     * Constructor
+     */
+    constructor() {
+        this.template = path.join(__dirname, 'template/report.html');
+        this.data = {
+            'summary' : {       // summary of benchmark result
+                'meta' : [],    // information of the summary, e.g. [{"name": "DLT Type", "value": "Fabric"}, {"name": "Benchmark", "value": "Simple"}...]
+                'head' : [],    // table head for the summary table, e.g. ["Test","Name","Succ","Fail","Send Rate","Max Delay","Min Delay", "Avg Delay", "Throughput"],
+                'results':[]   // table rows for the summary table, e.g. [{ "result": [0,"publish", 1,0,"1 tps", "10.78 s","10.78 s", "10.78 s", "1 tps"]},...]
+            },
+            // results of each rounds, e.g
+            // [{
+            //     "id": "round 0",
+            //     "description" : "Test the performance for publishing digital item",
+            //     "performance": {
+            //       "head": ["Name","Succ","Fail","Send Rate","Max Delay","Min Delay", "Avg Delay", "Throughput"],
+            //       "result": ["publish", 1,0,"1 tps", "10.78 s","10.78 s", "10.78 s", "1 tps"]
+            //     },
+            //     "resource": {
+            //       "head": ["TYPE","NAME", "Memory(max)","Memory(avg)","CPU(max)", "CPU(avg)", "Traffic In","Traffic Out"],
+            //       "results": [
+            //         {
+            //          "result": ["Docker","peer1.org1.example.com", "94.4MB", "94.4MB", "0.89%", "0.84%", "0B", "0B"]
+            //         },
+            //         {
+            //           "result": ["Docker","peer0.org2.example.com","90.4MB", "90.4MB", "1.2%", "1.2%", "6KB", "0B"]
+            //         }
+            //       ]
+            //     }
+            //   }
+            'tests' : [],
+            'benchmarkInfo': 'not provided',   // readable information for the benchmark
+            'sut': {
+                'meta' : [],                    // metadata of the SUT
+                'details' : 'not provided'     // details of the SUT
+            }
+        };
+        this.started = false;
+        this.peers = [];
+        this.monitors = [];
+    }
+
+    /**
+    * add a name/value metadata
+    * @param {String} name name of the metadata
+    * @param {String} value value of the metadata
+    */
+    addMetadata(name, value) {
+        this.data.summary.meta.push({'name': name, 'value': value});
+    }
+
+    /**
+    * @tableArray, [[head], [row1], [row2], ...]
+    *              the first element must be an array represents the header of the table,
+    *              and the rest elements represent the rows of the table
+    */
+
+    /**
+    * set the head of summary table
+    * @param {Array} table array containing rows of a table, each row is also an array
+    */
+    setSummaryTable(table) {
+        if(!Array.isArray(table) || table.length < 1) {
+            throw new Error('unrecognized report table');
+        }
+
+        this.data.summary.head = table[0];
+        for(let i = 1 ; i < table.length ; i++) {
+            if(!Array.isArray(table)) {
+                throw new Error('unrecognized report table');
+            }
+            this.data.summary.results.push({'result' : table[i]});
+        }
+    }
+
+    /**
+    * add a row to the summary table
+    * @param {Array} row elements of the row
+    */
+    addSummarytableRow(row) {
+        if(!Array.isArray(row) || row.length < 1) {
+            throw new Error('unrecognized report row');
+        }
+        this.data.summary.results.push({'result' : row});
+    }
+
+    /**
+    * add a new benchmark round
+    * @param {String} label the test label
+    * @return {Number} id of the round, used to add details to this round
+    */
+    addBenchmarkRound(label) {
+        let index;
+        let exists = false;
+        for (let i=0; i<this.data.tests.length; i++) {
+            if (this.data.tests[i].label.localeCompare(label) === 0){
+                // Label test container exists
+                exists = true;
+                index = i;
+            }
+        }
+
+        if (exists) {
+            // Add the next round at the index point
+            const id = this.data.tests[index].rounds.length;
+            this.data.tests[index].rounds.push({
+                'id' : 'round ' + id,
+                'performance' : {'head':[], 'result': []},
+                'resource' : {'head':[], 'results': []}
+            });
+            return id;
+        } else {
+            // New item
+            this.data.tests.push({
+                'description' : this.descriptionmap.get(label),
+                'label' : label,
+                'rounds': [{
+                    'id' : 'round 0',
+                    'performance' : {'head':[], 'result': []},
+                    'resource' : {'head':[], 'results': []}
+                }]
+            });
+            return 0;
+        }
+    }
+
+    /**
+    * set performance table of a specific round
+    * @param {String} label the round label
+    * @param {Number} id id of the round
+    * @param {Array} table table array containing the performance values
+    */
+    setRoundPerformance(label, id, table) {
+
+        let index;
+        let exists = false;
+        for (let i=0; i<this.data.tests.length; i++) {
+            if (this.data.tests[i].label.localeCompare(label) === 0){
+                // Label test container exists
+                exists = true;
+                index = i;
+            }
+        }
+
+        if (!exists){
+            throw new Error('Non-existing report test label passed');
+        }
+
+        if(id < 0 || id >= this.data.tests[index].rounds.length) {
+            throw new Error('unrecognized report id');
+        }
+        if(!Array.isArray(table) || table.length < 1) {
+            throw new Error('unrecognized report table');
+        }
+
+        this.data.tests[index].rounds[id].performance.head = table[0];
+        if(table.length > 1)
+        {
+            this.data.tests[index].rounds[id].performance.result = table[1];
+        }
+    }
+
+    /**
+    * set resource consumption table of a specific round
+    * @param {String} label the round label
+    * @param {Number} id id of the round
+    * @param {Array} table table array containing the resource consumption values
+    */
+    setRoundResource(label, id, table) {
+        let index;
+        let exists = false;
+        for (let i=0; i<this.data.tests.length; i++) {
+            if (this.data.tests[i].label.localeCompare(label) === 0){
+                // Label test container exists
+                exists = true;
+                index = i;
+            }
+        }
+
+        if (!exists){
+            throw new Error('Non-existing report test label passed');
+        }
+
+        if(id < 0 || id >= this.data.tests[index].rounds.length) {
+            throw new Error('unrecognized report id');
+        }
+        if(!Array.isArray(table) || table.length < 1) {
+            throw new Error('unrecognized report table');
+        }
+
+        this.data.tests[index].rounds[id].resource.head = table[0];
+        for(let i = 1 ; i < table.length ; i++) {
+            if(!Array.isArray(table)) {
+                throw new Error('unrecognized report table');
+            }
+            this.data.tests[index].rounds[id].resource.results.push({'result' : table[i]});
+        }
+    }
+
+    /**
+    * set the readable information of the benchmark
+    * @param {String} info information of the benchmark
+    */
+    setBenchmarkInfo(info) {
+        this.data.benchmarkInfo = info;
+    }
+
+    /**
+    * add SUT information
+    * @param {String} name name of the metadata
+    * @param {Object} value value of the metadata
+    */
+    addSUTInfo(name, value) {
+        if(name === 'details') {
+            this.data.sut.details = stringify(value);
+        }
+        else {
+            this.data.sut.meta.push({'name': name, 'value': stringify(value)});
+        }
+    }
+
+    /**
+    * generate a HTML report for the benchmark
+    * @param {String} output filename of the output
+    * @async
+    */
+    async generate(output) {
+        let templateStr = fs.readFileSync(this.template).toString();
+        let html = Mustache.render(templateStr, this.data);
+        try {
+            await fs.writeFileSync(output, html);
+            logger.info(`Generated report with path ${output}`);
+        } catch (err) {
+            logger.info(`Failed to generate report, with error ${err}`);
+            throw err;
+        }
+    }
+
+    /**
+     * Generate a label - descrition map
+     * @param {Object} rounds the test rounds from teh yaml config file
+     */
+    addLabelDescriptionMap(rounds){
+        const descriptionmap = new Map();
+        for(let i = 0 ; i < rounds.length ; i++) {
+            if(rounds[i].hasOwnProperty('description')) {
+                descriptionmap.set(rounds[i].label, rounds[i].description);
+            }
+        }
+        this.descriptionmap = descriptionmap;
+
+    }
+}
+
+module.exports = ReportBuilder;

--- a/packages/caliper-core/lib/test/defaultTest.js
+++ b/packages/caliper-core/lib/test/defaultTest.js
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+'use strict';
+
+const CaliperUtils = require('../utils/caliper-utils');
+const logger = CaliperUtils.getLogger('defaultTest');
+
+const path = require('path');
+
+/**
+ * Default testing class fot Caliper
+ */
+class DefaultTest {
+
+    /**
+    * load client(s) to do performance tests
+    * @param {Array} clientArgs arguments for clients
+    * @param {String} absNetworkFile the network config file patch
+    * @param {ClientOrchestrator} clientOrchestrator the client orchestrator
+    * @param {Object} clientFactory factory used to spawn test clients
+    * @param {String} networkRoot the root location
+    * @param {Report} report the report being built
+    * @param {Object} demo the demo UI component
+    */
+    constructor(clientArgs, absNetworkFile, clientOrchestrator, clientFactory, networkRoot, report, demo) {
+        this.clientArgs = clientArgs;
+        this.absNetworkFile = absNetworkFile;
+        this.clientFactory = clientFactory;
+        this.clientOrchestrator = clientOrchestrator;
+        this.networkRoot = networkRoot;
+        this.report = report;
+        this.round = 0;
+        this.demo = demo;
+    }
+
+    /**
+     * Run test rounds
+     * @param {JSON} args testing arguments
+     * @param {Boolean} final =true, the last test round; otherwise, =false
+     * @returns {Object} the number of successful and failed tests
+     * @async
+     */
+    async runTestRounds(args, final) {
+        logger.info(`####### Testing '${args.label}' #######`);
+        const testLabel   = args.label;
+        const testRounds  = args.txDuration ? args.txDuration : args.txNumber;
+        const tests = []; // array of all test rounds
+        const configPath = path.resolve(this.absNetworkFile);
+
+        // Build test rounds
+        for (let i = 0 ; i < testRounds.length ; i++) {
+            const msg = {
+                type: 'test',
+                label : testLabel,
+                rateControl: args.rateControl[i] ? args.rateControl[i] : {type:'fixed-rate', 'opts' : {'tps': 1}},
+                trim: args.trim ? args.trim : 0,
+                args: args.arguments,
+                cb  : args.callback,
+                config: configPath,
+                root: this.networkRoot
+            };
+            // condition for time based or number based test driving
+            if (args.txNumber) {
+                msg.numb = testRounds[i];
+                // File information for reading or writing transaction request
+                msg.txFile = {roundLength: testRounds.length, roundCurrent: i, txMode: args.txMode};
+                if (args.txMode && args.txMode.type === 'file-write') {
+                    logger.info('------ Prepare(file-write) waiting ------');
+                    msg.txFile.readWrite = 'write';
+                    msg.rateControl = {type: 'fixed-rate', opts: {tps: 400}};
+                    try {
+                        await this.clientOrchestrator.startTest(msg, this.clientArgs, function(){}, testLabel, this.clientFactory);
+                        msg.numb = testRounds[i];
+                        msg.txFile.readWrite = 'read';
+                        msg.rateControl = args.rateControl[i] ? args.rateControl[i] : {type:'fixed-rate', 'opts' : {'tps': 1}};
+                        if(i === (testRounds.length - 1)) {
+                            logger.info('Waiting 5 seconds...');
+                            logger.info('------ Prepare(file-write) success------');
+                            await CaliperUtils.sleep(5000);
+                        }
+                    } catch (err) {
+                        logger.error('------Prepare(file-write) failed------');
+                        args.txMode.type = 'file-no';
+                    }
+
+                } else if(args.txMode && args.txMode.type === 'file-read'){
+                    msg.txFile.readWrite = 'read';
+                } else {
+                    msg.txFile.readWrite = 'no';
+                }
+            } else if (args.txDuration) {
+                msg.txDuration = testRounds[i];
+            } else {
+                throw new Error('Unspecified test driving mode');
+            }
+            tests.push(msg);
+        }
+
+
+        let successes = 0;
+        let failures = 0;
+        let testIdx = 0;
+
+        // Run each test round
+        for (let test of tests) {
+            logger.info(`------ Test round ${this.round += 1} ------`);
+            testIdx++;
+
+            test.roundIdx = this.round; // propagate round ID to clients
+            this.demo.startWatch(this.clientOrchestrator);
+            try {
+                await this.clientOrchestrator.startTest(test, this.clientArgs, this.report, testLabel, this.clientFactory);
+
+                this.demo.pauseWatch();
+                successes++;
+                logger.info(`------ Passed '${testLabel}' testing ------`);
+
+                // prepare for the next round
+                if(!final || testIdx !== tests.length) {
+                    logger.info('Waiting 5 seconds for the next round...');
+                    await CaliperUtils.sleep(5000);
+                    await this.monitor.restart();
+                }
+            } catch (err) {
+                this.demo.pauseWatch();
+                failures++;
+                logger.error(`------ Failed '${testLabel}' testing with the following error ------
+    ${err.stack ? err.stack : err}`);
+                // continue with next round
+            }
+        }
+
+        return {successes, failures};
+    }
+
+}
+
+module.exports = DefaultTest;

--- a/packages/caliper-core/lib/utils/caliper-utils.js
+++ b/packages/caliper-core/lib/utils/caliper-utils.js
@@ -13,6 +13,9 @@
  */
 
 'use strict';
+
+const childProcess = require('child_process');
+const exec = childProcess.exec;
 const path = require('path');
 require('winston-daily-rotate-file');
 const fs = require('fs');
@@ -209,6 +212,28 @@ class CaliperUtils {
         for (let property of propertyNames) {
             CaliperUtils.assertProperty(object, objectName, property);
         }
+    }
+
+    /**
+     * Executes the given command asynchronously.
+     * @param {string} command The command to execute through a newly spawn shell.
+     * @return {Promise} The return promise is resolved upon the successful execution of the command, or rejected with an Error instance.
+     * @async
+     */
+    static execAsync(command) {
+        const logger = CaliperUtils.getLogger('caliper-utils');
+        return new Promise((resolve, reject) => {
+            logger.info(`Executing command: ${command}`);
+            let child = exec(command, (err, stdout, stderr) => {
+                if (err) {
+                    logger.error(`Unsuccessful command execution. Error code: ${err.code}. Terminating signal: ${err.signal}`);
+                    return reject(err);
+                }
+                return resolve();
+            });
+            child.stdout.pipe(process.stdout);
+            child.stderr.pipe(process.stderr);
+        });
     }
 }
 


### PR DESCRIPTION
This PR removes the report generation and default test from `caliper-flow`. This reduces the flow file size considerably.

The following is introduced:
- a report class builds an internal report using a report builder
- a `DefaultTest` class is used to encapsulate the test run process

This should enable the components to be maintained in a more isolated fashion, and lend itself to modularization of these components. 

Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>
