### PR TITLE
Enhance logging subsystem with flexible customization

### DIFF
--- a/packages/caliper-core/.gitignore
+++ b/packages/caliper-core/.gitignore
@@ -20,6 +20,7 @@ zookeeper.out
 .idea/
 **/node_modules/
 **/log/
+*.log
 
 # Ignore any composer logs
 composer-logs/

--- a/packages/caliper-core/lib/config/Config.js
+++ b/packages/caliper-core/lib/config/Config.js
@@ -36,7 +36,44 @@ const keys = {
     ZooAddress: 'caliper-zooaddress',
     ZooConfig: 'caliper-zooconfig',
     TxUpdateTime: 'caliper-txupdatetime',
-    Logging: 'caliper-logging',
+    LoggingRoot: 'caliper-logging',
+    Logging: {
+        Template: 'caliper-logging-template',
+        FormatsRoot: 'caliper-logging-formats',
+        Formats: {
+            Align: 'caliper-logging-formats-align',
+            Pad: 'caliper-logging-formats-pad',
+            ColorizeRoot: 'caliper-logging-formats-colorize',
+            Colorize: {
+                Level: 'caliper-logging-formats-colorize-level',
+                Message: 'caliper-logging-formats-colorize-message',
+                Colors: {
+                    Info: 'caliper-logging-formats-colorize-colors-info',
+                    Error: 'caliper-logging-formats-colorize-colors-error',
+                    Warn: 'caliper-logging-formats-colorize-colors-warn',
+                    Debug: 'caliper-logging-formats-colorize-colors-debug',
+                }
+            },
+            ErrorsRoot: 'caliper-logging-formats-errors',
+            Errors: {
+                Stack: 'caliper-logging-formats-errors-stack'
+            },
+            JsonRoot: 'caliper-logging-formats-json',
+            Json: {
+                Space: 'caliper-logging-formats-json-space'
+            },
+            LabelRoot: 'caliper-logging-formats-label',
+            Label: {
+                Label: 'caliper-logging-formats-label-label',
+                Message: 'caliper-logging-formats-label-message'
+            },
+            TimestampRoot: 'caliper-logging-formats-timestamp',
+            Timestamp: {
+                Format: 'caliper-logging-formats-timestamp-format'
+            }
+        },
+        Targets: 'caliper-logging-targets'
+    },
     Flow: {
         Skip: {
             Start : 'caliper-flow-skip-start',

--- a/packages/caliper-core/lib/config/config-util.js
+++ b/packages/caliper-core/lib/config/config-util.js
@@ -48,7 +48,7 @@ function set(name, value) {
  * @param {any} defaultValue The value to return in case the key is not found.
  * @return {any} The value of the configuration or the defaultValue parameter if not found.
  */
-function get(name, defaultValue) {
+function get(name, defaultValue = undefined) {
     return _getConfigInstance().get(name, defaultValue);
 }
 

--- a/packages/caliper-core/lib/config/default.yaml
+++ b/packages/caliper-core/lib/config/default.yaml
@@ -43,18 +43,59 @@ caliper:
     txupdatetime: 1000
     # Configurations related to the logging mechanism
     logging:
-        # Defines a console target with info level
-        consolelogger:
-            target: console
-            level: info
-        # Defines a daily rotating file target with debug level
-        filelogger:
-            target: daily-rotate-file
-            level: debug
-            filename: log/caliper-%DATE%.log
-            datePattern: YYYY-MM-DD-HH
-            maxSize: 5m
-            zippedArchive: true
+        # Specifies the message structure through placeholders
+        template: '%time% %level% [%label%] [%module%] %message% %meta%'
+        # Enables the different formats to apply to the log messages FOR ALL transports
+        # Each format can be disabled by setting it to false
+        formats:
+            # adds a tab delimiter before the message to align it in the same place
+            align: true
+            # pads the levels to be the same length
+            pad: true
+            # defines coloring for the different levels
+            colorize:
+                # Apply it to levels
+                level: true
+                # Apply it to messages
+                message: false
+                # The colors for each level
+                colors:
+                    info: green
+                    error: red
+                    warn: yellow
+                    debug: grey
+            # specifies whether to print stack traces
+            errors:
+                stack: true
+            # serializes the log messages as JSON
+            json: false
+            # Adds a specified label to every message. Useful for distributed client scenario
+            label:
+                label: caliper
+                message: false
+            # Adds a timestamp to the messages
+            timestamp:
+                # The timestamp format string
+                format: YYYY.MM.DD-HH:mm:ss.SSS
+        # Lists the targets (winston transports)
+        targets:
+            console:
+                target: console # Defines a console target
+                enabled: true # Enables the target
+                options: # These are passed to the winston console target as-is
+                    level: info
+            # Defines a target with debug level
+            file:
+                target: file
+                enabled: true
+                options:
+                    level: debug
+                    filename: caliper.log
+                    maxSize: 5m
+                    zippedArchive: false
+                    options:
+                        flags: a
+                        mode: 0666
 
     # Caliper flow options
     flow:

--- a/packages/caliper-core/lib/utils/caliper-utils.js
+++ b/packages/caliper-core/lib/utils/caliper-utils.js
@@ -49,13 +49,12 @@ class CaliperUtils {
     /**
      * Returns a logger configured with the given module name.
      * @param {string} name The name of module who will use the logger.
-     * @param {winston.LoggerInstance} parentLogger Optional. The logger of the parent module. Defaults to the global Caliper logger.
-     * @returns {winston.LoggerInstance} The configured logger instance.
+     * @returns {Logger} The configured logger instance.
      */
-    static getLogger(name, parentLogger) {
+    static getLogger(name) {
         // logger should be accessed through the Util class
         // but delegates to logging-util.js
-        return loggingUtil.getLogger(name, parentLogger);
+        return loggingUtil.getLogger(name);
     }
 
     /**

--- a/packages/caliper-core/package.json
+++ b/packages/caliper-core/package.json
@@ -23,7 +23,6 @@
     "dockerode": "^2.5.0",
     "fs-extra": "^8.0.1",
     "js-yaml": "^3.12.0",
-    "moment": "^2.22.2",
     "mustache": "^2.3.0",
     "nconf": "^0.10.0",
     "nconf-yaml": "^1.0.2",
@@ -33,8 +32,8 @@
     "request": "^2.81.0",
     "systeminformation": "^3.23.7",
     "table": "^4.0.1",
-    "winston": "^2.4.4",
-    "winston-daily-rotate-file": "^3.5.1"
+    "winston": "^3.2.1",
+    "winston-daily-rotate-file": "^4.2.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/packages/caliper-sawtooth/.gitignore
+++ b/packages/caliper-sawtooth/.gitignore
@@ -19,6 +19,7 @@ zookeeper.out
 .idea/
 **/node_modules/
 **/log/
+*.log
 
 # Ignore any composer logs
 composer-logs/


### PR DESCRIPTION
Signed-off-by: Attila Klenik <a.klenik@gmail.com>

Resolves #581 
The PR includes:
1. Changing to winston 3.X, to utilize the new formats feature
2. Restructure the logging section of the runtime settings
    1. Keep implementation-specific options separated for target transports
    2. Make targets easy to disable/enable
    3. Make logging style easily configurable
    4. Provide a message structure template
3. Related docs in other PR