### PR TITLE
Condition Caliper flow

### DIFF
--- a/packages/caliper-core/lib/config/config-util.js
+++ b/packages/caliper-core/lib/config/config-util.js
@@ -59,9 +59,23 @@ const keys = {
     ZooAddress: 'caliper-zooaddress',
     ZooConfig: 'caliper-zooconfig',
     TxUpdateTime: 'caliper-txupdatetime',
-    SkipStartScript: 'caliper-skipstartscript',
-    SkipEndScript: 'caliper-skipendscript',
     Logging: 'caliper-logging',
+    Flow: {
+        Skip: {
+            Start : 'caliper-flow-skip-start',
+            Init: 'caliper-flow-skip-init',
+            Install: 'caliper-flow-skip-install',
+            Test: 'caliper-flow-skip-test',
+            End: 'caliper-flow-skip-end'
+        },
+        Only: {
+            Start: 'caliper-flow-only-start',
+            Init: 'caliper-flow-only-init',
+            Install: 'caliper-flow-only-install',
+            Test: 'caliper-flow-only-test',
+            End: 'caliper-flow-only-end'
+        }
+    },
     Fabric: {
         SleepAfter: {
             CreateChannel: 'caliper-fabric-sleepafter-createchannel',

--- a/packages/caliper-core/lib/config/default.yaml
+++ b/packages/caliper-core/lib/config/default.yaml
@@ -25,10 +25,6 @@ caliper:
     zooconfig:
     # Sets the frequency of the progress reports in milliseconds
     txupdatetime: 1000
-    # Indicates whether to skip the start command script in the network configuration file, if provided
-    skipstartscript: false
-    # Indicates whether to skip the end command script in the network configuration file, if provided
-    skipendscript: false
     # Configurations related to the logging mechanism
     logging:
         # Defines a console target with info level
@@ -43,6 +39,33 @@ caliper:
             datePattern: YYYY-MM-DD-HH
             maxSize: 5m
             zippedArchive: true
+
+    # Caliper flow options
+    flow:
+        # Skip options
+        skip:
+            # Indicates whether to skip the start command script in the network configuration file, if provided
+            start: false
+            # Indicates whether to skip the init phase of the benchmark
+            init: false
+            # Indicates whether to skip the smart contract install phase of the benchmark
+            install: false
+            # Indicates whether to skip the test phase of the benchmark
+            test: false
+            # Indicates whether to skip the end command script in the network configuration file, if provided
+            end: false
+        # Only options
+        only:
+            # Indicates whether to only perform the start command script in the network configuration file, if provided
+            start: false
+            # Indicates whether to only perform the init phase of the benchmark
+            init: false
+            # Indicates whether to only perform the smart contract install phase of the benchmark
+            install: false
+            # Indicates whether to only perform the test phase of the benchmark
+            test: false
+            # Indicates whether to only perform the end command script in the network configuration file, if provided
+            end: false
 
     # Configurations related to the Fabric CCP adapter
     fabric:

--- a/packages/caliper-core/lib/utils/caliper-utils.js
+++ b/packages/caliper-core/lib/utils/caliper-utils.js
@@ -21,6 +21,7 @@ require('winston-daily-rotate-file');
 const fs = require('fs');
 const yaml = require('js-yaml');
 const loggingUtil = require('./logging-util.js');
+const Config = require('../config/config-util');
 
 /**
  * Internal Utility class for Caliper
@@ -234,6 +235,100 @@ class CaliperUtils {
             child.stdout.pipe(process.stdout);
             child.stderr.pipe(process.stderr);
         });
+    }
+
+    /**
+     * Retrieve user specified flow flags
+     * @returns {JSON} a JSON object containing conditioned flow options
+     */
+    static getFlowOptions() {
+        // High level flow default options
+        const flowOpts = {
+            performStart: true,
+            performInit: true,
+            performInstall: true,
+            performTest: true,
+            performEnd: true
+        };
+
+        let skip = 0;
+        let only = 0;
+
+        if (Config.get(Config.keys.Flow.Skip.Start, false)) {
+            flowOpts.performStart = false;
+            skip++;
+        }
+
+        if (Config.get(Config.keys.Flow.Skip.Init, false)) {
+            flowOpts.performInit = false;
+            skip++;
+        }
+
+        if (Config.get(Config.keys.Flow.Skip.Install, false)) {
+            flowOpts.performInstall = false;
+            skip++;
+        }
+
+        if (Config.get(Config.keys.Flow.Skip.Test, false)) {
+            flowOpts.performTest = false;
+            skip++;
+        }
+
+        if (Config.get(Config.keys.Flow.Skip.End, false)) {
+            flowOpts.performEnd = false;
+            skip++;
+        }
+
+        if (Config.get(Config.keys.Flow.Only.Start, false)) {
+            flowOpts.performInit = false;
+            flowOpts.performInstall = false;
+            flowOpts.performTest = false;
+            flowOpts.performEnd = false;
+            only++;
+        }
+
+        if (Config.get(Config.keys.Flow.Only.Init, false)) {
+            flowOpts.performStart = false;
+            flowOpts.performInstall = false;
+            flowOpts.performTest = false;
+            flowOpts.performEnd = false;
+            only++;
+        }
+
+        if (Config.get(Config.keys.Flow.Only.Install, false)) {
+            flowOpts.performStart = false;
+            flowOpts.performInit = false;
+            flowOpts.performTest = false;
+            flowOpts.performEnd = false;
+            only++;
+        }
+
+        if (Config.get(Config.keys.Flow.Only.Test, false)) {
+            flowOpts.performStart = false;
+            flowOpts.performInit = false;
+            flowOpts.performInstall = false;
+            flowOpts.performEnd = false;
+            only++;
+        }
+
+        if (Config.get(Config.keys.Flow.Only.End, false)) {
+            flowOpts.performStart = false;
+            flowOpts.performInit = false;
+            flowOpts.performInstall = false;
+            flowOpts.performTest = false;
+            only++;
+        }
+
+        if (skip && only) {
+            throw new Error('Incompatible benchmark flow parameters specified, caliper-flow-skip-x and caliper-flow-only-x flags may not be mixed');
+        }
+
+        if (only > 1) {
+            throw new Error('Incompatible benchmark flow parameters specified, only one of [caliper-flow-only-start, caliper-flow-only-init, caliper-flow-only-install, caliper-flow-only-test, caliper-flow-only-end] may be specified at a time');
+        }
+
+        return flowOpts;
+
     }
 }
 

--- a/packages/caliper-fabric/lib/fabric.js
+++ b/packages/caliper-fabric/lib/fabric.js
@@ -2262,6 +2262,7 @@ class Fabric extends BlockchainInterface {
         await this._initializeRegistrars(true);
         await this._initializeAdmins(true);
         await this._initializeUsers(true);
+        this.initPhaseCompleted = true;
 
         if (await this._createChannels()) {
             logger.info(`Sleeping ${this.configSleepAfterCreateChannel / 1000.0}s...`);
@@ -2279,6 +2280,13 @@ class Fabric extends BlockchainInterface {
      * @async
      */
     async installSmartContract() {
+        // With flow conditioning, this phase is conditionally required
+        if (!this.initPhaseCompleted ) {
+            await this._initializeRegistrars(true);
+            await this._initializeAdmins(true);
+            await this._initializeUsers(true);
+        }
+
         await this._installChaincodes();
         if (await this._instantiateChaincodes()) {
             logger.info(`Sleeping ${this.configSleepAfterInstantiateChaincode / 1000.0}s...`);

--- a/packages/caliper-samples/benchmark/marbles/config.yaml
+++ b/packages/caliper-samples/benchmark/marbles/config.yaml
@@ -13,11 +13,6 @@
 #
 
 ---
-flow:
-    skipStart: true
-    skipInit: true
-    skipInstall: true
-    skipEnd: true
 test:
   clients:
     type: local

--- a/packages/caliper-samples/benchmark/marbles/config.yaml
+++ b/packages/caliper-samples/benchmark/marbles/config.yaml
@@ -13,6 +13,11 @@
 #
 
 ---
+flow:
+    skipStart: true
+    skipInit: true
+    skipInstall: true
+    skipEnd: true
 test:
   clients:
     type: local


### PR DESCRIPTION
Related to #535 and enables conditional caliper-flow actions of:
- run start scripts
- run init phase
- run install smart contract phase
- run test phase
- run end script phase

All the above controlled via a config item passed at the command line level