### PR TITLE
add a query smart contract method

### DIFF
--- a/packages/caliper-core/lib/blockchain-interface.js
+++ b/packages/caliper-core/lib/blockchain-interface.js
@@ -81,10 +81,22 @@ class BlockchainInterface {
      * @param {String} contractID identity of the contract
      * @param {String} contractVer version of the contract
      * @param {Array} args array of JSON formatted arguments for multiple transactions
-     * @param {Number} timeout request timeout, in second
+     * @param {Number} timeout request timeout, in seconds
      */
     async invokeSmartContract(context, contractID, contractVer, args, timeout) {
         throw new Error('invokeSmartContract is not implemented for this blockchain system');
+    }
+
+    /**
+     * Query state from the ledger using a smart contract
+     * @param {Object} context context object
+     * @param {String} contractID identity of the contract
+     * @param {String} contractVer version of the contract
+     * @param {Array} args array of JSON formatted arguments
+     * @param {Number} timeout request timeout, in seconds
+     */
+    async querySmartContract(context, contractID, contractVer, args, timeout) {
+        throw new Error('querySmartContract is not implemented for this blockchain system');
     }
 
     /**

--- a/packages/caliper-core/lib/blockchain.js
+++ b/packages/caliper-core/lib/blockchain.js
@@ -115,13 +115,44 @@ class Blockchain {
     }
 
     /**
+     * Query state from the ledger using a smart contract
+     * @param {Object} context context object
+     * @param {String} contractID identiy of the contract
+     * @param {String} contractVer version of the contract
+     * @param {Array} args array of JSON formatted arguments
+     * @param {Number} timeout request timeout, in seconds
+     * @return {Promise} query response object
+     */
+    async querySmartContract(context, contractID, contractVer, args, timeout) {
+        let arg, time;
+        if(Array.isArray(args)) {
+            arg = args;
+        }
+        else if(typeof args === 'object') {
+            arg = [args];
+        }
+        else {
+            throw new Error('Invalid args for querySmartContract()');
+        }
+
+        if(typeof timeout !== 'number' || timeout < 0) {
+            time = 120;
+        }
+        else {
+            time = timeout;
+        }
+
+        return await this.bcObj.querySmartContract(context, contractID, contractVer, arg, time);
+    }
+
+    /**
      * Query state from the ledger
      * @param {Object} context context object from getContext
      * @param {String} contractID identiy of the contract
      * @param {String} contractVer version of the contract
      * @param {String} key lookup key
      * @param {String=} [fcn] query function name
-     * @return {Promise} as invokeSmateContract()
+     * @return {Object} as invokeSmateContract()
      */
     async queryState(context, contractID, contractVer, key, fcn) {
         return await this.bcObj.queryState(context, contractID, contractVer, key, fcn);


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

This PR adds the companion method of `invokeSmartContract` to expose the ability to `querySmartContract` from the blockchain object directly, thereby raising the ability to perform the call beyond a Fabric level interaction. 

This will give Caliper testing the ability to:
- explicitly perform a query using a deployed smart contract
- explicitly perform a query by going direct to the ledger if the underlying DLT engine permits it