### PR TITLE
Modify timeout setting for Fabric chaincode execute

### DIFF
--- a/packages/caliper-samples/network/fabric-v1.0/2org1peercouchdb/docker-compose.yaml
+++ b/packages/caliper-samples/network/fabric-v1.0/2org1peercouchdb/docker-compose.yaml
@@ -49,6 +49,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org1.example.com
       - CORE_PEER_ENDORSER_ENABLED=true
@@ -89,6 +90,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org2.example.com
       - CORE_PEER_ENDORSER_ENABLED=true

--- a/packages/caliper-samples/network/fabric-v1.0/2org1peergoleveldb/docker-compose.yaml
+++ b/packages/caliper-samples/network/fabric-v1.0/2org1peergoleveldb/docker-compose.yaml
@@ -49,6 +49,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org1.example.com
       - CORE_PEER_ENDORSER_ENABLED=true
@@ -78,6 +79,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org2.example.com
       - CORE_PEER_ENDORSER_ENABLED=true

--- a/packages/caliper-samples/network/fabric-v1.1/2org1peercouchdb/docker-compose.yaml
+++ b/packages/caliper-samples/network/fabric-v1.1/2org1peercouchdb/docker-compose.yaml
@@ -49,6 +49,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org1.example.com
       - CORE_PEER_ENDORSER_ENABLED=true
@@ -89,6 +90,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org2.example.com
       - CORE_PEER_ENDORSER_ENABLED=true

--- a/packages/caliper-samples/network/fabric-v1.1/2org1peergoleveldb/docker-compose.yaml
+++ b/packages/caliper-samples/network/fabric-v1.1/2org1peergoleveldb/docker-compose.yaml
@@ -49,6 +49,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org1.example.com
       - CORE_PEER_ENDORSER_ENABLED=true
@@ -78,6 +79,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org2.example.com
       - CORE_PEER_ENDORSER_ENABLED=true

--- a/packages/caliper-samples/network/fabric-v1.2/2org1peercouchdb/docker-compose.yaml
+++ b/packages/caliper-samples/network/fabric-v1.2/2org1peercouchdb/docker-compose.yaml
@@ -49,6 +49,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org1.example.com
       - CORE_PEER_ENDORSER_ENABLED=true
@@ -89,6 +90,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org2.example.com
       - CORE_PEER_ENDORSER_ENABLED=true

--- a/packages/caliper-samples/network/fabric-v1.2/2org1peergoleveldb/docker-compose.yaml
+++ b/packages/caliper-samples/network/fabric-v1.2/2org1peergoleveldb/docker-compose.yaml
@@ -49,6 +49,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org1.example.com
       - CORE_PEER_ENDORSER_ENABLED=true
@@ -78,6 +79,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org2.example.com
       - CORE_PEER_ENDORSER_ENABLED=true

--- a/packages/caliper-samples/network/fabric-v1.3/2org1peercouchdb/docker-compose.yaml
+++ b/packages/caliper-samples/network/fabric-v1.3/2org1peercouchdb/docker-compose.yaml
@@ -49,6 +49,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org1.example.com
       - CORE_PEER_ENDORSER_ENABLED=true
@@ -89,6 +90,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org2.example.com
       - CORE_PEER_ENDORSER_ENABLED=true

--- a/packages/caliper-samples/network/fabric-v1.3/2org1peergoleveldb/docker-compose.yaml
+++ b/packages/caliper-samples/network/fabric-v1.3/2org1peergoleveldb/docker-compose.yaml
@@ -49,6 +49,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org1.example.com
       - CORE_PEER_ENDORSER_ENABLED=true
@@ -78,6 +79,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org2.example.com
       - CORE_PEER_ENDORSER_ENABLED=true

--- a/packages/caliper-samples/network/fabric-v1.4.1/2org1peercouchdb/docker-compose.yaml
+++ b/packages/caliper-samples/network/fabric-v1.4.1/2org1peercouchdb/docker-compose.yaml
@@ -49,6 +49,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org1.example.com
       - CORE_PEER_ENDORSER_ENABLED=true
@@ -89,6 +90,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org2.example.com
       - CORE_PEER_ENDORSER_ENABLED=true

--- a/packages/caliper-samples/network/fabric-v1.4.1/2org1peergoleveldb/docker-compose.yaml
+++ b/packages/caliper-samples/network/fabric-v1.4.1/2org1peergoleveldb/docker-compose.yaml
@@ -49,6 +49,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org1.example.com
       - CORE_PEER_ENDORSER_ENABLED=true
@@ -78,6 +79,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org2.example.com
       - CORE_PEER_ENDORSER_ENABLED=true

--- a/packages/caliper-samples/network/fabric-v1.4.1/3org2peercouchdb/docker-compose.yaml
+++ b/packages/caliper-samples/network/fabric-v1.4.1/3org2peercouchdb/docker-compose.yaml
@@ -73,6 +73,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org1.example.com
       - CORE_PEER_ENDORSER_ENABLED=true
@@ -114,6 +115,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer1.org1.example.com
       - CORE_PEER_ENDORSER_ENABLED=true
@@ -155,6 +157,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org2.example.com
       - CORE_PEER_LOCALMSPID=Org2MSP
@@ -195,6 +198,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer1.org2.example.com
       - CORE_PEER_LOCALMSPID=Org2MSP
@@ -235,6 +239,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org3.example.com
       - CORE_PEER_LOCALMSPID=Org3MSP
@@ -275,6 +280,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer1.org3.example.com
       - CORE_PEER_LOCALMSPID=Org3MSP

--- a/packages/caliper-samples/network/fabric-v1.4.1/3org2peergoleveldb/docker-compose.yaml
+++ b/packages/caliper-samples/network/fabric-v1.4.1/3org2peergoleveldb/docker-compose.yaml
@@ -73,6 +73,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org1.example.com
       - CORE_PEER_ENDORSER_ENABLED=true
@@ -103,6 +104,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer1.org1.example.com
       - CORE_PEER_ENDORSER_ENABLED=true
@@ -133,6 +135,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org2.example.com
       - CORE_PEER_LOCALMSPID=Org2MSP
@@ -162,6 +165,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer1.org2.example.com
       - CORE_PEER_LOCALMSPID=Org2MSP
@@ -191,6 +195,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org3.example.com
       - CORE_PEER_LOCALMSPID=Org3MSP
@@ -220,6 +225,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer1.org3.example.com
       - CORE_PEER_LOCALMSPID=Org3MSP

--- a/packages/caliper-samples/network/fabric-v1.4/2org1peercouchdb/docker-compose.yaml
+++ b/packages/caliper-samples/network/fabric-v1.4/2org1peercouchdb/docker-compose.yaml
@@ -49,6 +49,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org1.example.com
       - CORE_PEER_ENDORSER_ENABLED=true
@@ -89,6 +90,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org2.example.com
       - CORE_PEER_ENDORSER_ENABLED=true

--- a/packages/caliper-samples/network/fabric-v1.4/2org1peergoleveldb/docker-compose.yaml
+++ b/packages/caliper-samples/network/fabric-v1.4/2org1peergoleveldb/docker-compose.yaml
@@ -49,6 +49,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org1.example.com
       - CORE_PEER_ENDORSER_ENABLED=true
@@ -78,6 +79,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org2.example.com
       - CORE_PEER_ENDORSER_ENABLED=true

--- a/packages/caliper-samples/network/fabric-v1.4/3org2peercouchdb/docker-compose.yaml
+++ b/packages/caliper-samples/network/fabric-v1.4/3org2peercouchdb/docker-compose.yaml
@@ -73,6 +73,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org1.example.com
       - CORE_PEER_ENDORSER_ENABLED=true
@@ -114,6 +115,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer1.org1.example.com
       - CORE_PEER_ENDORSER_ENABLED=true
@@ -155,6 +157,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org2.example.com
       - CORE_PEER_LOCALMSPID=Org2MSP
@@ -195,6 +198,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer1.org2.example.com
       - CORE_PEER_LOCALMSPID=Org2MSP
@@ -235,6 +239,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org3.example.com
       - CORE_PEER_LOCALMSPID=Org3MSP
@@ -275,6 +280,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer1.org3.example.com
       - CORE_PEER_LOCALMSPID=Org3MSP

--- a/packages/caliper-samples/network/fabric-v1.4/3org2peergoleveldb/docker-compose.yaml
+++ b/packages/caliper-samples/network/fabric-v1.4/3org2peergoleveldb/docker-compose.yaml
@@ -73,6 +73,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org1.example.com
       - CORE_PEER_ENDORSER_ENABLED=true
@@ -103,6 +104,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer1.org1.example.com
       - CORE_PEER_ENDORSER_ENABLED=true
@@ -133,6 +135,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org2.example.com
       - CORE_PEER_LOCALMSPID=Org2MSP
@@ -162,6 +165,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer1.org2.example.com
       - CORE_PEER_LOCALMSPID=Org2MSP
@@ -191,6 +195,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org3.example.com
       - CORE_PEER_LOCALMSPID=Org3MSP
@@ -220,6 +225,7 @@ services:
     environment:
       - CORE_LOGGING_PEER=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+      - CORE_CHAINCODE_EXECUTETIMEOUT=999999
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer1.org3.example.com
       - CORE_PEER_LOCALMSPID=Org3MSP

--- a/packages/caliper-samples/network/fabric-v1.4/kafka/docker-compose.yaml
+++ b/packages/caliper-samples/network/fabric-v1.4/kafka/docker-compose.yaml
@@ -100,6 +100,7 @@ services:
         - FABRIC_LOGGING_SPEC=grpc=debug:debug
         - CORE_CHAINCODE_LOGGING_LEVEL=INFO
         - CORE_CHAINCODE_LOGGING_SHIM=INFO
+        - CORE_CHAINCODE_EXECUTETIMEOUT=999999
         - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
         - CORE_PEER_ID=peer0.org1.example.com
         - CORE_PEER_ENDORSER_ENABLED=true
@@ -128,6 +129,7 @@ services:
         - FABRIC_LOGGING_SPEC=grpc=debug:debug
         - CORE_CHAINCODE_LOGGING_LEVEL=INFO
         - CORE_CHAINCODE_LOGGING_SHIM=INFO
+        - CORE_CHAINCODE_EXECUTETIMEOUT=999999
         - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
         - CORE_PEER_ID=peer0.org2.example.com
         - CORE_PEER_ENDORSER_ENABLED=true


### PR DESCRIPTION
Signed-off-by: lmuswere <lynn14m@gmail.com>

Fabric yaml files modified to specify CORE_CHAINCODE_EXECUTETIMEOUT with a large number to enable a larger timeout before failing the transaction.