### PR TITLE
Add configCountTxnAsLoad to fabric adaptor and default config

### DIFF
--- a/packages/caliper-core/lib/config/config-util.js
+++ b/packages/caliper-core/lib/config/config-util.js
@@ -101,6 +101,7 @@ const keys = {
         OverwriteGopath: 'caliper-fabric-overwritegopath',
         LatencyThreshold: 'caliper-fabric-latencythreshold',
         CountQueryAsLoad: 'caliper-fabric-countqueryasload',
+        CountTransactionAsLoad: 'caliper-fabric-counttransactionasload',
         SkipCreateChannelPrefix: 'caliper-fabric-skipcreatechannel-',
         Gateway: 'caliper-fabric-usegateway',
         GatewayLocalHost: 'caliper-fabric-gatewaylocalhost',

--- a/packages/caliper-core/lib/config/default.yaml
+++ b/packages/caliper-core/lib/config/default.yaml
@@ -112,6 +112,8 @@ caliper:
         latencythreshold: 1.0
         # Indicates whether to count queries as workload, i.e., whether the generated report should include them
         countqueryasload: true
+        # Indicates whether to count transactions as workload, i.e., whether the generated report should include them
+        counttransactionasload: true
         # Indicates whether to use the Fabric Gateway API
         usegateway: false
         # Indicates whether to use the localhost default within the Fabric Gateway API


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

closes #570 

Adds a `CountTransactionAsLoad` configuration parameter similar to the existing `CountQueryAsLoad` configuration option
- options added to both "submit transaction routes"
- query option added to gateway query option (previously missing)