### PR TITLE
Not use "tls_cacerts" value when TLS is not enabled (blockchain type …

### DIFF
--- a/packages/caliper-fabric/lib/create-channel.js
+++ b/packages/caliper-fabric/lib/create-channel.js
@@ -166,9 +166,12 @@ async function run(config_path, root_path) {
 
     try {
         let ORGS = fabric.network;
-        let caRootsPath = ORGS.orderer.tls_cacerts;
-        let data = fs.readFileSync(CaliperUtils.resolvePath(caRootsPath, root_path));
-        let caroots = Buffer.from(data).toString();
+        let caroots;
+        if(ORGS.orderer.url.startsWith("grpcs")) {
+            let caRootsPath = ORGS.orderer.tls_cacerts;
+            let data = fs.readFileSync(CaliperUtils.resolvePath(caRootsPath, root_path));
+            caroots = Buffer.from(data).toString();    
+        }
         utils.setConfigSetting('key-value-store', 'fabric-client/lib/impl/FileKeyValueStore.js');
 
         for (const channel of channels) {

--- a/packages/caliper-fabric/lib/create-channel.js
+++ b/packages/caliper-fabric/lib/create-channel.js
@@ -186,7 +186,7 @@ async function run(config_path, root_path) {
             const org = channel.organizations[0];
 
             // Conditional action on TLS enablement
-            if(fabric.network.orderer.url.toString().startsWith('grpcs')){
+            if(fabric.network.orderer.url.toString().startsWith('grpcs') && fabric.network[org].ca){
                 const fabricCAEndpoint = fabric.network[org].ca.url;
                 const caName = fabric.network[org].ca.name;
                 const tlsInfo = await e2eUtils.tlsEnroll(fabricCAEndpoint, caName);

--- a/packages/caliper-fabric/lib/create-channel.js
+++ b/packages/caliper-fabric/lib/create-channel.js
@@ -186,7 +186,7 @@ async function run(config_path, root_path) {
             const org = channel.organizations[0];
 
             // Conditional action on TLS enablement
-            if(fabric.network.orderer.url.toString().startsWith('grpcs') && fabric.network[org].ca){
+            if(fabric.network.orderer.url.toString().startsWith('grpcs')){
                 const fabricCAEndpoint = fabric.network[org].ca.url;
                 const caName = fabric.network[org].ca.name;
                 const tlsInfo = await e2eUtils.tlsEnroll(fabricCAEndpoint, caName);

--- a/packages/caliper-fabric/lib/create-channel.js
+++ b/packages/caliper-fabric/lib/create-channel.js
@@ -166,12 +166,9 @@ async function run(config_path, root_path) {
 
     try {
         let ORGS = fabric.network;
-        let caroots;
-        if(ORGS.orderer.url.startsWith("grpcs")) {
-            let caRootsPath = ORGS.orderer.tls_cacerts;
-            let data = fs.readFileSync(CaliperUtils.resolvePath(caRootsPath, root_path));
-            caroots = Buffer.from(data).toString();    
-        }
+        let caRootsPath = ORGS.orderer.tls_cacerts;
+        let data = fs.readFileSync(CaliperUtils.resolvePath(caRootsPath, root_path));
+        let caroots = Buffer.from(data).toString();
         utils.setConfigSetting('key-value-store', 'fabric-client/lib/impl/FileKeyValueStore.js');
 
         for (const channel of channels) {

--- a/packages/caliper-fabric/lib/e2eUtils.js
+++ b/packages/caliper-fabric/lib/e2eUtils.js
@@ -139,12 +139,9 @@ async function installChaincode(org, chaincode) {
     cryptoSuite.setCryptoKeyStore(Client.newCryptoKeyStore({path: testUtil.storePathForOrg(orgName)}));
     client.setCryptoSuite(cryptoSuite);
 
-    let caroots;
-    if(ORGS.orderer.url.startsWith("grpcs")) {
-        let caRootsPath = ORGS.orderer.tls_cacerts;
-        let data = fs.readFileSync(CaliperUtils.resolvePath(caRootsPath, networkRoot));
-        caroots = Buffer.from(data).toString();
-    }
+    const caRootsPath = ORGS.orderer.tls_cacerts;
+    let data = fs.readFileSync(CaliperUtils.resolvePath(caRootsPath, networkRoot));
+    let caroots = Buffer.from(data).toString();
 
     channel.addOrderer(
         client.newOrderer(
@@ -160,15 +157,11 @@ async function installChaincode(org, chaincode) {
     for (let key in ORGS[org]) {
         if (ORGS[org].hasOwnProperty(key)) {
             if (key.indexOf('peer') === 0) {
-                let peercaroots;
-                if(ORGS[org][key].requests.startsWith("grpcs")) {
-                    let data = fs.readFileSync(CaliperUtils.resolvePath(ORGS[org][key].tls_cacerts, networkRoot));
-                    peercaroots = Buffer.from(data).toString();
-                }                
+                let data = fs.readFileSync(CaliperUtils.resolvePath(ORGS[org][key].tls_cacerts, networkRoot));
                 let peer = client.newPeer(
                     ORGS[org][key].requests,
                     {
-                        pem: peercaroots,
+                        pem: Buffer.from(data).toString(),
                         'ssl-target-name-override': ORGS[org][key]['server-hostname']
                     }
                 );
@@ -301,12 +294,9 @@ async function instantiate(chaincode, endorsement_policy, upgrade){
     cryptoSuite.setCryptoKeyStore(Client.newCryptoKeyStore({path: testUtil.storePathForOrg(orgName)}));
     client.setCryptoSuite(cryptoSuite);
 
-    let caroots;
-    if(ORGS.orderer.url.startsWith("grpcs")) {
-        let caRootsPath = ORGS.orderer.tls_cacerts;
-        let data = fs.readFileSync(CaliperUtils.resolvePath(caRootsPath, networkRoot));
-        caroots = Buffer.from(data).toString();    
-    }    
+    const caRootsPath = ORGS.orderer.tls_cacerts;
+    let data = fs.readFileSync(CaliperUtils.resolvePath(caRootsPath, networkRoot));
+    let caroots = Buffer.from(data).toString();
 
     // Conditional action on TLS enablement
     if(ORGS.orderer.url.toString().startsWith('grpcs')){
@@ -337,15 +327,11 @@ async function instantiate(chaincode, endorsement_policy, upgrade){
         if(ORGS.hasOwnProperty(org) && org.indexOf('org') === 0) {
             for (let key in ORGS[org]) {
                 if(ORGS[org].hasOwnProperty(key) && key.indexOf('peer') === 0) {
-                    let peercaroots;
-                    if(ORGS[org][key].requests.startsWith("grpcs")) {
-                        let data = fs.readFileSync(CaliperUtils.resolvePath(ORGS[org][key].tls_cacerts, networkRoot));
-                        peercaroots = Buffer.from(data).toString();
-                    }                    
+                    let data = fs.readFileSync(CaliperUtils.resolvePath(ORGS[org][key].tls_cacerts, networkRoot));
                     let peer = client.newPeer(
                         ORGS[org][key].requests,
                         {
-                            pem: peercaroots,
+                            pem: Buffer.from(data).toString(),
                             'ssl-target-name-override': ORGS[org][key]['server-hostname']
                         });
                     targets.push(peer);
@@ -478,12 +464,9 @@ async function instantiateLegacy(chaincode, endorsement_policy, upgrade){
     cryptoSuite.setCryptoKeyStore(Client.newCryptoKeyStore({path: testUtil.storePathForOrg(orgName)}));
     client.setCryptoSuite(cryptoSuite);
 
-    let caroots;
-    if(ORGS.orderer.url.startsWith("grpcs")) {
-        let caRootsPath = ORGS.orderer.tls_cacerts;
-        let data = fs.readFileSync(CaliperUtils.resolvePath(caRootsPath, root_path));
-        caroots = Buffer.from(data).toString();
-    }
+    const caRootsPath = ORGS.orderer.tls_cacerts;
+    let data = fs.readFileSync(CaliperUtils.resolvePath(caRootsPath, networkRoot));
+    let caroots = Buffer.from(data).toString();
 
     channel.addOrderer(
         client.newOrderer(
@@ -508,15 +491,11 @@ async function instantiateLegacy(chaincode, endorsement_policy, upgrade){
         if(ORGS.hasOwnProperty(org) && org.indexOf('org') === 0) {
             for (let key in ORGS[org]) {
                 if(ORGS[org].hasOwnProperty(key) && key.indexOf('peer') === 0) {
-                    let peercaroots;
-                    if(ORGS[org][key].requests.startsWith("grpcs")) {
-                        let data = fs.readFileSync(CaliperUtils.resolvePath(ORGS[org][key].tls_cacerts, networkRoot));
-                        peercaroots = Buffer.from(data).toString();
-                    }                    
+                    let data = fs.readFileSync(CaliperUtils.resolvePath(ORGS[org][key].tls_cacerts, networkRoot));
                     let peer = client.newPeer(
                         ORGS[org][key].requests,
                         {
-                            pem: peercaroots,
+                            pem: Buffer.from(data).toString(),
                             'ssl-target-name-override': ORGS[org][key]['server-hostname']
                         });
                     targets.push(peer);
@@ -529,16 +508,12 @@ async function instantiateLegacy(chaincode, endorsement_policy, upgrade){
         }
     }
 
-    let peercaroots;
-    if(ORGS[userOrg][eventPeer].events.startsWith("grpcs")) {
-        let data = fs.readFileSync(CaliperUtils.resolvePath(ORGS[userOrg][eventPeer].tls_cacerts, networkRoot));
-        peercaroots = Buffer.from(data).toString();
-    }     
+    data = fs.readFileSync(CaliperUtils.resolvePath(ORGS[userOrg][eventPeer].tls_cacerts, networkRoot));
     let eh = client.newEventHub();
     eh.setPeerAddr(
         ORGS[userOrg][eventPeer].events,
         {
-            pem: peercaroots,
+            pem: Buffer.from(data).toString(),
             'ssl-target-name-override': ORGS[userOrg][eventPeer]['server-hostname']
         }
     );
@@ -728,12 +703,9 @@ async function getcontext(channelConfig, clientIdx, txModeFile) {
     cryptoSuite.setCryptoKeyStore(Client.newCryptoKeyStore({path: testUtil.storePathForOrg(orgName)}));
     client.setCryptoSuite(cryptoSuite);
 
-    let caroots;
-    if(ORGS.orderer.url.startsWith("grpcs")) {
-        let caRootsPath = ORGS.orderer.tls_cacerts;
-        let data = fs.readFileSync(CaliperUtils.resolvePath(caRootsPath, networkRoot));
-        caroots = Buffer.from(data).toString();
-    }
+    const caRootsPath = ORGS.orderer.tls_cacerts;
+    let data = fs.readFileSync(CaliperUtils.resolvePath(caRootsPath, networkRoot));
+    let caroots = Buffer.from(data).toString();
 
     channel.addOrderer(
         client.newOrderer(
@@ -763,15 +735,11 @@ async function getcontext(channelConfig, clientIdx, txModeFile) {
 
         // Cycle through available peers based on clientIdx
         let peerInfo = peers[clientIdx % peers.length];
-        let peercaroots;
-        if(peerInfo.requests.startsWith("grpcs")) {
-            let data = fs.readFileSync(CaliperUtils.resolvePath(peerInfo.tls_cacerts, networkRoot));
-            peercaroots = Buffer.from(data).toString();
-        }
+        let data = fs.readFileSync(CaliperUtils.resolvePath(peerInfo.tls_cacerts, networkRoot));
         let peer = client.newPeer(
             peerInfo.requests,
             {
-                pem: peercaroots,
+                pem: Buffer.from(data).toString(),
                 'ssl-target-name-override': peerInfo['server-hostname']
             }
         );

--- a/packages/caliper-fabric/lib/e2eUtils.js
+++ b/packages/caliper-fabric/lib/e2eUtils.js
@@ -127,7 +127,7 @@ async function installChaincode(org, chaincode) {
     const channel = client.newChannel(channel_name);
 
     // Conditional action on TLS enablement
-    if(ORGS.orderer.url.toString().startsWith('grpcs')){
+    if(ORGS.orderer.url.toString().startsWith('grpcs') && ORGS[org].ca){
         const fabricCAEndpoint = ORGS[org].ca.url;
         const caName = ORGS[org].ca.name;
         const tlsInfo = await tlsEnroll(fabricCAEndpoint, caName);
@@ -309,7 +309,7 @@ async function instantiate(chaincode, endorsement_policy, upgrade){
     }    
 
     // Conditional action on TLS enablement
-    if(ORGS.orderer.url.toString().startsWith('grpcs')){
+    if(ORGS.orderer.url.toString().startsWith('grpcs') && ORGS[userOrg].ca){
         const fabricCAEndpoint = ORGS[userOrg].ca.url;
         const caName = ORGS[userOrg].ca.name;
         const tlsInfo = await tlsEnroll(fabricCAEndpoint, caName);
@@ -718,7 +718,7 @@ async function getcontext(channelConfig, clientIdx, txModeFile) {
     const eventhubs = [];
 
     // Conditional action on TLS enablement
-    if(ORGS[userOrg].ca.url.toString().startsWith('https')){
+    if(ORGS[userOrg].ca && ORGS[userOrg].ca.url.toString().startsWith('https')){
         const fabricCAEndpoint = ORGS[userOrg].ca.url;
         const caName = ORGS[userOrg].ca.name;
         const tlsInfo = await tlsEnroll(fabricCAEndpoint, caName);

--- a/packages/caliper-fabric/lib/e2eUtils.js
+++ b/packages/caliper-fabric/lib/e2eUtils.js
@@ -127,7 +127,7 @@ async function installChaincode(org, chaincode) {
     const channel = client.newChannel(channel_name);
 
     // Conditional action on TLS enablement
-    if(ORGS.orderer.url.toString().startsWith('grpcs') && ORGS[org].ca){
+    if(ORGS.orderer.url.toString().startsWith('grpcs')){
         const fabricCAEndpoint = ORGS[org].ca.url;
         const caName = ORGS[org].ca.name;
         const tlsInfo = await tlsEnroll(fabricCAEndpoint, caName);
@@ -309,7 +309,7 @@ async function instantiate(chaincode, endorsement_policy, upgrade){
     }    
 
     // Conditional action on TLS enablement
-    if(ORGS.orderer.url.toString().startsWith('grpcs') && ORGS[userOrg].ca){
+    if(ORGS.orderer.url.toString().startsWith('grpcs')){
         const fabricCAEndpoint = ORGS[userOrg].ca.url;
         const caName = ORGS[userOrg].ca.name;
         const tlsInfo = await tlsEnroll(fabricCAEndpoint, caName);
@@ -718,7 +718,7 @@ async function getcontext(channelConfig, clientIdx, txModeFile) {
     const eventhubs = [];
 
     // Conditional action on TLS enablement
-    if(ORGS[userOrg].ca && ORGS[userOrg].ca.url.toString().startsWith('https')){
+    if(ORGS[userOrg].ca.url.toString().startsWith('https')){
         const fabricCAEndpoint = ORGS[userOrg].ca.url;
         const caName = ORGS[userOrg].ca.name;
         const tlsInfo = await tlsEnroll(fabricCAEndpoint, caName);

--- a/packages/caliper-fabric/lib/join-channel.js
+++ b/packages/caliper-fabric/lib/join-channel.js
@@ -35,12 +35,9 @@ async function joinChannel(org, channelName, orgs, root_path) {
     const orgName = orgs[org].name;
     const targets = [];
 
-    let caroots;
-    if(orgs.orderer.url.startsWith("grpcs")) {
-        let caRootsPath = orgs.orderer.tls_cacerts;
-        let data = fs.readFileSync(CaliperUtils.resolvePath(caRootsPath, root_path));
-        caroots = Buffer.from(data).toString();    
-    }
+    const caRootsPath = orgs.orderer.tls_cacerts;
+    let data = fs.readFileSync(CaliperUtils.resolvePath(caRootsPath, root_path));
+    let caroots = Buffer.from(data).toString();
 
     try {
 
@@ -81,16 +78,12 @@ async function joinChannel(org, channelName, orgs, root_path) {
         for (let key in orgs[org]) {
             if (orgs[org].hasOwnProperty(key)) {
                 if(key.indexOf('peer') === 0) {
-                    let peercaroots;
-                    if(orgs[org][key].requests.startsWith("grpcs")) {
-                        let data = fs.readFileSync(CaliperUtils.resolvePath(orgs[org][key].tls_cacerts, root_path));
-                        peercaroots = Buffer.from(data).toString();
-                    }
+                    data = fs.readFileSync(CaliperUtils.resolvePath(orgs[org][key].tls_cacerts, root_path));
                     targets.push(
                         client.newPeer(
                             orgs[org][key].requests,
                             {
-                                pem: peercaroots,
+                                pem: Buffer.from(data).toString(),
                                 'ssl-target-name-override': orgs[org][key]['server-hostname']
                             }
                         )

--- a/packages/caliper-fabric/lib/join-channel.js
+++ b/packages/caliper-fabric/lib/join-channel.js
@@ -45,7 +45,7 @@ async function joinChannel(org, channelName, orgs, root_path) {
     try {
 
         // Conditional action on TLS enablement
-        if(orgs.orderer.url.toString().startsWith('grpcs') && orgs[org].ca){
+        if(orgs.orderer.url.toString().startsWith('grpcs')){
             const fabricCAEndpoint = orgs[org].ca.url;
             const caName = orgs[org].ca.name;
             const tlsInfo = await e2eUtils.tlsEnroll(fabricCAEndpoint, caName);

--- a/packages/caliper-fabric/lib/join-channel.js
+++ b/packages/caliper-fabric/lib/join-channel.js
@@ -45,7 +45,7 @@ async function joinChannel(org, channelName, orgs, root_path) {
     try {
 
         // Conditional action on TLS enablement
-        if(orgs.orderer.url.toString().startsWith('grpcs')){
+        if(orgs.orderer.url.toString().startsWith('grpcs') && orgs[org].ca){
             const fabricCAEndpoint = orgs[org].ca.url;
             const caName = orgs[org].ca.name;
             const tlsInfo = await e2eUtils.tlsEnroll(fabricCAEndpoint, caName);


### PR DESCRIPTION
(blockchain type : fabric)
When you do not enable TLS in the "hyperledger fabric", you will get an error if you do not set the "tls_cacerts" value in the network configuration file.
So I modified it to handle "tls_cacerts" values ​​only when orderer's url or peer's requests values ​​start with "grpcs".
