### PR TITLE
Fix method of calculating CPU utilization for local docker containers in …

### DIFF
--- a/packages/caliper-core/lib/monitor/monitor-docker.js
+++ b/packages/caliper-core/lib/monitor/monitor-docker.js
@@ -211,7 +211,19 @@ class MonitorDocker extends MonitorInterface {
                         if(self.containers[i].remote === null) {    // local
                             self.stats[id].mem_usage.push(stat.mem_usage);
                             self.stats[id].mem_percent.push(stat.mem_percent);
-                            self.stats[id].cpu_percent.push(stat.cpu_percent);
+                            let cpuDelta = stat.cpu_stats.cpu_usage.total_usage - stat.precpu_stats.cpu_usage.total_usage;
+                            let sysDelta = stat.cpu_stats.system_cpu_usage - stat.precpu_stats.system_cpu_usage;
+                            if(cpuDelta > 0 && sysDelta > 0) {
+                                if(stat.cpu_stats.cpu_usage.hasOwnProperty('percpu_usage') && stat.cpu_stats.cpu_usage.percpu_usage !== null) {
+                                    self.stats[id].cpu_percent.push(cpuDelta / sysDelta * MonitorDocker.coresInUse(stat.cpu_stats) * 100.0);
+                                }
+                                else {
+                                    self.stats[id].cpu_percent.push(cpuDelta / sysDelta * 100.0);
+                                }
+                            }
+                            else {
+                                self.stats[id].cpu_percent.push(0);
+                            }
                             self.stats[id].netIO_rx.push(stat.netIO.rx);
                             self.stats[id].netIO_tx.push(stat.netIO.tx);
                             self.stats[id].blockIO_rx.push(stat.blockIO.r);


### PR DESCRIPTION
…docker monitor

<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [x]  A link to the issue/user story that the pull request relates to
 - [x]  How to recreate the problem without the fix
 - [x]  Design of the fix
 - [x]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?

## Issue/User story
<!--- What issue / user story is this for -->
https://github.com/hyperledger/caliper/issues/504

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1. Install Caliper and Caliper CLI
2. Configure a benchmark to monitor resource usage of local docker container
3. Run benchmark
4. Check statistics result of Caliper

## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-caliper)
- [ ] [GitHub Issues](https://github.com/hyperledger/caliper/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/caliper)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->
Calculating CPU utilization the same way as remote docker container's.

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->
After fixing,  the results is basically coherent and in line with the reality.
![image](https://user-images.githubusercontent.com/44284897/61115177-7c737f00-a4c4-11e9-9bed-20a9b63762b2.png)

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->
None

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->
None