### PR TITLE
Enable user to specify a client gateway test

### DIFF
--- a/packages/caliper-burrow/lib/burrowClientFactory.js
+++ b/packages/caliper-burrow/lib/burrowClientFactory.js
@@ -38,7 +38,7 @@ class BurrowClientFactory {
      * @returns {Object} the child process
      */
     async spawnWorker() {
-        const child = childProcess.fork(path.join(__dirname, './burrowClientWorker.js'));
+        const child = childProcess.fork(path.join(__dirname, './burrowClientWorker.js'), process.argv.slice(1), { env: process.env});
 
         const msg = {
             type: 'init',

--- a/packages/caliper-composer/lib/composerClientFactory.js
+++ b/packages/caliper-composer/lib/composerClientFactory.js
@@ -37,8 +37,8 @@ class ComposerClientFactory {
      * Spawn the worker and perform required init
      * @returns {Object} the child process
      */
-    async spawnWorker() {
-        const child = childProcess.fork(path.join(__dirname, './composerClientWorker.js'));
+    spawnWorker() {
+        const child = childProcess.fork(path.join(__dirname, './composerClientWorker.js'), process.argv.slice(1), { env: process.env});
 
         const msg = {
             type: 'init',

--- a/packages/caliper-core/lib/config/config-util.js
+++ b/packages/caliper-core/lib/config/config-util.js
@@ -69,7 +69,10 @@ const keys = {
     FabricOverwriteGopath: 'caliper-fabricccp-overwritegopath',
     FabricLatencyThreshold: 'caliper-fabricccp-latencythreshold',
     FabricCountQueryAsLoad: 'caliper-fabricccp-countqueryasload',
-    FabricSkipCreateChannelPrefix: 'caliper-fabricccp-skipcreatechannel-'
+    FabricSkipCreateChannelPrefix: 'caliper-fabricccp-skipcreatechannel-',
+    FabricGateway: 'caliper-fabricccp-usegateway',
+    FabricGatewayLocalHost: 'caliper-fabricccp-gatewaylocalhost',
+    FabricDiscovery: 'caliper-fabricccp-discovery'
 };
 
 module.exports.get = get;

--- a/packages/caliper-core/lib/config/default.yaml
+++ b/packages/caliper-core/lib/config/default.yaml
@@ -70,6 +70,12 @@ caliper:
         latencythreshold: 1.0
         # Indicates whether to count queries as workload, i.e., whether the generated report should include them
         countqueryasload: true
+        # Indicates whether to use the Fabric Gateway API
+        usegateway: false
+        # Indicates whether to use the localhost default within the Fabric Gateway API
+        gatewaylocalhost: true
+        # Indicates whether to use the Fabric discovery mechanism (via Gateway API)
+        discovery: false
 
     fabric:
     sawtooth:

--- a/packages/caliper-fabric-ccp/lib/fabricClientFactory.js
+++ b/packages/caliper-fabric-ccp/lib/fabricClientFactory.js
@@ -37,8 +37,8 @@ class FabricClientFactory {
      * Spawn the worker and perform required init
      * @returns {Object} the child process
      */
-    async spawnWorker() {
-        const child = childProcess.fork(path.join(__dirname, './fabricClientWorker.js'));
+    spawnWorker() {
+        const child = childProcess.fork(path.join(__dirname, './fabricClientWorker.js'), process.argv.slice(1), { env: process.env});
 
         const msg = {
             type: 'init',

--- a/packages/caliper-fabric-ccp/lib/fabricClientWorker.js
+++ b/packages/caliper-fabric-ccp/lib/fabricClientWorker.js
@@ -17,6 +17,7 @@
 const {CaliperLocalClient, CaliperUtils} = require('caliper-core');
 const FabricClient = require('./fabric');
 
+const logger = CaliperUtils.getLogger('fabric-ccp/fabricClientWorker');
 let caliperClient;
 /**
  * Message handler
@@ -32,8 +33,15 @@ process.on('message', async (message) => {
         switch (message.type) {
         case 'init': {
             const blockchain = new FabricClient(message.absNetworkFile, message.networkRoot);
+            // reload the profiles silently
+            await blockchain._initializeRegistrars(false);
+            await blockchain._initializeAdmins(false);
+            await blockchain._initializeUsers(false);
+
             caliperClient = new CaliperLocalClient(blockchain);
             process.send({type: 'ready', data: {pid: process.pid, complete: true}});
+
+            logger.info('Client ready');
             break;
         }
         case 'test': {

--- a/packages/caliper-fabric-ccp/lib/fabricNetwork.js
+++ b/packages/caliper-fabric-ccp/lib/fabricNetwork.js
@@ -1275,6 +1275,7 @@ class FabricNetwork {
     isTlsEnabled() {
         return this.tls;
     }
+
 }
 
 module.exports = FabricNetwork;

--- a/packages/caliper-fabric/lib/fabricClientFactory.js
+++ b/packages/caliper-fabric/lib/fabricClientFactory.js
@@ -37,8 +37,8 @@ class FabricClientFactory {
      * Spawn the worker and perform required init
      * @returns {Object} the child process
      */
-    async spawnWorker() {
-        const child = childProcess.fork(path.join(__dirname, './fabricClientWorker.js'));
+    spawnWorker() {
+        const child = childProcess.fork(path.join(__dirname, './fabricClientWorker.js'), process.argv.slice(1), { env: process.env});
 
         const msg = {
             type: 'init',

--- a/packages/caliper-iroha/lib/irohaClientFactory.js
+++ b/packages/caliper-iroha/lib/irohaClientFactory.js
@@ -37,8 +37,8 @@ class IrohaClientFactory {
      * Spawn the worker and perform required init
      * @returns {Object} the child process
      */
-    async spawnWorker() {
-        const child = childProcess.fork(path.join(__dirname, './irohaClientWorker.js'));
+    spawnWorker() {
+        const child = childProcess.fork(path.join(__dirname, './irohaClientWorker.js'), process.argv.slice(1), { env: process.env});
 
         const msg = {
             type: 'init',

--- a/packages/caliper-sawtooth/lib/sawtoothClientFactory.js
+++ b/packages/caliper-sawtooth/lib/sawtoothClientFactory.js
@@ -37,8 +37,8 @@ class SawtoothClientFactory {
      * Spawn the worker and perform required init
      * @returns {Object} the child process
      */
-    async spawnWorker() {
-        const child = childProcess.fork(path.join(__dirname, './sawtoothClientWorker.js'));
+    spawnWorker() {
+        const child = childProcess.fork(path.join(__dirname, './sawtoothClientWorker.js'), process.argv.slice(1), { env: process.env});
 
         const msg = {
             type: 'init',

--- a/packages/caliper-tests-integration/scripts/run-integration-tests.sh
+++ b/packages/caliper-tests-integration/scripts/run-integration-tests.sh
@@ -62,14 +62,14 @@ if [ "${BENCHMARK}" == "composer" ]; then
     cleanup
     exit $rc;
 elif [ "${BENCHMARK}" == "fabric-ccp" ]; then
-    # Run with channel creation using a createChannelTx in couchDB
-    caliper benchmark run -c benchmark/simple/config.yaml -n network/fabric-v1.4/2org1peercouchdb/fabric-ccp-node.yaml -w ../caliper-samples/
+    # Run with channel creation using a createChannelTx in couchDB, using a Gateway
+    caliper benchmark run -c benchmark/simple/config.yaml -n network/fabric-v1.4.1/2org1peercouchdb/fabric-ccp-node.yaml -w ../caliper-samples/ --caliper-fabricccp-usegateway
     rc=$?
     if [[ $rc != 0 ]]; then
         cleanup
         exit $rc;
     else
-        # Run with channel creation using a tx file in LevelDB
+        # Run with channel creation using an existing tx file in LevelDB, using a low level Caliper client
         caliper benchmark run -c benchmark/simple/config.yaml -n network/fabric-v1.4/2org1peergoleveldb/fabric-ccp-go.yaml -w ../caliper-samples/
         rc=$?
         cleanup


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

This PR extends the fabric-ccp adaptor to enable a user to specify the use of a Fabric Gateway based transaction by the addition of a `use-gateway: true` flag on the benchmark configuration file.

Changes:
- check/set of a `usegateway` flag within Fabric Network
- conditioning on fabric client version>=1.4.0 to use the new flag
- construction of required items (wallets and gateway contracts) during init/getContext phases
- fork in main submit/evaluate pathway to test with either the Gateway contract or the standard caliper client
- modification of integration test to use the alternative route (both client routes are tested)

Code flow:
- during the creation of clients, identities are conditionally added to an in-memory wallet
- during the getContext() method, a map-of-maps is created for each available client and all available chaincodes/smart-contracts: `Map<clientId, Map<chaincodeId, contract>>`
- if no `usegateway` flag is present, the standard transaction path is followed, otherwise, based on the invokingID and the chaincode identifier, a contract is extracted for the invokingID and then either `evaluateTransaction` or `submitTransaction` is called on the contract, with the passed test arguments

Documentation update is required:
- To use the new feature the flag `usegateway` must be added to the configuration file
- Using a gateway prevents the ability to produce detailed Caliper metrics of the transaction progress

Notes:
- Does not yet support discovery