### PR TITLE
Add multi-phase Fabric CI test

### DIFF
--- a/packages/caliper-tests-integration/.dockerignore
+++ b/packages/caliper-tests-integration/.dockerignore
@@ -16,5 +16,6 @@
 scripts/*
 node_modules/*
 log/*
+fabric_tests/*
 caliper.Dockerfile
 package.json

--- a/packages/caliper-tests-integration/fabric_tests/.gitignore
+++ b/packages/caliper-tests-integration/fabric_tests/.gitignore
@@ -1,0 +1,2 @@
+**/*.log
+report.html

--- a/packages/caliper-tests-integration/fabric_tests/caliper.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/caliper.yaml
@@ -1,0 +1,47 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+caliper:
+    benchconfig: benchconfig.yaml
+    networkconfig: networkconfig.yaml
+    report:
+        path: ../report.html
+    logging:
+        template: '%timestamp%%level%%module%%message%%metadata%'
+        formats:
+            timestamp: 'YYYY.MM.DD-HH:mm:ss.SSS ZZ'
+            label: false
+            json: false
+            pad: true
+            align: false
+            attributeformat:
+                level: ' %attribute%'
+                module: ' [%attribute%] '
+                metadata: ' (%attribute%)'
+            colorize:
+                all: true
+                colors:
+                    info: green
+                    error: red
+                    warn: yellow
+                    debug: grey
+        targets:
+            console:
+                target: console
+                enabled: true
+                options:
+                    level: debug
+            file:
+                target: file
+                enabled: false

--- a/packages/caliper-tests-integration/fabric_tests/config/.gitignore
+++ b/packages/caliper-tests-integration/fabric_tests/config/.gitignore
@@ -1,0 +1,5 @@
+bin/*
+config/*
+crypto-config/*
+genesis.block
+mychannel.tx

--- a/packages/caliper-tests-integration/fabric_tests/config/configtx.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/config/configtx.yaml
@@ -1,0 +1,92 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+
+Organizations:
+- &OrdererOrg
+    Name: OrdererMSP
+    ID: OrdererMSP
+    MSPDir: crypto-config/ordererOrganizations/example.com/msp
+    AdminPrincipal: Role.MEMBER
+
+- &Org1
+    Name: Org1MSP
+    ID: Org1MSP
+    MSPDir: crypto-config/peerOrganizations/org1.example.com/msp
+    AdminPrincipal: Role.ADMIN
+    AnchorPeers:
+    - Host: peer0.org1.example.com
+      Port: 7051
+
+- &Org2
+    Name: Org2MSP
+    ID: Org2MSP
+    MSPDir: crypto-config/peerOrganizations/org2.example.com/msp
+    AdminPrincipal: Role.ADMIN
+    AnchorPeers:
+    - Host: peer0.org2.example.com
+      Port: 7051
+
+Orderer: &OrdererDefaults
+    OrdererType: etcdraft
+    Addresses:
+    - orderer0.example.com:7050
+    - orderer1.example.com:7050
+
+    BatchTimeout: 500ms
+    BatchSize:
+        MaxMessageCount: 50
+        AbsoluteMaxBytes: 1 MB
+        PreferredMaxBytes: 1 MB
+
+    MaxChannels: 0
+    EtcdRaft:
+        Consenters:
+        - Host: orderer0.example.com
+          Port: 7050
+          ClientTLSCert: crypto-config/ordererOrganizations/example.com/orderers/orderer0.example.com/tls/server.crt
+          ServerTLSCert: crypto-config/ordererOrganizations/example.com/orderers/orderer0.example.com/tls/server.crt
+        - Host: orderer1.example.com
+          Port: 7050
+          ClientTLSCert: crypto-config/ordererOrganizations/example.com/orderers/orderer1.example.com/tls/server.crt
+          ServerTLSCert: crypto-config/ordererOrganizations/example.com/orderers/orderer1.example.com/tls/server.crt
+
+    Organizations:
+
+Application: &ApplicationDefaults
+    Organizations:
+
+Profiles:
+    OrdererGenesis:
+        Orderer:
+            <<: *OrdererDefaults
+            Organizations:
+            - *OrdererOrg
+        Consortiums:
+            SampleConsortium:
+                Organizations:
+                - *Org1
+                - *Org2
+            SampleConsortium2:
+                Organizations:
+                - *Org1
+                - *Org2
+    ChannelConfig:
+        Consortium: SampleConsortium
+        Application:
+            <<: *ApplicationDefaults
+            Organizations:
+            - *Org1
+            - *Org2

--- a/packages/caliper-tests-integration/fabric_tests/config/crypto-config.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/config/crypto-config.yaml
@@ -1,4 +1,3 @@
-#!/bin/bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,20 +12,25 @@
 # limitations under the License.
 #
 
-# Exit on first error, print all commands.
-set -e
-set -o pipefail
 
-# Bootstrap the project again
-npm i && npm run repoclean -- --yes && npm run bootstrap
+OrdererOrgs:
+- Name: Orderer
+  Domain: example.com
 
-# Run linting, license check and unit tests
-npm test
+  Template:
+      Count: 2
 
-# Call CLI directly
-# The CWD will be in one of the caliper-tests-integration/*-tests directories
-export CALL_METHOD="node ../caliper-cli/caliper.js"
+PeerOrgs:
+- Name: Org1
+  Domain: org1.example.com
+  Template:
+      Count: 1
+  Users:
+      Count: 1
 
-echo "---- Running Integration test for adaptor ${BENCHMARK}"
-cd ./packages/caliper-tests-integration/
-npm run run_tests
+- Name: Org2
+  Domain: org2.example.com
+  Template:
+      Count: 1
+  Users:
+      Count: 1

--- a/packages/caliper-tests-integration/fabric_tests/config/generate.sh
+++ b/packages/caliper-tests-integration/fabric_tests/config/generate.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# if the binaries are not available, download them
+if [[ ! -d "bin" ]]; then
+  curl -sSL http://bit.ly/2ysbOFE | bash -s -- 1.4.1 1.4.1 0.4.15 -ds
+fi
+
+rm -rf ./crypto-config/
+rm -f ./genesis.block
+rm -f ./mychannel.tx
+
+./bin/cryptogen generate --config=./crypto-config.yaml
+./bin/configtxgen -profile OrdererGenesis -outputBlock genesis.block -channelID syschannel
+./bin/configtxgen -profile ChannelConfig -outputCreateChannelTx mychannel.tx -channelID mychannel
+
+# Rename the key files we use to be key.pem instead of a uuid
+for KEY in $(find crypto-config -type f -name "*_sk"); do
+    KEY_DIR=$(dirname ${KEY})
+    mv ${KEY} ${KEY_DIR}/key.pem
+done

--- a/packages/caliper-tests-integration/fabric_tests/docker-compose.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/docker-compose.yaml
@@ -1,0 +1,301 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: '3'
+
+volumes:
+    prometheus_data: {}
+    grafana_storage: {}
+
+services:
+
+#######
+# CAs #
+#######
+
+    ca.org1.example.com:
+        image: hyperledger/fabric-ca:1.4.1
+        environment:
+        - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
+        - FABRIC_CA_SERVER_CA_NAME=ca.org1.example.com
+        - FABRIC_CA_SERVER_CA_CERTFILE=/etc/hyperledger/fabric-ca-server-config/ca.org1.example.com-cert.pem
+        - FABRIC_CA_SERVER_CA_KEYFILE=/etc/hyperledger/fabric-ca-server-config/key.pem
+        # TLS
+        - FABRIC_CA_SERVER_TLS_ENABLED=true
+        - FABRIC_CA_SERVER_TLS_CERTFILE=/etc/hyperledger/fabric-ca-server-tls/tlsca.org1.example.com-cert.pem
+        - FABRIC_CA_SERVER_TLS_KEYFILE=/etc/hyperledger/fabric-ca-server-tls/key.pem
+        ports:
+        - "7054:7054"
+        command: sh -c 'fabric-ca-server start -b admin:adminpw -d'
+        volumes:
+        - ./config/crypto-config/peerOrganizations/org1.example.com/ca/:/etc/hyperledger/fabric-ca-server-config
+        - ./config/crypto-config/peerOrganizations/org1.example.com/tlsca/:/etc/hyperledger/fabric-ca-server-tls
+        container_name: ca.org1.example.com
+
+    ca.org2.example.com:
+        image: hyperledger/fabric-ca:1.4.1
+        environment:
+        - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
+        - FABRIC_CA_SERVER_CA_NAME=ca.org2.example.com
+        - FABRIC_CA_SERVER_CA_CERTFILE=/etc/hyperledger/fabric-ca-server-config/ca.org2.example.com-cert.pem
+        - FABRIC_CA_SERVER_CA_KEYFILE=/etc/hyperledger/fabric-ca-server-config/key.pem
+        # TLS
+        - FABRIC_CA_SERVER_TLS_ENABLED=true
+        - FABRIC_CA_SERVER_TLS_CERTFILE=/etc/hyperledger/fabric-ca-server-tls/tlsca.org2.example.com-cert.pem
+        - FABRIC_CA_SERVER_TLS_KEYFILE=/etc/hyperledger/fabric-ca-server-tls/key.pem
+        ports:
+        - "8054:7054"
+        command: sh -c 'fabric-ca-server start -b admin:adminpw -d'
+        volumes:
+        - ./config/crypto-config/peerOrganizations/org2.example.com/ca/:/etc/hyperledger/fabric-ca-server-config
+        - ./config/crypto-config/peerOrganizations/org2.example.com/tlsca/:/etc/hyperledger/fabric-ca-server-tls
+        container_name: ca.org2.example.com
+
+############
+# ORDERERS #
+############
+
+    orderer0.example.com:
+        container_name: orderer0.example.com
+        image: hyperledger/fabric-orderer:1.4.1
+        environment:
+        - FABRIC_LOGGING_SPEC=info
+        - ORDERER_GENERAL_LISTENADDRESS=0.0.0.0
+        - ORDERER_GENERAL_GENESISMETHOD=file
+        - ORDERER_GENERAL_GENESISFILE=/etc/hyperledger/configtx/genesis.block
+        - ORDERER_GENERAL_LOCALMSPID=OrdererMSP
+        - ORDERER_GENERAL_LOCALMSPDIR=/etc/hyperledger/msp/orderer/msp
+        # TLS
+        - ORDERER_GENERAL_TLS_ENABLED=true
+        - ORDERER_GENERAL_TLS_PRIVATEKEY=/etc/hyperledger/msp/orderer/tls/server.key
+        - ORDERER_GENERAL_TLS_CERTIFICATE=/etc/hyperledger/msp/orderer/tls/server.crt
+        - ORDERER_GENERAL_TLS_ROOTCAS=[/etc/hyperledger/msp/orderer/tls/ca.crt]
+        # Mutual TLS
+        - ORDERER_GENERAL_TLS_CLIENTAUTHREQUIRED=true
+        - ORDERER_GENERAL_TLS_CLIENTROOTCAS=[/etc/hyperledger/msp/caOrg1/ca.org1.example.com-cert.pem, /etc/hyperledger/msp/caOrg2/ca.org2.example.com-cert.pem, /etc/hyperledger/msp/caOrderer/ca.example.com-cert.pem]
+        # Raft TLS
+        - ORDERER_GENERAL_CLUSTER_CLIENTCERTIFICATE=/etc/hyperledger/msp/orderer/tls/server.crt
+        - ORDERER_GENERAL_CLUSTER_CLIENTPRIVATEKEY=/etc/hyperledger/msp/orderer/tls/server.key
+        # setting up metrics
+        - ORDERER_OPERATIONS_LISTENADDRESS=0.0.0.0:9000
+        - ORDERER_OPERATIONS_TLS_ENABLED=false
+        - ORDERER_METRICS_ENABLE=true
+        - ORDERER_METRICS_PROVIDER=prometheus
+        working_dir: /opt/gopath/src/github.com/hyperledger/fabric
+        command: orderer
+        ports:
+        - 7050:7050
+        volumes:
+        - ./config/:/etc/hyperledger/configtx
+        - ./config/crypto-config/ordererOrganizations/example.com/orderers/orderer0.example.com/:/etc/hyperledger/msp/orderer
+        - ./config/crypto-config/peerOrganizations/org1.example.com/ca/:/etc/hyperledger/msp/caOrg1
+        - ./config/crypto-config/peerOrganizations/org2.example.com/ca/:/etc/hyperledger/msp/caOrg2
+        - ./config/crypto-config/ordererOrganizations/example.com/ca/:/etc/hyperledger/msp/caOrderer
+        depends_on:
+        - ca.org1.example.com
+        - ca.org2.example.com
+
+    orderer1.example.com:
+        container_name: orderer1.example.com
+        image: hyperledger/fabric-orderer:1.4.1
+        environment:
+        - FABRIC_LOGGING_SPEC=info
+        - ORDERER_GENERAL_LISTENADDRESS=0.0.0.0
+        - ORDERER_GENERAL_GENESISMETHOD=file
+        - ORDERER_GENERAL_GENESISFILE=/etc/hyperledger/configtx/genesis.block
+        - ORDERER_GENERAL_LOCALMSPID=OrdererMSP
+        - ORDERER_GENERAL_LOCALMSPDIR=/etc/hyperledger/msp/orderer/msp
+        # TLS
+        - ORDERER_GENERAL_TLS_ENABLED=true
+        - ORDERER_GENERAL_TLS_PRIVATEKEY=/etc/hyperledger/msp/orderer/tls/server.key
+        - ORDERER_GENERAL_TLS_CERTIFICATE=/etc/hyperledger/msp/orderer/tls/server.crt
+        - ORDERER_GENERAL_TLS_ROOTCAS=[/etc/hyperledger/msp/orderer/tls/ca.crt]
+        # Mutual TLS
+        - ORDERER_GENERAL_TLS_CLIENTAUTHREQUIRED=true
+        - ORDERER_GENERAL_TLS_CLIENTROOTCAS=[/etc/hyperledger/msp/caOrg1/ca.org1.example.com-cert.pem, /etc/hyperledger/msp/caOrg2/ca.org2.example.com-cert.pem, /etc/hyperledger/msp/caOrderer/ca.example.com-cert.pem]
+        # Raft TLS
+        - ORDERER_GENERAL_CLUSTER_CLIENTCERTIFICATE=/etc/hyperledger/msp/orderer/tls/server.crt
+        - ORDERER_GENERAL_CLUSTER_CLIENTPRIVATEKEY=/etc/hyperledger/msp/orderer/tls/server.key
+        # setting up metrics
+        - ORDERER_OPERATIONS_LISTENADDRESS=0.0.0.0:9000
+        - ORDERER_OPERATIONS_TLS_ENABLED=false
+        - ORDERER_METRICS_ENABLE=true
+        - ORDERER_METRICS_PROVIDER=prometheus
+        working_dir: /opt/gopath/src/github.com/hyperledger/fabric
+        command: orderer
+        ports:
+        - 8050:7050
+        volumes:
+        - ./config/:/etc/hyperledger/configtx
+        - ./config/crypto-config/ordererOrganizations/example.com/orderers/orderer1.example.com/:/etc/hyperledger/msp/orderer
+        - ./config/crypto-config/peerOrganizations/org1.example.com/ca/:/etc/hyperledger/msp/caOrg1
+        - ./config/crypto-config/peerOrganizations/org2.example.com/ca/:/etc/hyperledger/msp/caOrg2
+        - ./config/crypto-config/ordererOrganizations/example.com/ca/:/etc/hyperledger/msp/caOrderer
+        depends_on:
+        - ca.org1.example.com
+        - ca.org2.example.com
+
+#########
+# PEERS #
+#########
+
+    peer0.org1.example.com:
+        container_name: peer0.org1.example.com
+        image: hyperledger/fabric-peer:1.4.1
+        environment:
+        - FABRIC_LOGGING_SPEC=info
+        - CORE_CHAINCODE_LOGGING_LEVEL=INFO
+        - CORE_CHAINCODE_LOGGING_SHIM=INFO
+        - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
+        - CORE_PEER_ID=peer0.org1.example.com
+        - CORE_PEER_ENDORSER_ENABLED=true
+        - CORE_PEER_LOCALMSPID=Org1MSP
+        - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/peer/msp/
+        - CORE_PEER_ADDRESS=peer0.org1.example.com:7051
+        - CORE_PEER_GOSSIP_USELEADERELECTION=true
+        - CORE_PEER_GOSSIP_ORGLEADER=false
+        - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer0.org1.example.com:7051
+        - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=caliper_default
+        # CouchDB
+        - CORE_LEDGER_STATE_STATEDATABASE=CouchDB
+        - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=couchdb.peer0.org1.example.com:5984
+        # TLS
+        - CORE_PEER_TLS_ENABLED=true
+        - CORE_PEER_TLS_KEY_FILE=/etc/hyperledger/msp/peer/tls/server.key
+        - CORE_PEER_TLS_CERT_FILE=/etc/hyperledger/msp/peer/tls/server.crt
+        - CORE_PEER_TLS_ROOTCERT_FILE=/etc/hyperledger/msp/peer/tls/ca.crt
+        # Mutual TLS
+        - CORE_PEER_TLS_CLIENTAUTHREQUIRED=true
+        - CORE_PEER_TLS_CLIENTROOTCAS_FILES=/etc/hyperledger/msp/caOrg1/ca.org1.example.com-cert.pem /etc/hyperledger/msp/caOrg2/ca.org2.example.com-cert.pem /etc/hyperledger/msp/caOrderer/ca.example.com-cert.pem
+        # setting up metrics
+        - CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:9000
+        - CORE_OPERATIONS_TLS_ENABLED=false
+        - CORE_METRICS_ENABLE=true
+        - CORE_METRICS_PROVIDER=prometheus
+        working_dir: /opt/gopath/src/github.com/hyperledger/fabric
+        command: peer node start
+        ports:
+        - 7051:7051
+        volumes:
+        - /var/run/:/host/var/run/
+        - ./config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/:/etc/hyperledger/msp/peer
+        - ./config/crypto-config/peerOrganizations/org1.example.com/ca/:/etc/hyperledger/msp/caOrg1
+        - ./config/crypto-config/peerOrganizations/org2.example.com/ca/:/etc/hyperledger/msp/caOrg2
+        - ./config/crypto-config/ordererOrganizations/example.com/ca/:/etc/hyperledger/msp/caOrderer
+        depends_on:
+        - orderer0.example.com
+        - orderer1.example.com
+        - couchdb.peer0.org1.example.com
+
+    couchdb.peer0.org1.example.com:
+        container_name: couchdb.peer0.org1.example.com
+        image: hyperledger/fabric-couchdb:0.4.14
+        ports:
+        - 5984:5984
+        environment:
+            DB_URL: http://localhost:5984/member_db
+
+    peer0.org2.example.com:
+        container_name: peer0.org2.example.com
+        image: hyperledger/fabric-peer:1.4.1
+        environment:
+        - FABRIC_LOGGING_SPEC=info
+        - CORE_CHAINCODE_LOGGING_LEVEL=INFO
+        - CORE_CHAINCODE_LOGGING_SHIM=INFO
+        - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
+        - CORE_PEER_ID=peer0.org2.example.com
+        - CORE_PEER_ENDORSER_ENABLED=true
+        - CORE_PEER_LOCALMSPID=Org2MSP
+        - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/peer/msp/
+        - CORE_PEER_ADDRESS=peer0.org2.example.com:7051
+        - CORE_PEER_GOSSIP_USELEADERELECTION=true
+        - CORE_PEER_GOSSIP_ORGLEADER=false
+        - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer0.org2.example.com:7051
+        - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=caliper_default
+        # CouchDB
+        - CORE_LEDGER_STATE_STATEDATABASE=CouchDB
+        - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=couchdb.peer0.org2.example.com:5984
+        # TLS
+        - CORE_PEER_TLS_ENABLED=true
+        - CORE_PEER_TLS_KEY_FILE=/etc/hyperledger/msp/peer/tls/server.key
+        - CORE_PEER_TLS_CERT_FILE=/etc/hyperledger/msp/peer/tls/server.crt
+        - CORE_PEER_TLS_ROOTCERT_FILE=/etc/hyperledger/msp/peer/tls/ca.crt
+        # Mutual TLS
+        - CORE_PEER_TLS_CLIENTAUTHREQUIRED=true
+        - CORE_PEER_TLS_CLIENTROOTCAS_FILES=/etc/hyperledger/msp/caOrg1/ca.org1.example.com-cert.pem /etc/hyperledger/msp/caOrg2/ca.org2.example.com-cert.pem /etc/hyperledger/msp/caOrderer/ca.example.com-cert.pem
+        # setting up metrics
+        - CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:9000
+        - CORE_OPERATIONS_TLS_ENABLED=false
+        - CORE_METRICS_ENABLE=true
+        - CORE_METRICS_PROVIDER=prometheus
+        working_dir: /opt/gopath/src/github.com/hyperledger/fabric
+        command: peer node start
+        ports:
+        - 8051:7051
+        volumes:
+        - /var/run/:/host/var/run/
+        - ./config/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/:/etc/hyperledger/msp/peer
+        - ./config/crypto-config/peerOrganizations/org1.example.com/ca/:/etc/hyperledger/msp/caOrg1
+        - ./config/crypto-config/peerOrganizations/org2.example.com/ca/:/etc/hyperledger/msp/caOrg2
+        - ./config/crypto-config/ordererOrganizations/example.com/ca/:/etc/hyperledger/msp/caOrderer
+        depends_on:
+        - orderer0.example.com
+        - orderer1.example.com
+        - couchdb.peer0.org2.example.com
+
+    couchdb.peer0.org2.example.com:
+        container_name: couchdb.peer0.org2.example.com
+        image: hyperledger/fabric-couchdb:0.4.14
+        ports:
+        - 6984:5984
+        environment:
+            DB_URL: http://localhost:5984/member_db
+
+##############
+# MONITORING #
+##############
+
+    prometheus:
+        image: prom/prometheus
+        container_name: prometheus
+        volumes:
+        - ./prometheus/prometheus-fabric.yml:/etc/prometheus/prometheus.yml
+        - prometheus_data:/prometheus
+        command:
+        - '--config.file=/etc/prometheus/prometheus.yml'
+        - '--storage.tsdb.path=/prometheus'
+        - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+        - '--web.console.templates=/usr/share/prometheus/consoles'
+        ports:
+        - "9090:9090"
+        depends_on:
+          - peer0.org2.example.com
+          - peer0.org1.example.com
+
+    pushGateway:
+        image: prom/pushgateway
+        container_name: pushGateway
+        ports:
+        - "9091:9091"
+
+    cadvisor:
+        image: google/cadvisor
+        container_name: cadvisor
+        volumes:
+        - /var/run:/var/run:rw
+        - /sys:/sys:ro
+        - /var/lib/docker/:/var/lib/docker:ro
+        ports:
+        - 8080:8080
+        restart: always

--- a/packages/caliper-tests-integration/fabric_tests/init.js
+++ b/packages/caliper-tests-integration/fabric_tests/init.js
@@ -1,0 +1,47 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+
+
+module.exports.info  = 'Creating marbles.';
+
+let txIndex = 0;
+let colors = ['red', 'blue', 'green', 'black', 'white', 'pink', 'rainbow'];
+let owners = ['Alice', 'Bob', 'Claire', 'David'];
+let bc, contx;
+
+module.exports.init = async function(blockchain, context, args) {
+    bc = blockchain;
+    contx = context;
+};
+
+module.exports.run = async function() {
+    txIndex++;
+    let marbleName = 'marble_' + txIndex.toString() + '_' + process.pid.toString();
+    let marbleColor = colors[txIndex % colors.length];
+    let marbleSize = (((txIndex % 10) + 1) * 10).toString(); // [10, 100]
+    let marbleOwner = owners[txIndex % owners.length];
+
+    let args = {
+        chaincodeFunction: 'initMarble',
+        chaincodeArguments: [marbleName, marbleColor, marbleSize, marbleOwner],
+    };
+
+    let targetCC = txIndex % 2 === 0 ? 'mymarbles' : 'yourmarbles';
+    return bc.invokeSmartContract(contx, targetCC, 'v0', args, 5);
+};
+
+module.exports.end = async function() {};

--- a/packages/caliper-tests-integration/fabric_tests/phase1/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase1/benchconfig.yaml
@@ -1,0 +1,38 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+test:
+    clients:
+        type: local
+        number: 2
+    rounds:
+    - label: init1
+      txNumber: [100]
+      rateControl: [{ type: 'fixed-rate', opts: { tps: 20 } }]
+      callback: ../init.js
+    - label: init2
+      txNumber: [200]
+      rateControl: [{ type: 'fixed-feedback-rate', opts: { tps: 20, unfinished_per_client: 5 } }]
+      callback: ../init.js
+    - label: query
+      txNumber: [100]
+      rateControl: [{ type: 'linear-rate', opts: { startingTps: 10, finishingTps: 20 } }]
+      callback: ../query.js
+observer:
+    interval: 1
+    type: none
+monitor:
+    interval: 1
+    type: ['none']

--- a/packages/caliper-tests-integration/fabric_tests/phase1/networkconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase1/networkconfig.yaml
@@ -1,4 +1,3 @@
-#!/bin/bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,20 +12,10 @@
 # limitations under the License.
 #
 
-# Exit on first error, print all commands.
-set -e
-set -o pipefail
+name: Fabric
+version: "1.0"
 
-# Bootstrap the project again
-npm i && npm run repoclean -- --yes && npm run bootstrap
-
-# Run linting, license check and unit tests
-npm test
-
-# Call CLI directly
-# The CWD will be in one of the caliper-tests-integration/*-tests directories
-export CALL_METHOD="node ../caliper-cli/caliper.js"
-
-echo "---- Running Integration test for adaptor ${BENCHMARK}"
-cd ./packages/caliper-tests-integration/
-npm run run_tests
+caliper:
+    blockchain: fabric
+    command:
+        start: docker-compose -p caliper up -d;rm -rf /tmp/hfc-*;sleep 5s

--- a/packages/caliper-tests-integration/fabric_tests/phase2/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase2/benchconfig.yaml
@@ -1,0 +1,39 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+test:
+    clients:
+        type: local
+        number: 2
+    rounds:
+    - label: init1
+      txNumber: [100]
+      rateControl: [{ type: 'fixed-rate', opts: { tps: 20 } }]
+      callback: ../init.js
+    - label: init2
+      txNumber: [200]
+      rateControl: [{ type: 'fixed-feedback-rate', opts: { tps: 20, unfinished_per_client: 5 } }]
+      callback: ../init.js
+    - label: query
+      txNumber: [100]
+      rateControl: [{ type: 'linear-rate', opts: { startingTps: 10, finishingTps: 20 } }]
+      callback: ../query.js
+observer:
+    interval: 1
+    type: local
+monitor:
+    interval: 1
+    type: ['process']
+    process: [{ command: 'node', arguments: 'fabricClientWorker.js', multiOutput: 'avg' }]

--- a/packages/caliper-tests-integration/fabric_tests/phase2/networkconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase2/networkconfig.yaml
@@ -1,0 +1,162 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Fabric
+version: "1.0"
+mutual-tls: true
+
+caliper:
+    blockchain: fabric
+
+clients:
+    client0.org1.example.com:
+        client:
+            organization: Org1
+            credentialStore:
+                path: /tmp/hfc-kvs/org1
+                cryptoStore:
+                    path: /tmp/hfc-cvs/org1
+            clientPrivateKey:
+                path: ../config/crypto-config/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp/keystore/key.pem
+            clientSignedCert:
+                path: ../config/crypto-config/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp/signcerts/User1@org1.example.com-cert.pem
+
+    client0.org2.example.com:
+        client:
+            organization: Org2
+            credentialStore:
+                path: /tmp/hfc-kvs/org2
+                cryptoStore:
+                    path: /tmp/hfc-cvs/org2
+            clientPrivateKey:
+                path: ../config/crypto-config/peerOrganizations/org2.example.com/users/User1@org2.example.com/msp/keystore/key.pem
+            clientSignedCert:
+                path: ../config/crypto-config/peerOrganizations/org2.example.com/users/User1@org2.example.com/msp/signcerts/User1@org2.example.com-cert.pem
+
+channels:
+    mychannel:
+        created: false
+        configBinary: ../config/mychannel.tx
+        orderers:
+        - orderer0.example.com
+        - orderer1.example.com
+        peers:
+            peer0.org1.example.com:
+                eventSource: true
+            peer0.org2.example.com:
+                eventSource: true
+        chaincodes:
+        - id: marbles
+          contractID: mymarbles
+          version: v0
+          language: node
+          path: src/marbles/node
+          metadataPath: src/marbles/node/metadata
+    yourchannel:
+        created: false
+        definition:
+            capabilities: []
+            consortium: 'SampleConsortium2'
+            msps: ['Org1MSP', 'Org2MSP']
+            version: 0
+        orderers:
+        - orderer0.example.com
+        - orderer1.example.com
+        peers:
+            peer0.org1.example.com:
+                eventSource: true
+            peer0.org2.example.com:
+                eventSource: true
+        chaincodes:
+        - id: marbles
+          contractID: yourmarbles
+          version: v0
+          language: golang
+          path: marbles/go
+          metadataPath: src/marbles/go/metadata
+
+organizations:
+    Org1:
+        mspid: Org1MSP
+        peers:
+        - peer0.org1.example.com
+        certificateAuthorities:
+        - ca.org1.example.com
+        adminPrivateKey:
+            path: ../config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem
+        signedCert:
+            path: ../config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem
+
+    Org2:
+        mspid: Org2MSP
+        peers:
+        - peer0.org2.example.com
+        certificateAuthorities:
+        - ca.org2.example.com
+        adminPrivateKey:
+            path: ../config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem
+        signedCert:
+            path: ../config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem
+
+orderers:
+    orderer0.example.com:
+        url: grpcs://localhost:7050
+        grpcOptions:
+            ssl-target-name-override: orderer0.example.com
+        tlsCACerts:
+            path: ../config/crypto-config/ordererOrganizations/example.com/orderers/orderer0.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
+    orderer1.example.com:
+        url: grpcs://localhost:8050
+        grpcOptions:
+            ssl-target-name-override: orderer1.example.com
+        tlsCACerts:
+            path: ../config/crypto-config/ordererOrganizations/example.com/orderers/orderer1.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
+
+peers:
+    peer0.org1.example.com:
+        url: grpcs://localhost:7051
+        grpcOptions:
+            ssl-target-name-override: peer0.org1.example.com
+            grpc.keepalive_time_ms: 600000
+        tlsCACerts:
+            path: ../config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp/tlscacerts/tlsca.org1.example.com-cert.pem
+
+    peer0.org2.example.com:
+        url: grpcs://localhost:8051
+        grpcOptions:
+            ssl-target-name-override: peer0.org2.example.com
+            grpc.keepalive_time_ms: 600000
+        tlsCACerts:
+            path: ../config/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/msp/tlscacerts/tlsca.org2.example.com-cert.pem
+
+certificateAuthorities:
+    ca.org1.example.com:
+        url: https://localhost:7054
+        httpOptions:
+            verify: false
+        tlsCACerts:
+            path: ../config/crypto-config/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem
+        registrar:
+        - enrollId: admin
+          enrollSecret: adminpw
+
+    ca.org2.example.com:
+        url: https://localhost:8054
+        httpOptions:
+            verify: false
+        tlsCACerts:
+            path: ../config/crypto-config/peerOrganizations/org2.example.com/tlsca/tlsca.org2.example.com-cert.pem
+        registrar:
+        - enrollId: admin
+          enrollSecret: adminpw

--- a/packages/caliper-tests-integration/fabric_tests/phase3/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase3/benchconfig.yaml
@@ -1,0 +1,41 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+test:
+    clients:
+        type: local
+        number: 2
+    rounds:
+    - label: init1
+      txNumber: [100]
+      rateControl: [{ type: 'fixed-rate', opts: { tps: 20 } }]
+      callback: ../init.js
+    - label: init2
+      txNumber: [200]
+      rateControl: [{ type: 'fixed-feedback-rate', opts: { tps: 20, unfinished_per_client: 5 } }]
+      callback: ../init.js
+    - label: query
+      txNumber: [100]
+      rateControl: [{ type: 'linear-rate', opts: { startingTps: 10, finishingTps: 20 } }]
+      callback: ../query.js
+observer:
+    interval: 1
+    type: local
+monitor:
+    interval: 1
+    type: ['process', 'docker']
+    process: [{ command: 'node', arguments: 'fabricClientWorker.js', multiOutput: 'avg' }]
+    docker:
+        name: ['peer0.org1.example.com', 'peer0.org2.example.com', 'orderer0.example.com', 'orderer1.example.com']

--- a/packages/caliper-tests-integration/fabric_tests/phase3/networkconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase3/networkconfig.yaml
@@ -1,0 +1,158 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Fabric
+version: "1.0"
+mutual-tls: true
+
+caliper:
+    blockchain: fabric
+
+clients:
+    client0.org1.example.com:
+        client:
+            organization: Org1
+            credentialStore:
+                path: /tmp/hfc-kvs/org1
+                cryptoStore:
+                    path: /tmp/hfc-cvs/org1
+            clientPrivateKey:
+                path: ../config/crypto-config/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp/keystore/key.pem
+            clientSignedCert:
+                path: ../config/crypto-config/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp/signcerts/User1@org1.example.com-cert.pem
+
+    client0.org2.example.com:
+        client:
+            organization: Org2
+            credentialStore:
+                path: /tmp/hfc-kvs/org2
+                cryptoStore:
+                    path: /tmp/hfc-cvs/org2
+            clientPrivateKey:
+                path: ../config/crypto-config/peerOrganizations/org2.example.com/users/User1@org2.example.com/msp/keystore/key.pem
+            clientSignedCert:
+                path: ../config/crypto-config/peerOrganizations/org2.example.com/users/User1@org2.example.com/msp/signcerts/User1@org2.example.com-cert.pem
+
+channels:
+    mychannel:
+        created: true
+        orderers:
+        - orderer0.example.com
+        - orderer1.example.com
+        peers:
+            peer0.org1.example.com:
+                eventSource: true
+            peer0.org2.example.com:
+                eventSource: true
+
+        chaincodes:
+        - id: marbles
+          contractID: mymarbles
+          version: v0
+          language: node
+          path: src/marbles/node
+          metadataPath: src/marbles/node/metadata
+    yourchannel:
+        created: true
+        orderers:
+        - orderer0.example.com
+        - orderer1.example.com
+        peers:
+            peer0.org1.example.com:
+                eventSource: true
+            peer0.org2.example.com:
+                eventSource: true
+
+        chaincodes:
+        - id: marbles
+          contractID: yourmarbles
+          version: v0
+          language: golang
+          path: marbles/go
+          metadataPath: src/marbles/go/metadata
+
+organizations:
+    Org1:
+        mspid: Org1MSP
+        peers:
+        - peer0.org1.example.com
+        certificateAuthorities:
+        - ca.org1.example.com
+        adminPrivateKey:
+            path: ../config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem
+        signedCert:
+            path: ../config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem
+
+    Org2:
+        mspid: Org2MSP
+        peers:
+        - peer0.org2.example.com
+        certificateAuthorities:
+        - ca.org2.example.com
+        adminPrivateKey:
+            path: ../config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem
+        signedCert:
+            path: ../config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem
+
+orderers:
+    orderer0.example.com:
+        url: grpcs://localhost:7050
+        grpcOptions:
+            ssl-target-name-override: orderer0.example.com
+        tlsCACerts:
+            path: ../config/crypto-config/ordererOrganizations/example.com/orderers/orderer0.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
+    orderer1.example.com:
+        url: grpcs://localhost:8050
+        grpcOptions:
+            ssl-target-name-override: orderer1.example.com
+        tlsCACerts:
+            path: ../config/crypto-config/ordererOrganizations/example.com/orderers/orderer1.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
+
+peers:
+    peer0.org1.example.com:
+        url: grpcs://localhost:7051
+        grpcOptions:
+            ssl-target-name-override: peer0.org1.example.com
+            grpc.keepalive_time_ms: 600000
+        tlsCACerts:
+            path: ../config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp/tlscacerts/tlsca.org1.example.com-cert.pem
+
+    peer0.org2.example.com:
+        url: grpcs://localhost:8051
+        grpcOptions:
+            ssl-target-name-override: peer0.org2.example.com
+            grpc.keepalive_time_ms: 600000
+        tlsCACerts:
+            path: ../config/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/msp/tlscacerts/tlsca.org2.example.com-cert.pem
+
+certificateAuthorities:
+    ca.org1.example.com:
+        url: https://localhost:7054
+        httpOptions:
+            verify: false
+        tlsCACerts:
+            path: ../config/crypto-config/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem
+        registrar:
+        - enrollId: admin
+          enrollSecret: adminpw
+
+    ca.org2.example.com:
+        url: https://localhost:8054
+        httpOptions:
+            verify: false
+        tlsCACerts:
+            path: ../config/crypto-config/peerOrganizations/org2.example.com/tlsca/tlsca.org2.example.com-cert.pem
+        registrar:
+        - enrollId: admin
+          enrollSecret: adminpw

--- a/packages/caliper-tests-integration/fabric_tests/phase3/src/marbles/go/marbles.go
+++ b/packages/caliper-tests-integration/fabric_tests/phase3/src/marbles/go/marbles.go
@@ -1,0 +1,652 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/*
+* NOTE: This implementation is a replica of the following:
+* https://github.com/hyperledger/fabric-samples/blob/release-1.1/chaincode/marbles02/node/marbles_chaincode.js
+*/
+
+// ====CHAINCODE EXECUTION SAMPLES (CLI) ==================
+
+// ==== Invoke marbles ====
+// peer chaincode invoke -C myc1 -n marbles -c '{"Args":["initMarble","marble1","blue","35","tom"]}'
+// peer chaincode invoke -C myc1 -n marbles -c '{"Args":["initMarble","marble2","red","50","tom"]}'
+// peer chaincode invoke -C myc1 -n marbles -c '{"Args":["initMarble","marble3","blue","70","tom"]}'
+// peer chaincode invoke -C myc1 -n marbles -c '{"Args":["transferMarble","marble2","jerry"]}'
+// peer chaincode invoke -C myc1 -n marbles -c '{"Args":["transferMarblesBasedOnColor","blue","jerry"]}'
+// peer chaincode invoke -C myc1 -n marbles -c '{"Args":["delete","marble1"]}'
+
+// ==== Query marbles ====
+// peer chaincode query -C myc1 -n marbles -c '{"Args":["readMarble","marble1"]}'
+// peer chaincode query -C myc1 -n marbles -c '{"Args":["getMarblesByRange","marble1","marble3"]}'
+// peer chaincode query -C myc1 -n marbles -c '{"Args":["getHistoryForMarble","marble1"]}'
+
+// Rich Query (Only supported if CouchDB is used as state database):
+//   peer chaincode query -C myc1 -n marbles -c '{"Args":["queryMarblesByOwner","tom"]}'
+//   peer chaincode query -C myc1 -n marbles -c '{"Args":["queryMarbles","{\"selector\":{\"owner\":\"tom\"}}"]}'
+
+// INDEXES TO SUPPORT COUCHDB RICH QUERIES
+//
+// Indexes in CouchDB are required in order to make JSON queries efficient and are required for
+// any JSON query with a sort. As of Hyperledger Fabric 1.1, indexes may be packaged alongside
+// chaincode in a META-INF/statedb/couchdb/indexes directory. Each index must be defined in its own
+// text file with extension *.json with the index definition formatted in JSON following the
+// CouchDB index JSON syntax as documented at:
+// http://docs.couchdb.org/en/2.1.1/api/database/find.html#db-index
+//
+// This marbles02 example chaincode demonstrates a packaged
+// index which you can find in META-INF/statedb/couchdb/indexes/indexOwner.json.
+// For deployment of chaincode to production environments, it is recommended
+// to define any indexes alongside chaincode so that the chaincode and supporting indexes
+// are deployed automatically as a unit, once the chaincode has been installed on a peer and
+// instantiated on a channel. See Hyperledger Fabric documentation for more details.
+//
+// If you have access to the your peer's CouchDB state database in a development environment,
+// you may want to iteratively test various indexes in support of your chaincode queries.  You
+// can use the CouchDB Fauxton interface or a command line curl utility to create and update
+// indexes. Then once you finalize an index, include the index definition alongside your
+// chaincode in the META-INF/statedb/couchdb/indexes directory, for packaging and deployment
+// to managed environments.
+//
+// In the examples below you can find index definitions that support marbles02
+// chaincode queries, along with the syntax that you can use in development environments
+// to create the indexes in the CouchDB Fauxton interface or a curl command line utility.
+//
+
+//Example hostname:port configurations to access CouchDB.
+//
+//To access CouchDB docker container from within another docker container or from vagrant environments:
+// http://couchdb:5984/
+//
+//Inside couchdb docker container
+// http://127.0.0.1:5984/
+
+// Index for docType, owner.
+// Note that docType and owner fields must be prefixed with the "data" wrapper
+//
+// Index definition for use with Fauxton interface
+// {"index":{"fields":["data.docType","data.owner"]},"ddoc":"indexOwnerDoc", "name":"indexOwner","type":"json"}
+//
+// Example curl command line to define index in the CouchDB channel_chaincode database
+// curl -i -X POST -H "Content-Type: application/json" -d "{\"index\":{\"fields\":[\"data.docType\",\"data.owner\"]},\"name\":\"indexOwner\",\"ddoc\":\"indexOwnerDoc\",\"type\":\"json\"}" http://hostname:port/myc1_marbles/_index
+//
+
+// Index for docType, owner, size (descending order).
+// Note that docType, owner and size fields must be prefixed with the "data" wrapper
+//
+// Index definition for use with Fauxton interface
+// {"index":{"fields":[{"data.size":"desc"},{"data.docType":"desc"},{"data.owner":"desc"}]},"ddoc":"indexSizeSortDoc", "name":"indexSizeSortDesc","type":"json"}
+//
+// Example curl command line to define index in the CouchDB channel_chaincode database
+// curl -i -X POST -H "Content-Type: application/json" -d "{\"index\":{\"fields\":[{\"data.size\":\"desc\"},{\"data.docType\":\"desc\"},{\"data.owner\":\"desc\"}]},\"ddoc\":\"indexSizeSortDoc\", \"name\":\"indexSizeSortDesc\",\"type\":\"json\"}" http://hostname:port/myc1_marbles/_index
+
+// Rich Query with index design doc and index name specified (Only supported if CouchDB is used as state database):
+//   peer chaincode query -C myc1 -n marbles -c '{"Args":["queryMarbles","{\"selector\":{\"docType\":\"marble\",\"owner\":\"tom\"}, \"use_index\":[\"_design/indexOwnerDoc\", \"indexOwner\"]}"]}'
+
+// Rich Query with index design doc specified only (Only supported if CouchDB is used as state database):
+//   peer chaincode query -C myc1 -n marbles -c '{"Args":["queryMarbles","{\"selector\":{\"docType\":{\"$eq\":\"marble\"},\"owner\":{\"$eq\":\"tom\"},\"size\":{\"$gt\":0}},\"fields\":[\"docType\",\"owner\",\"size\"],\"sort\":[{\"size\":\"desc\"}],\"use_index\":\"_design/indexSizeSortDoc\"}"]}'
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+	pb "github.com/hyperledger/fabric/protos/peer"
+)
+
+// SimpleChaincode example simple Chaincode implementation
+type SimpleChaincode struct {
+}
+
+type marble struct {
+	ObjectType string `json:"docType"` //docType is used to distinguish the various types of objects in state database
+	Name       string `json:"name"`    //the fieldtags are needed to keep case from bouncing around
+	Color      string `json:"color"`
+	Size       int    `json:"size"`
+	Owner      string `json:"owner"`
+}
+
+// ===================================================================================
+// Main
+// ===================================================================================
+func main() {
+	err := shim.Start(new(SimpleChaincode))
+	if err != nil {
+		fmt.Printf("Error starting Simple chaincode: %s", err)
+	}
+}
+
+// Init initializes chaincode
+// ===========================
+func (t *SimpleChaincode) Init(stub shim.ChaincodeStubInterface) pb.Response {
+	return shim.Success(nil)
+}
+
+// Invoke - Our entry point for Invocations
+// ========================================
+func (t *SimpleChaincode) Invoke(stub shim.ChaincodeStubInterface) pb.Response {
+	function, args := stub.GetFunctionAndParameters()
+	fmt.Println("invoke is running " + function)
+
+	// Handle different functions
+	if function == "initMarble" { //create a new marble
+		return t.initMarble(stub, args)
+	} else if function == "transferMarble" { //change owner of a specific marble
+		return t.transferMarble(stub, args)
+	} else if function == "transferMarblesBasedOnColor" { //transfer all marbles of a certain color
+		return t.transferMarblesBasedOnColor(stub, args)
+	} else if function == "delete" { //delete a marble
+		return t.delete(stub, args)
+	} else if function == "readMarble" { //read a marble
+		return t.readMarble(stub, args)
+	} else if function == "queryMarblesByOwner" { //find marbles for owner X using rich query
+		return t.queryMarblesByOwner(stub, args)
+	} else if function == "queryMarbles" { //find marbles based on an ad hoc rich query
+		return t.queryMarbles(stub, args)
+	} else if function == "getHistoryForMarble" { //get history of values for a marble
+		return t.getHistoryForMarble(stub, args)
+	} else if function == "getMarblesByRange" { //get marbles based on range query
+		return t.getMarblesByRange(stub, args)
+	}
+
+	fmt.Println("invoke did not find func: " + function) //error
+	return shim.Error("Received unknown function invocation")
+}
+
+// ============================================================
+// initMarble - create a new marble, store into chaincode state
+// ============================================================
+func (t *SimpleChaincode) initMarble(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+	var err error
+
+	//   0       1       2     3
+	// "asdf", "blue", "35", "bob"
+	if len(args) != 4 {
+		return shim.Error("Incorrect number of arguments. Expecting 4")
+	}
+
+	// ==== Input sanitation ====
+	fmt.Println("- start init marble")
+	if len(args[0]) <= 0 {
+		return shim.Error("1st argument must be a non-empty string")
+	}
+	if len(args[1]) <= 0 {
+		return shim.Error("2nd argument must be a non-empty string")
+	}
+	if len(args[2]) <= 0 {
+		return shim.Error("3rd argument must be a non-empty string")
+	}
+	if len(args[3]) <= 0 {
+		return shim.Error("4th argument must be a non-empty string")
+	}
+	marbleName := args[0]
+	color := strings.ToLower(args[1])
+	owner := strings.ToLower(args[3])
+	size, err := strconv.Atoi(args[2])
+	if err != nil {
+		return shim.Error("3rd argument must be a numeric string")
+	}
+
+	// ==== Check if marble already exists ====
+	marbleAsBytes, err := stub.GetState(marbleName)
+	if err != nil {
+		return shim.Error("Failed to get marble: " + err.Error())
+	} else if marbleAsBytes != nil {
+		fmt.Println("This marble already exists: " + marbleName)
+		return shim.Error("This marble already exists: " + marbleName)
+	}
+
+	// ==== Create marble object and marshal to JSON ====
+	objectType := "marble"
+	marble := &marble{objectType, marbleName, color, size, owner}
+	marbleJSONasBytes, err := json.Marshal(marble)
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+	//Alternatively, build the marble json string manually if you don't want to use struct marshalling
+	//marbleJSONasString := `{"docType":"Marble",  "name": "` + marbleName + `", "color": "` + color + `", "size": ` + strconv.Itoa(size) + `, "owner": "` + owner + `"}`
+	//marbleJSONasBytes := []byte(str)
+
+	// === Save marble to state ===
+	err = stub.PutState(marbleName, marbleJSONasBytes)
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+
+	//  ==== Index the marble to enable color-based range queries, e.g. return all blue marbles ====
+	//  An 'index' is a normal key/value entry in state.
+	//  The key is a composite key, with the elements that you want to range query on listed first.
+	//  In our case, the composite key is based on indexName~color~name.
+	//  This will enable very efficient state range queries based on composite keys matching indexName~color~*
+	indexName := "color~name"
+	colorNameIndexKey, err := stub.CreateCompositeKey(indexName, []string{marble.Color, marble.Name})
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+	//  Save index entry to state. Only the key name is needed, no need to store a duplicate copy of the marble.
+	//  Note - passing a 'nil' value will effectively delete the key from state, therefore we pass null character as value
+	value := []byte{0x00}
+	stub.PutState(colorNameIndexKey, value)
+
+	// ==== Marble saved and indexed. Return success ====
+	fmt.Println("- end init marble")
+	return shim.Success(nil)
+}
+
+// ===============================================
+// readMarble - read a marble from chaincode state
+// ===============================================
+func (t *SimpleChaincode) readMarble(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+	var name, jsonResp string
+	var err error
+
+	if len(args) != 1 {
+		return shim.Error("Incorrect number of arguments. Expecting name of the marble to query")
+	}
+
+	name = args[0]
+	valAsbytes, err := stub.GetState(name) //get the marble from chaincode state
+	if err != nil {
+		jsonResp = "{\"Error\":\"Failed to get state for " + name + "\"}"
+		return shim.Error(jsonResp)
+	} else if valAsbytes == nil {
+		jsonResp = "{\"Error\":\"Marble does not exist: " + name + "\"}"
+		return shim.Error(jsonResp)
+	}
+
+	return shim.Success(valAsbytes)
+}
+
+// ==================================================
+// delete - remove a marble key/value pair from state
+// ==================================================
+func (t *SimpleChaincode) delete(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+	var jsonResp string
+	var marbleJSON marble
+	if len(args) != 1 {
+		return shim.Error("Incorrect number of arguments. Expecting 1")
+	}
+	marbleName := args[0]
+
+	// to maintain the color~name index, we need to read the marble first and get its color
+	valAsbytes, err := stub.GetState(marbleName) //get the marble from chaincode state
+	if err != nil {
+		jsonResp = "{\"Error\":\"Failed to get state for " + marbleName + "\"}"
+		return shim.Error(jsonResp)
+	} else if valAsbytes == nil {
+		jsonResp = "{\"Error\":\"Marble does not exist: " + marbleName + "\"}"
+		return shim.Error(jsonResp)
+	}
+
+	err = json.Unmarshal([]byte(valAsbytes), &marbleJSON)
+	if err != nil {
+		jsonResp = "{\"Error\":\"Failed to decode JSON of: " + marbleName + "\"}"
+		return shim.Error(jsonResp)
+	}
+
+	err = stub.DelState(marbleName) //remove the marble from chaincode state
+	if err != nil {
+		return shim.Error("Failed to delete state:" + err.Error())
+	}
+
+	// maintain the index
+	indexName := "color~name"
+	colorNameIndexKey, err := stub.CreateCompositeKey(indexName, []string{marbleJSON.Color, marbleJSON.Name})
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+
+	//  Delete index entry to state.
+	err = stub.DelState(colorNameIndexKey)
+	if err != nil {
+		return shim.Error("Failed to delete state:" + err.Error())
+	}
+	return shim.Success(nil)
+}
+
+// ===========================================================
+// transfer a marble by setting a new owner name on the marble
+// ===========================================================
+func (t *SimpleChaincode) transferMarble(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+
+	//   0       1
+	// "name", "bob"
+	if len(args) < 2 {
+		return shim.Error("Incorrect number of arguments. Expecting 2")
+	}
+
+	marbleName := args[0]
+	newOwner := strings.ToLower(args[1])
+	fmt.Println("- start transferMarble ", marbleName, newOwner)
+
+	marbleAsBytes, err := stub.GetState(marbleName)
+	if err != nil {
+		return shim.Error("Failed to get marble:" + err.Error())
+	} else if marbleAsBytes == nil {
+		return shim.Error("Marble does not exist")
+	}
+
+	marbleToTransfer := marble{}
+	err = json.Unmarshal(marbleAsBytes, &marbleToTransfer) //unmarshal it aka JSON.parse()
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+	marbleToTransfer.Owner = newOwner //change the owner
+
+	marbleJSONasBytes, _ := json.Marshal(marbleToTransfer)
+	err = stub.PutState(marbleName, marbleJSONasBytes) //rewrite the marble
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+
+	fmt.Println("- end transferMarble (success)")
+	return shim.Success(nil)
+}
+
+// ===========================================================================================
+// getMarblesByRange performs a range query based on the start and end keys provided.
+
+// Read-only function results are not typically submitted to ordering. If the read-only
+// results are submitted to ordering, or if the query is used in an update transaction
+// and submitted to ordering, then the committing peers will re-execute to guarantee that
+// result sets are stable between endorsement time and commit time. The transaction is
+// invalidated by the committing peers if the result set has changed between endorsement
+// time and commit time.
+// Therefore, range queries are a safe option for performing update transactions based on query results.
+// ===========================================================================================
+func (t *SimpleChaincode) getMarblesByRange(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+
+	if len(args) < 2 {
+		return shim.Error("Incorrect number of arguments. Expecting 2")
+	}
+
+	startKey := args[0]
+	endKey := args[1]
+
+	resultsIterator, err := stub.GetStateByRange(startKey, endKey)
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+	defer resultsIterator.Close()
+
+	// buffer is a JSON array containing QueryResults
+	var buffer bytes.Buffer
+	buffer.WriteString("[")
+
+	bArrayMemberAlreadyWritten := false
+	for resultsIterator.HasNext() {
+		queryResponse, err := resultsIterator.Next()
+		if err != nil {
+			return shim.Error(err.Error())
+		}
+		// Add a comma before array members, suppress it for the first array member
+		if bArrayMemberAlreadyWritten == true {
+			buffer.WriteString(",")
+		}
+		buffer.WriteString("{\"Key\":")
+		buffer.WriteString("\"")
+		buffer.WriteString(queryResponse.Key)
+		buffer.WriteString("\"")
+
+		buffer.WriteString(", \"Record\":")
+		// Record is a JSON object, so we write as-is
+		buffer.WriteString(string(queryResponse.Value))
+		buffer.WriteString("}")
+		bArrayMemberAlreadyWritten = true
+	}
+	buffer.WriteString("]")
+
+	fmt.Printf("- getMarblesByRange queryResult:\n%s\n", buffer.String())
+
+	return shim.Success(buffer.Bytes())
+}
+
+// ==== Example: GetStateByPartialCompositeKey/RangeQuery =========================================
+// transferMarblesBasedOnColor will transfer marbles of a given color to a certain new owner.
+// Uses a GetStateByPartialCompositeKey (range query) against color~name 'index'.
+// Committing peers will re-execute range queries to guarantee that result sets are stable
+// between endorsement time and commit time. The transaction is invalidated by the
+// committing peers if the result set has changed between endorsement time and commit time.
+// Therefore, range queries are a safe option for performing update transactions based on query results.
+// ===========================================================================================
+func (t *SimpleChaincode) transferMarblesBasedOnColor(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+
+	//   0       1
+	// "color", "bob"
+	if len(args) < 2 {
+		return shim.Error("Incorrect number of arguments. Expecting 2")
+	}
+
+	color := args[0]
+	newOwner := strings.ToLower(args[1])
+	fmt.Println("- start transferMarblesBasedOnColor ", color, newOwner)
+
+	// Query the color~name index by color
+	// This will execute a key range query on all keys starting with 'color'
+	coloredMarbleResultsIterator, err := stub.GetStateByPartialCompositeKey("color~name", []string{color})
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+	defer coloredMarbleResultsIterator.Close()
+
+	// Iterate through result set and for each marble found, transfer to newOwner
+	var i int
+	for i = 0; coloredMarbleResultsIterator.HasNext(); i++ {
+		// Note that we don't get the value (2nd return variable), we'll just get the marble name from the composite key
+		responseRange, err := coloredMarbleResultsIterator.Next()
+		if err != nil {
+			return shim.Error(err.Error())
+		}
+
+		// get the color and name from color~name composite key
+		objectType, compositeKeyParts, err := stub.SplitCompositeKey(responseRange.Key)
+		if err != nil {
+			return shim.Error(err.Error())
+		}
+		returnedColor := compositeKeyParts[0]
+		returnedMarbleName := compositeKeyParts[1]
+		fmt.Printf("- found a marble from index:%s color:%s name:%s\n", objectType, returnedColor, returnedMarbleName)
+
+		// Now call the transfer function for the found marble.
+		// Re-use the same function that is used to transfer individual marbles
+		response := t.transferMarble(stub, []string{returnedMarbleName, newOwner})
+		// if the transfer failed break out of loop and return error
+		if response.Status != shim.OK {
+			return shim.Error("Transfer failed: " + response.Message)
+		}
+	}
+
+	responsePayload := fmt.Sprintf("Transferred %d %s marbles to %s", i, color, newOwner)
+	fmt.Println("- end transferMarblesBasedOnColor: " + responsePayload)
+	return shim.Success([]byte(responsePayload))
+}
+
+// =======Rich queries =========================================================================
+// Two examples of rich queries are provided below (parameterized query and ad hoc query).
+// Rich queries pass a query string to the state database.
+// Rich queries are only supported by state database implementations
+//  that support rich query (e.g. CouchDB).
+// The query string is in the syntax of the underlying state database.
+// With rich queries there is no guarantee that the result set hasn't changed between
+//  endorsement time and commit time, aka 'phantom reads'.
+// Therefore, rich queries should not be used in update transactions, unless the
+// application handles the possibility of result set changes between endorsement and commit time.
+// Rich queries can be used for point-in-time queries against a peer.
+// ============================================================================================
+
+// ===== Example: Parameterized rich query =================================================
+// queryMarblesByOwner queries for marbles based on a passed in owner.
+// This is an example of a parameterized query where the query logic is baked into the chaincode,
+// and accepting a single query parameter (owner).
+// Only available on state databases that support rich query (e.g. CouchDB)
+// =========================================================================================
+func (t *SimpleChaincode) queryMarblesByOwner(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+
+	//   0
+	// "bob"
+	if len(args) < 1 {
+		return shim.Error("Incorrect number of arguments. Expecting 1")
+	}
+
+	owner := strings.ToLower(args[0])
+
+	queryString := fmt.Sprintf("{\"selector\":{\"docType\":\"marble\",\"owner\":\"%s\"}}", owner)
+
+	queryResults, err := getQueryResultForQueryString(stub, queryString)
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+	return shim.Success(queryResults)
+}
+
+// ===== Example: Ad hoc rich query ========================================================
+// queryMarbles uses a query string to perform a query for marbles.
+// Query string matching state database syntax is passed in and executed as is.
+// Supports ad hoc queries that can be defined at runtime by the client.
+// If this is not desired, follow the queryMarblesForOwner example for parameterized queries.
+// Only available on state databases that support rich query (e.g. CouchDB)
+// =========================================================================================
+func (t *SimpleChaincode) queryMarbles(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+
+	//   0
+	// "queryString"
+	if len(args) < 1 {
+		return shim.Error("Incorrect number of arguments. Expecting 1")
+	}
+
+	queryString := args[0]
+
+	queryResults, err := getQueryResultForQueryString(stub, queryString)
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+	return shim.Success(queryResults)
+}
+
+// =========================================================================================
+// getQueryResultForQueryString executes the passed in query string.
+// Result set is built and returned as a byte array containing the JSON results.
+// =========================================================================================
+func getQueryResultForQueryString(stub shim.ChaincodeStubInterface, queryString string) ([]byte, error) {
+
+	fmt.Printf("- getQueryResultForQueryString queryString:\n%s\n", queryString)
+
+	resultsIterator, err := stub.GetQueryResult(queryString)
+	if err != nil {
+		return nil, err
+	}
+	defer resultsIterator.Close()
+
+	// buffer is a JSON array containing QueryRecords
+	var buffer bytes.Buffer
+	buffer.WriteString("[")
+
+	bArrayMemberAlreadyWritten := false
+	for resultsIterator.HasNext() {
+		queryResponse, err := resultsIterator.Next()
+		if err != nil {
+			return nil, err
+		}
+		// Add a comma before array members, suppress it for the first array member
+		if bArrayMemberAlreadyWritten == true {
+			buffer.WriteString(",")
+		}
+		buffer.WriteString("{\"Key\":")
+		buffer.WriteString("\"")
+		buffer.WriteString(queryResponse.Key)
+		buffer.WriteString("\"")
+
+		buffer.WriteString(", \"Record\":")
+		// Record is a JSON object, so we write as-is
+		buffer.WriteString(string(queryResponse.Value))
+		buffer.WriteString("}")
+		bArrayMemberAlreadyWritten = true
+	}
+	buffer.WriteString("]")
+
+	fmt.Printf("- getQueryResultForQueryString queryResult:\n%s\n", buffer.String())
+
+	return buffer.Bytes(), nil
+}
+
+func (t *SimpleChaincode) getHistoryForMarble(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+
+	if len(args) < 1 {
+		return shim.Error("Incorrect number of arguments. Expecting 1")
+	}
+
+	marbleName := args[0]
+
+	fmt.Printf("- start getHistoryForMarble: %s\n", marbleName)
+
+	resultsIterator, err := stub.GetHistoryForKey(marbleName)
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+	defer resultsIterator.Close()
+
+	// buffer is a JSON array containing historic values for the marble
+	var buffer bytes.Buffer
+	buffer.WriteString("[")
+
+	bArrayMemberAlreadyWritten := false
+	for resultsIterator.HasNext() {
+		response, err := resultsIterator.Next()
+		if err != nil {
+			return shim.Error(err.Error())
+		}
+		// Add a comma before array members, suppress it for the first array member
+		if bArrayMemberAlreadyWritten == true {
+			buffer.WriteString(",")
+		}
+		buffer.WriteString("{\"TxId\":")
+		buffer.WriteString("\"")
+		buffer.WriteString(response.TxId)
+		buffer.WriteString("\"")
+
+		buffer.WriteString(", \"Value\":")
+		// if it was a delete operation on given key, then we need to set the
+		//corresponding value null. Else, we will write the response.Value
+		//as-is (as the Value itself a JSON marble)
+		if response.IsDelete {
+			buffer.WriteString("null")
+		} else {
+			buffer.WriteString(string(response.Value))
+		}
+
+		buffer.WriteString(", \"Timestamp\":")
+		buffer.WriteString("\"")
+		buffer.WriteString(time.Unix(response.Timestamp.Seconds, int64(response.Timestamp.Nanos)).String())
+		buffer.WriteString("\"")
+
+		buffer.WriteString(", \"IsDelete\":")
+		buffer.WriteString("\"")
+		buffer.WriteString(strconv.FormatBool(response.IsDelete))
+		buffer.WriteString("\"")
+
+		buffer.WriteString("}")
+		bArrayMemberAlreadyWritten = true
+	}
+	buffer.WriteString("]")
+
+	fmt.Printf("- getHistoryForMarble returning:\n%s\n", buffer.String())
+
+	return shim.Success(buffer.Bytes())
+}

--- a/packages/caliper-tests-integration/fabric_tests/phase3/src/marbles/go/metadata/statedb/couchdb/indexes/indexOwner.json
+++ b/packages/caliper-tests-integration/fabric_tests/phase3/src/marbles/go/metadata/statedb/couchdb/indexes/indexOwner.json
@@ -1,0 +1,1 @@
+{"index":{"fields":["docType","owner"]},"ddoc":"indexOwnerDoc", "name":"indexOwner","type":"json"}

--- a/packages/caliper-tests-integration/fabric_tests/phase3/src/marbles/node/marbles.js
+++ b/packages/caliper-tests-integration/fabric_tests/phase3/src/marbles/node/marbles.js
@@ -1,0 +1,486 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/*
+* NOTE: This implementation is a derivative work of the following:
+* https://github.com/hyperledger/fabric-samples/blob/release-1.1/chaincode/marbles02/node/marbles_chaincode.js
+* The modifications include: bug fixes and refactoring for eslint compliance.
+*/
+
+/* eslint-disable no-console */
+
+'use strict';
+const shim = require('fabric-shim');
+const util = require('util');
+
+/**
+ * Marble asset management chaincode written in node.js, implementing {@link ChaincodeInterface}.
+ * @type {SimpleChaincode}
+ * @extends {ChaincodeInterface}
+ */
+let Chaincode = class {
+    /**
+     * Called during chaincode instantiate and upgrade. This method can be used
+     * to initialize asset states.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub is implemented by the fabric-shim
+     * library and passed to the {@link ChaincodeInterface} calls by the Hyperledger Fabric platform. The stub
+     * encapsulates the APIs between the chaincode implementation and the Fabric peer.
+     * @return {Promise<SuccessResponse>} Returns a promise of a response indicating the result of the invocation.
+     */
+    async Init(stub) {
+        let ret = stub.getFunctionAndParameters();
+        console.info(ret);
+        console.info('=========== Instantiated Marbles Chaincode ===========');
+        return shim.success();
+    }
+
+    /**
+     * Called throughout the life time of the chaincode to carry out business
+     * transaction logic and effect the asset states.
+     * The provided functions are the following: initMarble, delete, transferMarble, readMarble, getMarblesByRange,
+     * transferMarblesBasedOnColor, queryMarblesByOwner, queryMarbles, getHistoryForMarble.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub is implemented by the fabric-shim
+     * library and passed to the {@link ChaincodeInterface} calls by the Hyperledger Fabric platform. The stub
+     * encapsulates the APIs between the chaincode implementation and the Fabric peer.
+     * @return {Promise<SuccessResponse | ErrorResponse>} Returns a promise of a response indicating the result of the invocation.
+     */
+    async Invoke(stub) {
+        console.info('Transaction ID: ' + stub.getTxID());
+        console.info(util.format('Args: %j', stub.getArgs()));
+
+        let ret = stub.getFunctionAndParameters();
+        console.info(ret);
+
+        let method = this[ret.fcn];
+        if (!method) {
+            console.log('no function of name:' + ret.fcn + ' found');
+            throw new Error('Received unknown function ' + ret.fcn + ' invocation');
+        }
+        try {
+            let payload = await method(stub, ret.params, this);
+            return shim.success(payload);
+        } catch (err) {
+            console.log(err);
+            return shim.error(err);
+        }
+    }
+
+    /**
+     * Creates a new marble with the given attributes.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub.
+     * @param {String[]} args The arguments of the function. Index 0: marble name. Index 1: marble color.
+     * Index 2: marble size. Index 3: marble owner.
+     */
+    async initMarble(stub, args) {
+        if (args.length !== 4) {
+            throw new Error('Incorrect number of arguments. Expecting 4');
+        }
+        // ==== Input sanitation ====
+        console.info('--- start init marble ---');
+        if (args[0].length <= 0) {
+            throw new Error('1st argument must be a non-empty string');
+        }
+        if (args[1].length <= 0) {
+            throw new Error('2nd argument must be a non-empty string');
+        }
+        if (args[2].length <= 0) {
+            throw new Error('3rd argument must be a non-empty string');
+        }
+        if (args[3].length <= 0) {
+            throw new Error('4th argument must be a non-empty string');
+        }
+        let marbleName = args[0];
+        let color = args[1].toLowerCase();
+        let owner = args[3].toLowerCase();
+        let size = parseInt(args[2]);
+        if (isNaN(size)) {
+            throw new Error('3rd argument must be a numeric string');
+        }
+
+        // ==== Check if marble already exists ====
+        let marbleState = await stub.getState(marbleName);
+        if (marbleState.toString()) {
+            throw new Error('This marble already exists: ' + marbleName);
+        }
+
+        // ==== Create marble object and marshal to JSON ====
+        let marble = {};
+        marble.docType = 'marble';
+        marble.name = marbleName;
+        marble.color = color;
+        marble.size = size;
+        marble.owner = owner;
+
+        // === Save marble to state ===
+        await stub.putState(marbleName, Buffer.from(JSON.stringify(marble)));
+        let indexName = 'color~name';
+        let colorNameIndexKey = await stub.createCompositeKey(indexName, [marble.color, marble.name]);
+        console.info(colorNameIndexKey);
+        //  Save index entry to state. Only the key name is needed, no need to store a duplicate copy of the marble.
+        //  Note - passing a 'nil' value will effectively delete the key from state, therefore we pass null character as value
+        await stub.putState(colorNameIndexKey, Buffer.from('\u0000'));
+        // ==== Marble saved and indexed. Return success ====
+        console.info('- end init marble');
+    }
+
+    /**
+     * Retrieves the information about a marble.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub.
+     * @param {String[]} args The arguments of the function. Index 0: marble name.
+     * @return {Promise<Object[]>} The byte representation of the marble.
+     */
+    async readMarble(stub, args) {
+        if (args.length !== 1) {
+            throw new Error('Incorrect number of arguments. Expecting name of the marble to query');
+        }
+
+        let name = args[0];
+        if (!name) {
+            throw new Error(' marble name must not be empty');
+        }
+        let marbleAsBytes = await stub.getState(name); //get the marble from chaincode state
+        if (!marbleAsBytes.toString()) {
+            let jsonResp = {};
+            jsonResp.Error = 'Marble does not exist: ' + name;
+            throw new Error(JSON.stringify(jsonResp));
+        }
+        console.info('=======================================');
+        console.log(marbleAsBytes.toString());
+        console.info('=======================================');
+        return marbleAsBytes;
+    }
+
+    /**
+     * Deletes the given marble.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub.
+     * @param {String[]} args The arguments of the function. Index 0: marble name.
+     */
+    async delete(stub, args) {
+        if (args.length !== 1) {
+            throw new Error('Incorrect number of arguments. Expecting name of the marble to delete');
+        }
+        let marbleName = args[0];
+        if (!marbleName) {
+            throw new Error('marble name must not be empty');
+        }
+        // to maintain the color~name index, we need to read the marble first and get its color
+        let valAsBytes = await stub.getState(marbleName); //get the marble from chaincode state
+        let jsonResp = {};
+        if (!valAsBytes) {
+            jsonResp.error = 'marble does not exist: ' + marbleName;
+            throw new Error(jsonResp);
+        }
+        let marbleJSON = {};
+        try {
+            marbleJSON = JSON.parse(valAsBytes.toString());
+        } catch (err) {
+            jsonResp = {};
+            jsonResp.error = 'Failed to decode JSON of: ' + marbleName;
+            throw new Error(jsonResp);
+        }
+
+        await stub.deleteState(marbleName); //remove the marble from chaincode state
+
+        // delete the index
+        let indexName = 'color~name';
+        let colorNameIndexKey = stub.createCompositeKey(indexName, [marbleJSON.color, marbleJSON.name]);
+        if (!colorNameIndexKey) {
+            throw new Error(' Failed to create the createCompositeKey');
+        }
+        //  Delete index entry to state.
+        await stub.deleteState(colorNameIndexKey);
+    }
+
+    // ===========================================================
+    // transfer a marble by setting a new owner name on the marble
+    // ===========================================================
+    /**
+     * Transfers the given marble to a new owner.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub.
+     * @param {String[]} args The arguments of the function. Index 0: marble name. Index 1: the new owner.
+     */
+    async transferMarble(stub, args) {
+        if (args.length !== 2) {
+            throw new Error('Incorrect number of arguments. Expecting marble name and owner');
+        }
+
+        let marbleName = args[0];
+        let newOwner = args[1].toLowerCase();
+        console.info('- start transferMarble ', marbleName, newOwner);
+
+        let marbleAsBytes = await stub.getState(marbleName);
+        if (!marbleAsBytes || !marbleAsBytes.toString()) {
+            throw new Error('marble does not exist');
+        }
+        let marbleToTransfer = {};
+        try {
+            marbleToTransfer = JSON.parse(marbleAsBytes.toString()); //unmarshal
+        } catch (err) {
+            let jsonResp = {};
+            jsonResp.error = 'Failed to decode JSON of: ' + marbleName;
+            throw new Error(jsonResp);
+        }
+        console.info(marbleToTransfer);
+        marbleToTransfer.owner = newOwner; //change the owner
+
+        let marbleJSONasBytes = Buffer.from(JSON.stringify(marbleToTransfer));
+        await stub.putState(marbleName, marbleJSONasBytes); //rewrite the marble
+
+        console.info('- end transferMarble (success)');
+    }
+
+    /**
+     * Performs a range query based on the start and end keys provided.
+     *
+     * Read-only function results are not typically submitted to ordering. If the read-only
+     * results are submitted to ordering, or if the query is used in an update transaction
+     * and submitted to ordering, then the committing peers will re-execute to guarantee that
+     * result sets are stable between endorsement time and commit time. The transaction is
+     * invalidated by the committing peers if the result set has changed between endorsement
+     * time and commit time.
+     * Therefore, range queries are a safe option for performing update transactions based on query results.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub.
+     * @param {String[]} args The arguments of the function. Index 0: start key. Index 1: end key.
+     * @param {Chaincode} thisObject The chaincode object context.
+     * @return {Promise<Buffer>} The marbles in the given range.
+     */
+    async getMarblesByRange(stub, args, thisObject) {
+
+        if (args.length !== 2) {
+            throw new Error('Incorrect number of arguments. Expecting 2');
+        }
+
+        let startKey = args[0];
+        let endKey = args[1];
+
+        let resultsIterator = await stub.getStateByRange(startKey, endKey);
+        let results = await thisObject.getAllResults(resultsIterator, false);
+
+        return Buffer.from(JSON.stringify(results));
+    }
+
+    /**
+     * Transfers marbles of a given color to a certain new owner.
+     *
+     * Uses a GetStateByPartialCompositeKey (range query) against color~name 'index'.
+     * Committing peers will re-execute range queries to guarantee that result sets are stable
+     * between endorsement time and commit time. The transaction is invalidated by the
+     * committing peers if the result set has changed between endorsement time and commit time.
+     * Therefore, range queries are a safe option for performing update transactions based on query results.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub.
+     * @param {String[]} args The arguments of the function. Index 0: marble color. Index 1: new owner.
+     * @param {Chaincode} thisObject The chaincode object context.
+     */
+    async transferMarblesBasedOnColor(stub, args, thisObject) {
+        if (args.length !== 2) {
+            throw new Error('Incorrect number of arguments. Expecting color and owner');
+        }
+
+        let color = args[0];
+        let newOwner = args[1].toLowerCase();
+        console.info('- start transferMarblesBasedOnColor ', color, newOwner);
+
+        // Query the color~name index by color
+        // This will execute a key range query on all keys starting with 'color'
+        let coloredMarbleResultsIterator = await stub.getStateByPartialCompositeKey('color~name', [color]);
+
+        let hasNext = true;
+        // Iterate through result set and for each marble found, transfer to newOwner
+        while (hasNext) {
+            let responseRange;
+            try {
+                responseRange = await coloredMarbleResultsIterator.next();
+            } catch (err) {
+                hasNext = false;
+                continue;
+            }
+
+            if (!responseRange || !responseRange.value || !responseRange.value.key) {
+                return;
+            }
+            console.log(responseRange.value.key);
+
+            // let value = res.value.value.toString('utf8');
+            let objectType;
+            let attributes;
+            ({
+                objectType,
+                attributes
+            } = await stub.splitCompositeKey(responseRange.value.key));
+
+            let returnedColor = attributes[0];
+            let returnedMarbleName = attributes[1];
+            console.info(util.format('- found a marble from index:%s color:%s name:%s\n', objectType, returnedColor, returnedMarbleName));
+
+            // Now call the transfer function for the found marble.
+            // Re-use the same function that is used to transfer individual marbles
+            await thisObject.transferMarble(stub, [returnedMarbleName, newOwner]);
+        }
+
+        let responsePayload = util.format('Transferred %s marbles to %s', color, newOwner);
+        console.info('- end transferMarblesBasedOnColor: ' + responsePayload);
+    }
+
+    /**
+     * Queries for marbles based on a passed in owner.
+     * This is an example of a parameterized query where the query logic is baked into the chaincode,
+     * and accepting a single query parameter (owner).
+     * Only available on state databases that support rich query (e.g. CouchDB)
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub.
+     * @param {String[]} args The arguments of the function. Index 0: marble owner.
+     * @param {Chaincode} thisObject The chaincode object context.
+     * @return {Promise<Buffer>} The marbles of the specified owner.
+     */
+    async queryMarblesByOwner(stub, args, thisObject) {
+        if (args.length !== 1) {
+            throw new Error('Incorrect number of arguments. Expecting owner name.');
+        }
+
+        let owner = args[0].toLowerCase();
+        let queryString = {};
+        queryString.selector = {};
+        queryString.selector.docType = 'marble';
+        queryString.selector.owner = owner;
+        return await thisObject.getQueryResultForQueryString(stub, JSON.stringify(queryString), thisObject); //shim.success(queryResults);
+    }
+
+    /**
+     * Uses a query string to perform a query for marbles.
+     * Query string matching state database syntax is passed in and executed as is.
+     * Supports ad hoc queries that can be defined at runtime by the client.
+     * If this is not desired, follow the queryMarblesForOwner example for parameterized queries.
+     * Only available on state databases that support rich query (e.g. CouchDB)
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub.
+     * @param {String[]} args The arguments of the function. Index 0: query string.
+     * @param {Chaincode} thisObject The chaincode object context.
+     * @return {Promise<Buffer>} The results of the specified query.
+     */
+    async queryMarbles(stub, args, thisObject) {
+        if (args.length !== 1) {
+            throw new Error('Incorrect number of arguments. Expecting queryString');
+        }
+        let queryString = args[0];
+        if (!queryString) {
+            throw new Error('queryString must not be empty');
+        }
+
+        return await thisObject.getQueryResultForQueryString(stub, queryString, thisObject);
+    }
+
+    /**
+     * Gets the results of a specified iterator.
+     * @async
+     * @param {Object} iterator The iterator to use.
+     * @param {Boolean} isHistory Specifies whether the iterator returns history entries or not.
+     * @return {Promise<Object[]>} The array of results in JSON format.
+     */
+    async getAllResults(iterator, isHistory) {
+        let allResults = [];
+        let hasNext = true;
+        while (hasNext) {
+            let res;
+            try {
+                res = await iterator.next();
+            } catch (err) {
+                hasNext = false;
+                continue;
+            }
+
+            if (res.value && res.value.value.toString()) {
+                let jsonRes = {};
+                console.log(res.value.value.toString('utf8'));
+
+                if (isHistory && isHistory === true) {
+                    jsonRes.TxId = res.value.tx_id;
+                    jsonRes.Timestamp = res.value.timestamp;
+                    jsonRes.IsDelete = res.value.is_delete.toString();
+                    try {
+                        jsonRes.Value = JSON.parse(res.value.value.toString('utf8'));
+                    } catch (err) {
+                        console.log(err);
+                        jsonRes.Value = res.value.value.toString('utf8');
+                    }
+                } else {
+                    jsonRes.Key = res.value.key;
+                    try {
+                        jsonRes.Record = JSON.parse(res.value.value.toString('utf8'));
+                    } catch (err) {
+                        console.log(err);
+                        jsonRes.Record = res.value.value.toString('utf8');
+                    }
+                }
+                allResults.push(jsonRes);
+            }
+            if (res.done) {
+                console.log('end of data');
+                await iterator.close();
+                console.info(allResults);
+                return allResults;
+            }
+        }
+    }
+
+    /**
+     * Executes the provided query string.
+     * Result set is built and returned as a byte array containing the JSON results.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub.
+     * @param {String} queryString The query string to execute.
+     * @param {Chaincode} thisObject The chaincode object context.
+     * @return {Promise<Buffer>} The results of the specified query.
+     */
+    async getQueryResultForQueryString(stub, queryString, thisObject) {
+
+        console.info('- getQueryResultForQueryString queryString:\n' + queryString);
+        let resultsIterator = await stub.getQueryResult(queryString);
+
+        let results = await thisObject.getAllResults(resultsIterator, false);
+
+        return Buffer.from(JSON.stringify(results));
+    }
+
+    /**
+     * Retrieves the history for a marble.
+     * @async
+     * @param {ChaincodeStub} stub The chaincode stub.
+     * @param {String[]} args The arguments of the function. Index 0: marble name.
+     * @param {Chaincode} thisObject The chaincode object context.
+     * @return {Promise<Buffer>} The history entries of the specified marble.
+     */
+    async getHistoryForMarble(stub, args, thisObject) {
+
+        if (args.length !== 1) {
+            throw new Error('Incorrect number of arguments. Expecting 1');
+        }
+        let marbleName = args[0];
+        console.info('- start getHistoryForMarble: %s\n', marbleName);
+
+        let resultsIterator = await stub.getHistoryForKey(marbleName);
+        let results = await thisObject.getAllResults(resultsIterator, true);
+
+        return Buffer.from(JSON.stringify(results));
+    }
+};
+
+shim.start(new Chaincode());

--- a/packages/caliper-tests-integration/fabric_tests/phase3/src/marbles/node/metadata/statedb/couchdb/indexes/indexOwner.json
+++ b/packages/caliper-tests-integration/fabric_tests/phase3/src/marbles/node/metadata/statedb/couchdb/indexes/indexOwner.json
@@ -1,0 +1,1 @@
+{"index":{"fields":["docType","owner"]},"ddoc":"indexOwnerDoc", "name":"indexOwner","type":"json"}

--- a/packages/caliper-tests-integration/fabric_tests/phase3/src/marbles/node/package.json
+++ b/packages/caliper-tests-integration/fabric_tests/phase3/src/marbles/node/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "marbles",
+	"version": "1.0.0",
+	"description": "marbles chaincode implemented in node.js",
+	"engines": {
+		"node": ">=8.4.0",
+		"npm": ">=5.3.0"
+	},
+	"scripts": {
+		"start": "node marbles.js"
+	},
+	"engine-strict": true,
+	"license": "Apache-2.0",
+	"dependencies": {
+		"fabric-shim": "~1.4.0"
+	}
+}

--- a/packages/caliper-tests-integration/fabric_tests/phase4/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase4/benchconfig.yaml
@@ -1,0 +1,55 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+test:
+    clients:
+        type: local
+        number: 2
+    rounds:
+    - label: init1
+      txNumber: [100]
+      rateControl: [{ type: 'fixed-rate', opts: { tps: 20 } }]
+      callback: ../init.js
+    - label: init2
+      txNumber: [200]
+      rateControl: [{ type: 'fixed-feedback-rate', opts: { tps: 20, unfinished_per_client: 5 } }]
+      callback: ../init.js
+    - label: query
+      txNumber: [100]
+      rateControl: [{ type: 'linear-rate', opts: { startingTps: 10, finishingTps: 20 } }]
+      callback: ../query.js
+observer:
+    interval: 1
+    type: prometheus
+monitor:
+    interval: 1
+    type: ['prometheus']
+    prometheus:
+        url: "http://localhost:9090"
+        push_url: "http://localhost:9091"
+        metrics:
+            ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter]
+            include:
+                Endorse Time (s):
+                    query: rate(endorser_propsal_duration_sum{chaincode="marbles:v0"}[1m])/rate(endorser_propsal_duration_count{chaincode="marbles:v0"}[1m])
+                    step: 1
+                    label: instance
+                    statistic: avg
+                Max Memory (MB):
+                    query: sum(container_memory_rss{name=~".+"}) by (name)
+                    step: 10
+                    label: name
+                    statistic: max
+                    multiplier: 0.000001

--- a/packages/caliper-tests-integration/fabric_tests/phase4/networkconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase4/networkconfig.yaml
@@ -1,0 +1,158 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Fabric
+version: "1.0"
+mutual-tls: true
+
+caliper:
+    blockchain: fabric
+
+clients:
+    client0.org1.example.com:
+        client:
+            organization: Org1
+            credentialStore:
+                path: /tmp/hfc-kvs/org1
+                cryptoStore:
+                    path: /tmp/hfc-cvs/org1
+            clientPrivateKey:
+                path: ../config/crypto-config/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp/keystore/key.pem
+            clientSignedCert:
+                path: ../config/crypto-config/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp/signcerts/User1@org1.example.com-cert.pem
+
+    client0.org2.example.com:
+        client:
+            organization: Org2
+            credentialStore:
+                path: /tmp/hfc-kvs/org2
+                cryptoStore:
+                    path: /tmp/hfc-cvs/org2
+            clientPrivateKey:
+                path: ../config/crypto-config/peerOrganizations/org2.example.com/users/User1@org2.example.com/msp/keystore/key.pem
+            clientSignedCert:
+                path: ../config/crypto-config/peerOrganizations/org2.example.com/users/User1@org2.example.com/msp/signcerts/User1@org2.example.com-cert.pem
+
+channels:
+    mychannel:
+        created: true
+        orderers:
+        - orderer0.example.com
+        - orderer1.example.com
+        peers:
+            peer0.org1.example.com:
+                eventSource: true
+            peer0.org2.example.com:
+                eventSource: true
+
+        chaincodes:
+        - id: marbles
+          contractID: mymarbles
+          version: v0
+          language: node
+          path: src/marbles/node
+          metadataPath: src/marbles/node/metadata
+    yourchannel:
+        created: true
+        orderers:
+        - orderer0.example.com
+        - orderer1.example.com
+        peers:
+            peer0.org1.example.com:
+                eventSource: true
+            peer0.org2.example.com:
+                eventSource: true
+
+        chaincodes:
+        - id: marbles
+          contractID: yourmarbles
+          version: v0
+          language: golang
+          path: marbles/go
+          metadataPath: src/marbles/go/metadata
+
+organizations:
+    Org1:
+        mspid: Org1MSP
+        peers:
+        - peer0.org1.example.com
+        certificateAuthorities:
+        - ca.org1.example.com
+        adminPrivateKey:
+            path: ../config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem
+        signedCert:
+            path: ../config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem
+
+    Org2:
+        mspid: Org2MSP
+        peers:
+        - peer0.org2.example.com
+        certificateAuthorities:
+        - ca.org2.example.com
+        adminPrivateKey:
+            path: ../config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem
+        signedCert:
+            path: ../config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem
+
+orderers:
+    orderer0.example.com:
+        url: grpcs://localhost:7050
+        grpcOptions:
+            ssl-target-name-override: orderer0.example.com
+        tlsCACerts:
+            path: ../config/crypto-config/ordererOrganizations/example.com/orderers/orderer0.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
+    orderer1.example.com:
+        url: grpcs://localhost:8050
+        grpcOptions:
+            ssl-target-name-override: orderer1.example.com
+        tlsCACerts:
+            path: ../config/crypto-config/ordererOrganizations/example.com/orderers/orderer1.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
+
+peers:
+    peer0.org1.example.com:
+        url: grpcs://localhost:7051
+        grpcOptions:
+            ssl-target-name-override: peer0.org1.example.com
+            grpc.keepalive_time_ms: 600000
+        tlsCACerts:
+            path: ../config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp/tlscacerts/tlsca.org1.example.com-cert.pem
+
+    peer0.org2.example.com:
+        url: grpcs://localhost:8051
+        grpcOptions:
+            ssl-target-name-override: peer0.org2.example.com
+            grpc.keepalive_time_ms: 600000
+        tlsCACerts:
+            path: ../config/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/msp/tlscacerts/tlsca.org2.example.com-cert.pem
+
+certificateAuthorities:
+    ca.org1.example.com:
+        url: https://localhost:7054
+        httpOptions:
+            verify: false
+        tlsCACerts:
+            path: ../config/crypto-config/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem
+        registrar:
+        - enrollId: admin
+          enrollSecret: adminpw
+
+    ca.org2.example.com:
+        url: https://localhost:8054
+        httpOptions:
+            verify: false
+        tlsCACerts:
+            path: ../config/crypto-config/peerOrganizations/org2.example.com/tlsca/tlsca.org2.example.com-cert.pem
+        registrar:
+        - enrollId: admin
+          enrollSecret: adminpw

--- a/packages/caliper-tests-integration/fabric_tests/phase5/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase5/benchconfig.yaml
@@ -1,0 +1,39 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+test:
+    clients:
+        type: local
+        number: 2
+    rounds:
+    - label: init1
+      txNumber: [100]
+      rateControl: [{ type: 'fixed-rate', opts: { tps: 20 } }]
+      callback: ../init.js
+    - label: init2
+      txNumber: [200]
+      rateControl: [{ type: 'fixed-feedback-rate', opts: { tps: 20, unfinished_per_client: 5 } }]
+      callback: ../init.js
+    - label: query
+      txNumber: [100]
+      rateControl: [{ type: 'linear-rate', opts: { startingTps: 10, finishingTps: 20 } }]
+      callback: ../query.js
+observer:
+    interval: 1
+    type: local
+monitor:
+    interval: 1
+    type: ['process']
+    process: [{ command: 'node', arguments: 'fabricClientWorker.js', multiOutput: 'avg' }]

--- a/packages/caliper-tests-integration/fabric_tests/phase5/networkconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase5/networkconfig.yaml
@@ -1,4 +1,3 @@
-#!/bin/bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,20 +12,10 @@
 # limitations under the License.
 #
 
-# Exit on first error, print all commands.
-set -e
-set -o pipefail
+name: Fabric
+version: "1.0"
 
-# Bootstrap the project again
-npm i && npm run repoclean -- --yes && npm run bootstrap
-
-# Run linting, license check and unit tests
-npm test
-
-# Call CLI directly
-# The CWD will be in one of the caliper-tests-integration/*-tests directories
-export CALL_METHOD="node ../caliper-cli/caliper.js"
-
-echo "---- Running Integration test for adaptor ${BENCHMARK}"
-cd ./packages/caliper-tests-integration/
-npm run run_tests
+caliper:
+    blockchain: fabric
+    command:
+        end: docker-compose -p caliper down;(test -z \"$(docker ps -aq)\") || docker rm $(docker ps -aq);(test -z \"$(docker images dev* -q)\") || docker rmi $(docker images dev* -q);rm -rf /tmp/hfc-*

--- a/packages/caliper-tests-integration/fabric_tests/prometheus/prometheus-fabric.yml
+++ b/packages/caliper-tests-integration/fabric_tests/prometheus/prometheus-fabric.yml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 1s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    honor_labels: true # Retain labels, as within PushGateway use
+    static_configs:
+    - targets: ['prometheus:9090', 'pushGateway:9091','peer0.org1.example.com:9000', 'peer0.org2.example.com:9000']
+
+  - job_name: cadvisor
+    scrape_interval: 1s
+    static_configs:
+    - targets: ['cadvisor:8080']

--- a/packages/caliper-tests-integration/fabric_tests/query.js
+++ b/packages/caliper-tests-integration/fabric_tests/query.js
@@ -1,0 +1,40 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+module.exports.info  = 'Querying marbles.';
+
+let txIndex = 0;
+let owners = ['Alice', 'Bob', 'Claire', 'David'];
+let bc, contx;
+
+module.exports.init = async function(blockchain, context, args) {
+    bc = blockchain;
+    contx = context;
+};
+
+module.exports.run = async function() {
+    txIndex++;
+    let marbleOwner = owners[txIndex % owners.length];
+    let args = {
+        chaincodeFunction: 'queryMarblesByOwner',
+        chaincodeArguments: [marbleOwner]
+    };
+
+    let targetCC = txIndex % 2 === 0 ? 'mymarbles' : 'yourmarbles';
+    return bc.querySmartContract(contx, targetCC, '', args, 10);
+};
+
+module.exports.end = async function() {};

--- a/packages/caliper-tests-integration/fabric_tests/run.sh
+++ b/packages/caliper-tests-integration/fabric_tests/run.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Exit on first error, print all commands.
+set -ev
+set -o pipefail
+
+# Grab the parent (fabric_tests) directory.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "${DIR}"
+
+# generate the crypto materials
+cd ./config
+./generate.sh
+
+# back to this dir
+cd ${DIR}
+
+# TODO: should come from the Travis script, once every test uses the same dir hierarchy
+export CALL_METHOD="node ../../caliper-cli/caliper.js"
+
+# change default settings (add config paths too)
+export CALIPER_PROJECTCONFIG=../caliper.yaml
+
+# PHASE 1: just starting the network
+${CALL_METHOD} benchmark run --caliper-workspace phase1 --caliper-flow-only-start
+rc=$?
+if [[ ${rc} != 0 ]]; then
+    exit ${rc};
+fi
+
+# PHASE 2: just initialize the network
+# TODO: chaincodes shouldn't be required at this point
+${CALL_METHOD} benchmark run --caliper-workspace phase2 --caliper-flow-only-init
+rc=$?
+if [[ ${rc} != 0 ]]; then
+    exit ${rc};
+fi
+
+# PHASE 3: just init network and install the contracts (channels marked as created)
+${CALL_METHOD} benchmark run --caliper-workspace phase3 --caliper-flow-skip-start --caliper-flow-skip-end --caliper-flow-skip-test
+rc=$?
+if [[ ${rc} != 0 ]]; then
+    exit ${rc};
+fi
+
+# PHASE 3 again: deployed contracts should be detected
+${CALL_METHOD} benchmark run --caliper-workspace phase3 --caliper-flow-skip-start --caliper-flow-skip-end --caliper-flow-skip-test
+rc=$?
+if [[ ${rc} != 0 ]]; then
+    exit ${rc};
+fi
+
+# PHASE 4: testing through the low-level API
+${CALL_METHOD} benchmark run --caliper-workspace phase4 --caliper-flow-only-test
+rc=$?
+if [[ ${rc} != 0 ]]; then
+    exit ${rc};
+fi
+
+# PHASE 4 again: testing through the gateway API
+${CALL_METHOD} benchmark run --caliper-workspace phase4 --caliper-flow-only-test --caliper-fabric-usegateway
+rc=$?
+if [[ ${rc} != 0 ]]; then
+    exit ${rc};
+fi
+
+# PHASE 5: just disposing of the network
+${CALL_METHOD} benchmark run --caliper-workspace phase5 --caliper-flow-only-end
+rc=$?
+if [[ ${rc} != 0 ]]; then
+    exit ${rc};
+fi

--- a/packages/caliper-tests-integration/package.json
+++ b/packages/caliper-tests-integration/package.json
@@ -46,20 +46,40 @@
       ".pm2/touch",
       "storage",
       "scripts/storage",
-      "log"
+      "log",
+      "fabric_tests/.gitignore",
+      "fabric_tests/config/.gitignore"
     ],
     "file_type_method": "EXCLUDE",
     "file_types": [
+      ".pm2",
+      ".pid",
       ".yml",
       ".log",
-      ".pm2",
+      ".acl",
+      ".md",
+      ".toml",
+      ".sample",
+      ".service",
+      ".priv",
+      ".pub",
+      ".pem",
       ".html",
-      ".pid",
-      ".md"
+      ".bin",
+      ".crt",
+      ".key",
+      ".tx",
+      ".block",
+      ".sh",
+      ".qry",
+      ".list",
+      ".sol",
+      ".proto",
+      ".cfg"
     ],
     "insert_license": false,
     "license_formats": {
-      "js": {
+      "js|go": {
         "prepend": "/*",
         "append": "*/",
         "eachLine": {

--- a/packages/caliper-tests-integration/scripts/run-tests.sh
+++ b/packages/caliper-tests-integration/scripts/run-tests.sh
@@ -40,21 +40,7 @@ if [[ "${BENCHMARK}" == "composer" ]]; then
     rc=$?
     exit $rc;
 elif [[ "${BENCHMARK}" == "fabric" ]]; then
-    export CALIPER_FABRIC_SLEEPAFTER_CREATECHANNEL=10000
-    export CALIPER_FABRIC_SLEEPAFTER_JOINCHANNEL=10000
-    export CALIPER_FABRIC_SLEEPAFTER_INSTANTIATECHAINCODE=10000
-    # Run with channel creation using a createChannelTx in couchDB, using a Gateway
-
-    ${CALL_METHOD} benchmark run --caliper-benchconfig benchmark/simple/config.yaml --caliper-networkconfig network/fabric-v1.4.1/2org1peercouchdb/fabric-node.yaml --caliper-workspace ../caliper-samples/ --caliper-fabric-usegateway
-    rc=$?
-    if [[ $rc != 0 ]]; then
-        exit $rc;
-    else
-        # Run with channel creation using an existing tx file in LevelDB, using a low level Caliper client
-        ${CALL_METHOD} benchmark run --caliper-benchconfig benchmark/simple/config.yaml --caliper-networkconfig network/fabric-v1.4.1/2org1peergoleveldb/fabric-go.yaml --caliper-workspace ../caliper-samples/
-        rc=$?
-        exit $rc;
-    fi
+    ./fabric_tests/run.sh
 elif [[ "${BENCHMARK}" == "ethereum" ]]; then
     ${CALL_METHOD} benchmark run --caliper-benchconfig benchmark/simple/config.yaml --caliper-networkconfig network/ethereum/1node-clique/ethereum.json --caliper-workspace ../caliper-samples/
     rc=$?


### PR DESCRIPTION
Signed-off-by: Attila Klenik <a.klenik@gmail.com>

Adds a multi-phase Fabric test for CI, that is independent of the samples (because of #569)

## Specifics
SUT details (`packages/caliper-tests-integration/fabric-tests` dir):
* 2 Orgs, 1-1 peer, 1-1 CA, 2 Raft orderers, mutual TLS
* 2 channels, Marbles golang CC (with rich query) in both channel
* Benchmark configs:
    * 3 rounds (init, init, query)
    * With 3 different rate controllers
    * Different observer and monitor combination for each phases
* Dedicated network config for all phases, stripped to the required minimum
* Phases
    1. Only start the network
    2. Only initialize the network
    3. Only deploy the contracts (channels already created)
    4. The previous phase again to check the correct detection of already deployed contracts
    5. Only performing the testing phase through the low-level SDK API
    6. Only performing the testing phase through the gateway SDK API
    7. Only disposing of the network

## Remarks/Decisions
1. CAs can be removed since no dynamic user registration occurs
2. Or could add dynamic user registration