### PR TITLE
Make report file path configurable

### DIFF
--- a/packages/caliper-core/lib/caliper-flow.js
+++ b/packages/caliper-core/lib/caliper-flow.js
@@ -23,7 +23,6 @@ const DefaultTest = require('./test-runners/default-test');
 const TestObserver = require('./test-observers/test-observer');
 const BenchValidator = require('./utils/benchmark-validator');
 
-const path = require('path');
 const logger = CaliperUtils.getLogger('caliper-flow');
 
 /**
@@ -120,9 +119,7 @@ module.exports.run = async function(absConfigFile, absNetworkFile, admin, client
             report.printResultsByRound();
             await monitorOrchestrator.stopAllMonitors();
 
-            const date = new Date().toISOString().replace(/-/g,'').replace(/:/g,'').substr(0,15);
-            const outFile = path.join(process.cwd(), `report-${date}.html`);
-            await report.finalize(outFile);
+            await report.finalize();
 
             clientOrchestrator.stop();
 

--- a/packages/caliper-core/lib/config/Config.js
+++ b/packages/caliper-core/lib/config/Config.js
@@ -27,6 +27,10 @@ const keys = {
         Args: 'caliper-bind-args',
         Cwd: 'caliper-bind-cwd'
     },
+    Report: {
+        Path: 'caliper-report-path',
+        Options: 'caliper-report-options'
+    },
     Workspace: 'caliper-workspace',
     ProjectConfig: 'caliper-projectconfig',
     UserConfig: 'caliper-userconfig',

--- a/packages/caliper-core/lib/config/default.yaml
+++ b/packages/caliper-core/lib/config/default.yaml
@@ -23,6 +23,14 @@ caliper:
         cwd:
         # The additional args to pass to the binding (i.e., npm install) command
         args:
+    # Report file-related options
+    report:
+        # The absolute or workspace-relative path of the report file.
+        path: 'report.html'
+        # The options to pass to fs.writeFile
+        options:
+            flag: 'w'
+            mode: 0666
     # Workspace directory that contains all configuration information
     workspace: './'
     # The file path for the project-level configuration file. Can be relative to the workspace.

--- a/packages/caliper-core/lib/report/report-builder.js
+++ b/packages/caliper-core/lib/report/report-builder.js
@@ -15,7 +15,9 @@
 
 'use strict';
 
-const Logger = require('../utils/caliper-utils').getLogger('caliper-flow');
+const Config = require('../config/config-util');
+const Utils = require('../utils/caliper-utils');
+const Logger = Utils.getLogger('caliper-flow');
 const fs = require('fs');
 const Mustache = require('mustache');
 const path = require('path');
@@ -285,15 +287,18 @@ class ReportBuilder {
 
     /**
     * generate a HTML report for the benchmark
-    * @param {String} output filename of the output
     * @async
     */
-    async generate(output) {
+    async generate() {
         let templateStr = fs.readFileSync(this.template).toString();
         let html = Mustache.render(templateStr, this.data);
         try {
-            await fs.writeFileSync(output, html);
-            Logger.info(`Generated report with path ${output}`);
+            let filePath = Config.get(Config.keys.Report.Path, 'report.html');
+            filePath = Utils.resolvePath(filePath, Config.get(Config.keys.Workspace, './'));
+            let writeOptions = Config.get(Config.keys.Report.Options, { flag: 'w', mode: 0o666 });
+
+            await fs.writeFileSync(filePath, html, writeOptions);
+            Logger.info(`Generated report with path ${filePath}`);
         } catch (err) {
             Logger.info(`Failed to generate report, with error ${err}`);
             throw err;

--- a/packages/caliper-core/lib/report/report.js
+++ b/packages/caliper-core/lib/report/report.js
@@ -347,11 +347,10 @@ class Report {
 
     /**
      * Print the generated report to file
-     * @param {string} outFile the name of the file to write
      * @async
      */
-    async finalize(outFile) {
-        await this.reportBuilder.generate(outFile);
+    async finalize() {
+        await this.reportBuilder.generate();
     }
 }
 

--- a/packages/caliper-core/lib/utils/caliper-utils.js
+++ b/packages/caliper-core/lib/utils/caliper-utils.js
@@ -74,7 +74,7 @@ class CaliperUtils {
             return relOrAbsPath;
         }
 
-        return path.join(root_path, relOrAbsPath);
+        return path.resolve(root_path, relOrAbsPath);
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Attila Klenik <a.klenik@gmail.com>

Resolves #597 
The PR makes the reporting path configurable through the usual runtime config mechanism. Plus exposes the file access settings, which can come in handy when the container executes Caliper as root.