### PR TITLE
make gateway timeout configurable with configDefaultTimeout

### DIFF
--- a/packages/caliper-fabric/lib/fabric.js
+++ b/packages/caliper-fabric/lib/fabric.js
@@ -1030,7 +1030,8 @@ class Fabric extends BlockchainInterface {
             discovery: {
                 asLocalhost: this.configLocalHost,
                 enabled: this.configDiscovery
-            }
+            },
+            eventHandlerOptions: { commitTimeout: this.configDefaultTimeout }
         };
 
         // Optional on mutual auth


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

The gateway created in fabric.js will pick up on the default config unless it is overridden as a gateway config as an event handler option. 

This should be done on gateway creation, and can neatly pick up on the default test parameter