### PR TITLE
update versions to remove verdaccio vulnerability and bootstrap warning

### DIFF
--- a/packages/caliper-fabric-ccp/package.json
+++ b/packages/caliper-fabric-ccp/package.json
@@ -26,7 +26,7 @@
     "fabric-client" : "^1.4.0",
     "fabric-network" : "^1.4.0",
     "fabric-protos": "2.0.0-snapshot.1",
-    "fs-extra": "^4.0.2",
+    "fs-extra": "^8.0.1",
     "nconf": "^0.10.0"
   },
   "devDependencies": {

--- a/packages/caliper-fabric/package.json
+++ b/packages/caliper-fabric/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "caliper-core" : "0.1.0",
     "fabric-protos": "2.0.0-snapshot.1",
-    "fs-extra": "^4.0.2",
+    "fs-extra": "^8.0.1",
     "nconf": "^0.10.0"
   },
   "devDependencies": {

--- a/packages/caliper-tests-integration/package.json
+++ b/packages/caliper-tests-integration/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/hyperledger/caliper#readme",
   "devDependencies": {
     "pm2": "2.10.1",
-    "verdaccio": "2.6.4"
+    "verdaccio": "3.12.0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

Vulnerability scan showed some version issues within verdaccio, and the warning on a fs-extra hoist mis-match during bootstrap is getting frustrating ... this PR resolves both.