### PR TITLE
Fix Docker build script for public NPM repo

### DIFF
--- a/packages/caliper-tests-integration/scripts/buildDockerImage.js
+++ b/packages/caliper-tests-integration/scripts/buildDockerImage.js
@@ -50,7 +50,7 @@ const registryArg = args[1];
             if (registryArg) {
                 dockerArgs = dockerArgs.concat(['--build-arg', `npm_registry=--registry=${registryArg}`, '.']);
             } else {
-                dockerArgs = dockerArgs.concat(['--build-arg', 'npm_registry=""', '.']);
+                dockerArgs = dockerArgs.concat(['--build-arg', 'npm_registry=', '.']);
             }
 
             // the command is executed from the caliper-tests-integration dir


### PR DESCRIPTION
Signed-off-by: Attila Klenik <a.klenik@gmail.com>

When building the Docker image from the public NPM packages, the "empty" registry argument was passed incorrectly, resulting in an erroneous npm call.