### PR TITLE
avoid verdaccio use during build tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install: |
     set -o pipefail
     npm install -g @alrra/travis-scripts
 
-script: ./.travis/script.sh
+script: ./.travis/avoid_verdaccio.sh
 
 cache:
   directories:

--- a/.travis/avoid_verdaccio.sh
+++ b/.travis/avoid_verdaccio.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Exit on first error, print all commands.
+set -e
+set -o pipefail
+
+# Bootstrap the project
+npm run bootstrap
+
+# Run linting, license check and unit tests
+npm test
+
+echo "---- Running Integration test for adaptor ${BENCHMARK}"
+cd ./packages/caliper-tests-integration/
+npm run run_tests_direct

--- a/packages/caliper-tests-integration/package.json
+++ b/packages/caliper-tests-integration/package.json
@@ -9,6 +9,7 @@
     "install_cli": "./scripts/install-packages.sh",
     "e2e_install": "npm run cleanup && npm run start_verdaccio && npm run publish_packages && npm run install_cli && npm run cleanup",
     "run_tests": "./scripts/run-tests.sh",
+    "run_tests_direct": "./scripts/run-tests-direct.sh",
     "stop_verdaccio": "PM2_HOME=.pm2 pm2 stop verdaccio || true",
     "pretest": "npm run licchk",
     "licchk": "license-check-and-add",

--- a/packages/caliper-tests-integration/scripts/run-tests-direct.sh
+++ b/packages/caliper-tests-integration/scripts/run-tests-direct.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Exit on first error, print all commands.
+set -ev
+set -o pipefail
+
+# Set ARCH
+ARCH=`uname -m`
+
+# Grab the parent (root) directory.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+# Switch into the integration tests directory to access required npm run commands
+cd "${DIR}"
+
+# Barf if we don't recognize this test adaptor.
+if [[ "${BENCHMARK}" = "" ]]; then
+    echo You must set BENCHMARK to one of the desired test adaptors 'composer|fabric'
+    echo For example:
+    echo  export BENCHMARK=fabric
+    exit 1
+fi
+
+# Run benchmark adaptor
+if [[ "${BENCHMARK}" == "composer" ]]; then
+    node ../caliper-cli/caliper.js benchmark run --caliper-benchconfig benchmark/composer/config.yaml --caliper-networkconfig network/fabric-v1.3/2org1peercouchdb/composer.json --caliper-workspace ../caliper-samples/
+    rc=$?
+    exit $rc;
+elif [[ "${BENCHMARK}" == "fabric" ]]; then
+    # Run with channel creation using a createChannelTx in couchDB, using a Gateway
+
+    node ../caliper-cli/caliper.js benchmark run --caliper-benchconfig benchmark/simple/config.yaml --caliper-networkconfig network/fabric-v1.4.1/2org1peercouchdb/fabric-node.yaml --caliper-workspace ../caliper-samples/ --caliper-fabric-usegateway
+    rc=$?
+    if [[ $rc != 0 ]]; then
+        exit $rc;
+    else
+        # Run with channel creation using an existing tx file in LevelDB, using a low level Caliper client
+        node ../caliper-cli/caliper.js benchmark run --caliper-benchconfig benchmark/simple/config.yaml --caliper-networkconfig network/fabric-v1.4/2org1peergoleveldb/fabric-go.yaml --caliper-workspace ../caliper-samples/
+        rc=$?
+        exit $rc;
+    fi
+else
+    echo "Unknown target benchmark ${BENCHMARK}"
+    exit 1
+fi


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

Current builds are failing due to what appears to be a significant resource availability drop that is preventing the use of the verdaccio test process, which requires significant resource utilisation during the hosting of the proxy npm server.

This PR circumvents the verdaccio process as a temporary measure to get the build pipeline working again. The new route tests the CLI `caliper.js` directly, rather than installing it as a CLI package