### PR TITLE
Add composer transaction fail error

### DIFF
--- a/packages/caliper-composer/lib/composer.js
+++ b/packages/caliper-composer/lib/composer.js
@@ -159,7 +159,7 @@ class Composer extends BlockchainInterface {
             .catch((err) => {
                 invoke_status.SetStatusFail();
                 invoke_status.result = [];
-
+                logger.error('submitTransaction failed with error: ', err);
                 return Promise.resolve(invoke_status);
             });
     }


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>
At the moment failing composer transactions are not identified, which is problematic when trying to set up a Composer test.

This PR adds logging of any error messages coming back from the failed transaction to help assist in debugging