### PR TITLE
Improve logging style flexibility

### DIFF
--- a/packages/caliper-core/lib/config/Config.js
+++ b/packages/caliper-core/lib/config/Config.js
@@ -45,12 +45,32 @@ const keys = {
         Template: 'caliper-logging-template',
         FormatsRoot: 'caliper-logging-formats',
         Formats: {
-            Align: 'caliper-logging-formats-align',
+            Timestamp: 'caliper-logging-formats-timestamp',
+            Label: 'caliper-logging-formats-label',
+            JsonRoot: 'caliper-logging-formats-json',
+            Json: {
+                Space: 'caliper-logging-formats-json-space'
+            },
             Pad: 'caliper-logging-formats-pad',
+            Align: 'caliper-logging-formats-align',
+            AttributeFormatRoot: 'caliper-logging-formats-attributeformat',
+            AttributeFormat: {
+                Timestamp: 'caliper-logging-formats-attributeformat-timestamp',
+                Label: 'caliper-logging-formats-attributeformat-label',
+                Level: 'caliper-logging-formats-attributeformat-level',
+                Module: 'caliper-logging-formats-attributeformat-module',
+                Message: 'caliper-logging-formats-attributeformat-message',
+                Metadata: 'caliper-logging-formats-attributeformat-metadata'
+            },
             ColorizeRoot: 'caliper-logging-formats-colorize',
             Colorize: {
+                All: 'caliper-logging-formats-colorize-all',
+                Timestamp: 'caliper-logging-formats-colorize-timestamp',
+                Label: 'caliper-logging-formats-colorize-label',
                 Level: 'caliper-logging-formats-colorize-level',
+                Module: 'caliper-logging-formats-colorize-module',
                 Message: 'caliper-logging-formats-colorize-message',
+                Metadata: 'caliper-logging-formats-colorize-metadata',
                 Colors: {
                     Info: 'caliper-logging-formats-colorize-colors-info',
                     Error: 'caliper-logging-formats-colorize-colors-error',
@@ -58,23 +78,6 @@ const keys = {
                     Debug: 'caliper-logging-formats-colorize-colors-debug',
                 }
             },
-            ErrorsRoot: 'caliper-logging-formats-errors',
-            Errors: {
-                Stack: 'caliper-logging-formats-errors-stack'
-            },
-            JsonRoot: 'caliper-logging-formats-json',
-            Json: {
-                Space: 'caliper-logging-formats-json-space'
-            },
-            LabelRoot: 'caliper-logging-formats-label',
-            Label: {
-                Label: 'caliper-logging-formats-label-label',
-                Message: 'caliper-logging-formats-label-message'
-            },
-            TimestampRoot: 'caliper-logging-formats-timestamp',
-            Timestamp: {
-                Format: 'caliper-logging-formats-timestamp-format'
-            }
         },
         Targets: 'caliper-logging-targets'
     },

--- a/packages/caliper-core/lib/config/default.yaml
+++ b/packages/caliper-core/lib/config/default.yaml
@@ -52,15 +52,31 @@ caliper:
     # Configurations related to the logging mechanism
     logging:
         # Specifies the message structure through placeholders
-        template: '%time% %level% [%label%] [%module%] %message% %meta%'
+        template: '%timestamp%%level%%label%%module%%message%%metadata%'
         # Enables the different formats to apply to the log messages FOR ALL transports
         # Each format can be disabled by setting it to false
         formats:
-            # adds a tab delimiter before the message to align it in the same place
-            align: true
+            # Adds a timestamp to the messages with the following format
+            timestamp: 'YYYY.MM.DD-HH:mm:ss.SSS'
+            # Adds a specified label to every message. Useful for distributed client scenario
+            label: caliper
+            # serializes the log messages as JSON
+            json: false
             # pads the levels to be the same length
             pad: true
-            # defines coloring for the different levels
+            # adds a tab delimiter before the message to align it in the same place
+            align: true
+            # specifies formatting strings for different log message attributes
+            attributeformat:
+                # add a space before the level
+                level: ' %attribute%'
+                # put [] around the label and space before it
+                label: ' [%attribute%]'
+                # put [] around the module name and space before/after it
+                module: ' [%attribute%] '
+                # put () around the metadata and space before it
+                metadata: ' (%attribute%)'
+            # defines coloring for the different levels for each (or all) message property
             colorize:
                 # Apply it to levels
                 level: true
@@ -72,19 +88,6 @@ caliper:
                     error: red
                     warn: yellow
                     debug: grey
-            # specifies whether to print stack traces
-            errors:
-                stack: true
-            # serializes the log messages as JSON
-            json: false
-            # Adds a specified label to every message. Useful for distributed client scenario
-            label:
-                label: caliper
-                message: false
-            # Adds a timestamp to the messages
-            timestamp:
-                # The timestamp format string
-                format: YYYY.MM.DD-HH:mm:ss.SSS
         # Lists the targets (winston transports)
         targets:
             console:

--- a/packages/caliper-core/lib/utils/log-formats.js
+++ b/packages/caliper-core/lib/utils/log-formats.js
@@ -1,0 +1,64 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const colors = require('colors/safe');
+const { format } = require('logform');
+const { LEVEL } = require('triple-beam');
+
+const attributeRegex = /%attribute%/gi;
+
+const colorizeExtra = format((info, opts) => {
+    // The immutable level string of the message (the normal property could be mutated already)
+    let lev = info[LEVEL];
+    // colors enables multiple styles separated by spaces
+    let colorStyles = opts.colors[lev].split(' ');
+
+    for (let key of Object.keys(info)) {
+        if (info[key] !== undefined && (opts.all || opts[key])) {
+            // surround the value with the style codes one by one
+            for (let style of colorStyles) {
+                info[key] = colors[style](info[key]);
+            }
+        }
+    }
+
+    return info;
+});
+
+const padLevelExtra = format(info => {
+
+    let padding = ' '.repeat(Math.max(5 - info[LEVEL].length, 0));
+    info.level = `${info.level}${padding}`;
+    return info;
+});
+
+const attributeFormat = format((info, opts) => {
+    for (let key of Object.keys(info)) {
+        if (typeof opts[key] === 'string') {
+            if (typeof info[key] !== 'string') {
+                info[key] = JSON.stringify(info[key]);
+            }
+
+            info[key] = opts[key].replace(attributeRegex, info[key]);
+        }
+    }
+
+    return info;
+});
+
+module.exports.ColorizerExtra = colorizeExtra;
+module.exports.PadLevelExtra = padLevelExtra;
+module.exports.AttributeFormat = attributeFormat;

--- a/packages/caliper-core/package.json
+++ b/packages/caliper-core/package.json
@@ -33,7 +33,10 @@
     "systeminformation": "^3.23.7",
     "table": "^4.0.1",
     "winston": "^3.2.1",
-    "winston-daily-rotate-file": "^4.2.1"
+    "winston-daily-rotate-file": "^4.2.1",
+    "triple-beam": "^1.3.0",
+    "logform": "^2.1.2",
+    "colors": "^1.4.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/packages/caliper-samples/network/fabric-v1.4.1/2org1peercouchdb/fabric-node.yaml
+++ b/packages/caliper-samples/network/fabric-v1.4.1/2org1peercouchdb/fabric-node.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/packages/caliper-tests-integration/scripts/run-tests.sh
+++ b/packages/caliper-tests-integration/scripts/run-tests.sh
@@ -40,15 +40,18 @@ if [[ "${BENCHMARK}" == "composer" ]]; then
     rc=$?
     exit $rc;
 elif [[ "${BENCHMARK}" == "fabric" ]]; then
+    export CALIPER_FABRIC_SLEEPAFTER_CREATECHANNEL=10000
+    export CALIPER_FABRIC_SLEEPAFTER_JOINCHANNEL=10000
+    export CALIPER_FABRIC_SLEEPAFTER_INSTANTIATECHAINCODE=10000
     # Run with channel creation using a createChannelTx in couchDB, using a Gateway
 
-    ${CALL_METHOD} benchmark run --caliper-benchconfig benchmark/simple/config.yaml --caliper-networkconfig network/fabric-v1.4/2org1peercouchdb/fabric-node.yaml --caliper-workspace ../caliper-samples/ --caliper-fabric-usegateway
+    ${CALL_METHOD} benchmark run --caliper-benchconfig benchmark/simple/config.yaml --caliper-networkconfig network/fabric-v1.4.1/2org1peercouchdb/fabric-node.yaml --caliper-workspace ../caliper-samples/ --caliper-fabric-usegateway
     rc=$?
     if [[ $rc != 0 ]]; then
         exit $rc;
     else
         # Run with channel creation using an existing tx file in LevelDB, using a low level Caliper client
-        ${CALL_METHOD} benchmark run --caliper-benchconfig benchmark/simple/config.yaml --caliper-networkconfig network/fabric-v1.4/2org1peergoleveldb/fabric-go.yaml --caliper-workspace ../caliper-samples/
+        ${CALL_METHOD} benchmark run --caliper-benchconfig benchmark/simple/config.yaml --caliper-networkconfig network/fabric-v1.4.1/2org1peergoleveldb/fabric-go.yaml --caliper-workspace ../caliper-samples/
         rc=$?
         exit $rc;
     fi


### PR DESCRIPTION
Signed-off-by: Attila Klenik <a.klenik@gmail.com>

The new logging formats introduced by #598 were not flexible enough to create consistent all-line coloring, for example (and also had issues with JSON formatting). This PR fixes that by using a more flexible color and attribute formatter, and a strictly ordered formatting pipeline.