### PR TITLE
Fixed expected parameter

### DIFF
--- a/packages/caliper-core/lib/monitor/monitor-docker.js
+++ b/packages/caliper-core/lib/monitor/monitor-docker.js
@@ -109,7 +109,7 @@ function findContainers() {
                 return Promise.resolve();
             }
 
-            if(filterName.remote[h].containers.indexOf('all') !== -1) {
+            if(filterName.remote[h].containers.indexOf('/all') !== -1) {
                 for(let i = 0 ; i < size ; i++) {
                     let container = docker.getContainer(containers[i].Id);
                     this.containers.push({id: containers[i].Id, name: h + containers[i].Names[0], remote: container});


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [x]  How to recreate the problem without the fix
 - [x]  Design of the fix
 - [x]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
<!--- What issue / user story is this for -->

When I try to use a remote docker and passing the link of it into the config file, like:
http://127.0.0.34:2375/all
Caliper is not able to fetch the stats data of all the docker containers.

I guess that a similar problem is present on the "else" of the same branch. line: 121 (NOT FIXED)
## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1. To recreate the bug just start hyperledger caliper passing the endpoint to the remote docker.

> monitor:
>   type:
>   - docker
>   docker:
>     name: 
>         **- http://127.0.0.34:2375/all**
>   interval: 1;

 The result of the execution, without the fix, will be to do not be able to fetch the containers stats.




## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-caliper)
- [ ] [GitHub Issues](https://github.com/hyperledger/caliper/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/caliper)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->
In any case, the value inside filterName.remote[h].containers cannot exclude the '/'.
The value is coming from line: 49, the function url.parse is cutting the different parts of the url and "pathname" will include the slash.
Adding the slash will make it able to match the value contained inside filterName.remote[h].containers

Another possible solution could remove the slash in the beginning.
## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->
I tried by my self and with this little fix everything works fine.
## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->
