### PR TITLE
remove .only on mocha  test

### DIFF
--- a/packages/caliper-core/lib/monitor/monitor-orchestrator.js
+++ b/packages/caliper-core/lib/monitor/monitor-orchestrator.js
@@ -39,7 +39,6 @@ class MonitorOrchestrator {
         this.config = Util.parseYaml(configPath);
         this.started = false;
         this.monitors = new Map();
-
         // Parse the config and retrieve the monitor types
         const m = this.config.monitor;
         if(typeof m === 'undefined') {

--- a/packages/caliper-core/lib/monitor/monitor-prometheus.js
+++ b/packages/caliper-core/lib/monitor/monitor-prometheus.js
@@ -36,7 +36,6 @@ class PrometheusMonitor extends MonitorInterface {
         super(monitorConfig, interval);
         this.prometheusPushClient = new PrometheusPushClient(monitorConfig.pushUrl);
         this.prometheusQueryClient = new PrometheusQueryClient(monitorConfig.url);
-
         // User defined options for monitoring
         if (monitorConfig.hasOwnProperty('metrics')) {
             // Might have an ignore list

--- a/packages/caliper-core/test/client/client-orchestrator.js
+++ b/packages/caliper-core/test/client/client-orchestrator.js
@@ -131,21 +131,21 @@ describe('client orchestrator implementation', () => {
         ClientOrchestratorRewire.__set__('util.parseYaml', FakeParseYaml);
         const myOrchestrator = new ClientOrchestratorRewire();
 
-        it('should group all client results into an array under a txStats label', () => {
-            const result0 = {result: [1] , start: new Date(2018, 11, 24, 10, 33), end: new Date(2018, 11, 24, 11, 33)};
-            const result1 = {result: [2] , start: new Date(2018, 11, 24, 10, 34), end: new Date(2018, 11, 24, 11, 23)};
-            const result2 = {result: [3] , start: new Date(2018, 11, 24, 10, 35), end: new Date(2018, 11, 24, 11, 13)};
+        it('should group all client results into an array under a results label', () => {
+            const result0 = {results: [1] , start: new Date(2018, 11, 24, 10, 33), end: new Date(2018, 11, 24, 11, 33)};
+            const result1 = {results: [2] , start: new Date(2018, 11, 24, 10, 34), end: new Date(2018, 11, 24, 11, 23)};
+            const result2 = {results: [3] , start: new Date(2018, 11, 24, 10, 35), end: new Date(2018, 11, 24, 11, 13)};
             const testData = [result0, result1, result2];
 
             const output = myOrchestrator.formatResults(testData);
-            output.txStats.should.deep.equal([1,2,3]);
+            output.results.should.deep.equal([1,2,3]);
         });
 
         it('should determine and persist the time when all clients have started', () => {
             const compareStart = new Date(2018, 11, 24, 10, 35);
-            const result0 = {result: [1] , start: new Date(2018, 11, 24, 10, 33), end: new Date(2018, 11, 24, 11, 33)};
-            const result1 = {result: [2] , start: new Date(2018, 11, 24, 10, 34), end: new Date(2018, 11, 24, 11, 13)};
-            const result2 = {result: [3] , start: compareStart, end: new Date(2018, 11, 24, 11, 23)};
+            const result0 = {results: [1] , start: new Date(2018, 11, 24, 10, 33), end: new Date(2018, 11, 24, 11, 33)};
+            const result1 = {results: [2] , start: new Date(2018, 11, 24, 10, 34), end: new Date(2018, 11, 24, 11, 13)};
+            const result2 = {results: [3] , start: compareStart, end: new Date(2018, 11, 24, 11, 23)};
             const testData = [result0, result1, result2];
 
             const output = myOrchestrator.formatResults(testData);
@@ -154,9 +154,9 @@ describe('client orchestrator implementation', () => {
 
         it('should determine and persist the last time when all clients were running', () => {
             const compareEnd = new Date(2018, 11, 24, 11, 13);
-            const result0 = {result: [1] , start: new Date(2018, 11, 24, 10, 33), end: new Date(2018, 11, 24, 11, 33)};
-            const result1 = {result: [2] , start: new Date(2018, 11, 24, 10, 34), end: compareEnd};
-            const result2 = {result: [3] , start:  new Date(2018, 11, 24, 10, 35), end: new Date(2018, 11, 24, 11, 23)};
+            const result0 = {results: [1] , start: new Date(2018, 11, 24, 10, 33), end: new Date(2018, 11, 24, 11, 33)};
+            const result1 = {results: [2] , start: new Date(2018, 11, 24, 10, 34), end: compareEnd};
+            const result2 = {results: [3] , start:  new Date(2018, 11, 24, 10, 35), end: new Date(2018, 11, 24, 11, 23)};
             const testData = [result0, result1, result2];
 
             const output = myOrchestrator.formatResults(testData);

--- a/packages/caliper-core/test/monitor/monitor-prometheus.js
+++ b/packages/caliper-core/test/monitor/monitor-prometheus.js
@@ -158,15 +158,15 @@ describe('Prometheus monitor implementation', () => {
         it('should return a map with keys that correspond to the passed `include` keys, with default entries populated', () => {
 
             const mon = new PrometheusMonitorRewire(include);
-            const map = mon.getResultColumnMapForQueryTag('query', 'tag');
+            const map = mon.getResultColumnMapForQueryTag('query', 'MyTag');
 
             // Three keys
             map.size.should.equal(3);
 
-            // Tags, and Type should contain the corect information
+            // Tags, and Type should contain the correct information
             map.get('Prometheus Query').should.equal('query');
             map.get('Name').should.equal('N/A');
-            map.get('tag').should.equal('N/A');
+            map.get('Metric').should.equal('MyTag');
         });
     });
 

--- a/packages/caliper-core/test/prometheus/prometheus-query-helper.js
+++ b/packages/caliper-core/test/prometheus/prometheus-query-helper.js
@@ -29,13 +29,13 @@ describe('PrometheusQueryHelper implementation', () => {
         const step = 45;
 
         it('should add start, end and step information', () => {
-            const demoString = 'test_the_heper';
+            const demoString = 'test_the_helper';
 
             const output = PrometheusQueryHelper.buildStringRangeQuery(demoString, startTime, endTime, step);
             output.endsWith('&start=100&end=200&step=45').should.be.true;
         });
 
-        it('should replace an instance of `{values}` with URI encoded version of that occurence', () => {
+        it('should replace an instance of `{values}` with URI encoded version of that occurrence', () => {
             const demoString = 'sum(rate(container_cpu_usage_seconds_total{name=~".+"}[5m])) by (name) * 100';
 
             const output = PrometheusQueryHelper.buildStringRangeQuery(demoString, startTime, endTime, step);
@@ -50,56 +50,60 @@ describe('PrometheusQueryHelper implementation', () => {
     describe('#extractFirstValueFromQueryResponse', () => {
 
 
-        it('should deal with a vetor response that is numerical', () => {
+        it('should deal with a vector response that is numerical', () => {
             const response = {
-                status:'success',
-                data:{
+                status: 'success',
+                data: {
                     resultType: 'vector',
-                    result:[
-                        {metric: {name:'Name0'},value:[1565608080.458,'10']}
+                    result: [
+                        { metric: { name: 'Name0' }, value: [1565608080.458, '10'] }
                     ]
-                }};
+                }
+            };
             const output = PrometheusQueryHelper.extractFirstValueFromQueryResponse(response, true);
             output.should.equal(10);
         });
 
-        it('should deal with a vetor response that is numerical string', () => {
+        it('should deal with a vector response that is numerical string', () => {
             const response = {
-                status:'success',
-                data:{
+                status: 'success',
+                data: {
                     resultType: 'vector',
-                    result:[
-                        {metric: {name:'Name0'},value:[1565608080.458,'10']}
+                    result: [
+                        { metric: { name: 'Name0' }, value: [1565608080.458, '10'] }
                     ]
-                }};
+                }
+            };
             const output = PrometheusQueryHelper.extractFirstValueFromQueryResponse(response);
             output.should.equal(10);
         });
 
-        it('should deal with a vetor response that is a string', () => {
+        it('should deal with a vector response that is a string', () => {
             const response = {
-                status:'success',
-                data:{
+                status: 'success',
+                data: {
                     resultType: 'vector',
-                    result:[
-                        {metric: {name:'Name0'},value:[1565608080.458,'bob']}
+                    result: [
+                        { metric: { name: 'Name0' }, value: [1565608080.458, 'bob'] }
                     ]
-                }};
+                }
+            };
             const output = PrometheusQueryHelper.extractFirstValueFromQueryResponse(response, false);
             output.should.equal('bob');
         });
 
         it('should deal with a matrix response that is numerical', () => {
             const response = {
-                status:'success',
-                data:{
+                status: 'success',
+                data: {
                     resultType: 'matrix',
-                    result:[
-                        {metric: {name:'Name0'},values:[[1565608080.458,3.1]]},
-                        {metric: {name:'Name1'},values:[[1565608080.458,0.2]]},
-                        {metric: {name:'Name2'},values:[[1565608080.458,0.1]]}
+                    result: [
+                        { metric: { name: 'Name0' }, values: [[1565608080.458, 3.1]] },
+                        { metric: { name: 'Name1' }, values: [[1565608080.458, 0.2]] },
+                        { metric: { name: 'Name2' }, values: [[1565608080.458, 0.1]] }
                     ]
-                }};
+                }
+            };
             const output = PrometheusQueryHelper.extractFirstValueFromQueryResponse(response, true);
             output.should.be.an('map');
             output.size.should.equal(3);
@@ -110,15 +114,16 @@ describe('PrometheusQueryHelper implementation', () => {
 
         it('should deal with a matrix response that contains numerical string values', () => {
             const response = {
-                status:'success',
-                data:{
+                status: 'success',
+                data: {
                     resultType: 'matrix',
-                    result:[
-                        {metric: {name:'Name0'},values:[[1565608080.458,'3.1']]},
-                        {metric: {name:'Name1'},values:[[1565608080.458,'0.2']]},
-                        {metric: {name:'Name2'},values:[[1565608080.458,'0.1']]}
+                    result: [
+                        { metric: { name: 'Name0' }, values: [[1565608080.458, '3.1']] },
+                        { metric: { name: 'Name1' }, values: [[1565608080.458, '0.2']] },
+                        { metric: { name: 'Name2' }, values: [[1565608080.458, '0.1']] }
                     ]
-                }};
+                }
+            };
             const output = PrometheusQueryHelper.extractFirstValueFromQueryResponse(response, true);
             output.should.be.an('map');
             output.size.should.equal(3);
@@ -129,15 +134,16 @@ describe('PrometheusQueryHelper implementation', () => {
 
         it('should deal with a matrix response that contains string values', () => {
             const response = {
-                status:'success',
-                data:{
+                status: 'success',
+                data: {
                     resultType: 'matrix',
-                    result:[
-                        {metric: {name:'Name0'},values:[[1565608080.458,'a']]},
-                        {metric: {name:'Name1'},values:[[1565608080.458,'b']]},
-                        {metric: {name:'Name2'},values:[[1565608080.458,'c']]}
+                    result: [
+                        { metric: { name: 'Name0' }, values: [[1565608080.458, 'a']] },
+                        { metric: { name: 'Name1' }, values: [[1565608080.458, 'b']] },
+                        { metric: { name: 'Name2' }, values: [[1565608080.458, 'c']] }
                     ]
-                }};
+                }
+            };
             const output = PrometheusQueryHelper.extractFirstValueFromQueryResponse(response, false);
             output.should.be.an('map');
             output.size.should.equal(3);
@@ -150,18 +156,18 @@ describe('PrometheusQueryHelper implementation', () => {
             const response = {
                 data: {
                     resultType: 'vector',
-                    result : [1,2,3,4]
+                    result: [1, 2, 3, 4]
                 }
             };
             const value = PrometheusQueryHelper.extractFirstValueFromQueryResponse(response);
             value.should.equal('-');
         });
 
-        it('should return `-` if no value field' , () => {
+        it('should return `-` if no value field', () => {
             const response = {
                 data: {
                     resultType: 'vector',
-                    result : [{missing: 'yes'}]
+                    result: [{ missing: 'yes' }]
                 }
             };
             const value = PrometheusQueryHelper.extractFirstValueFromQueryResponse(response);
@@ -172,7 +178,7 @@ describe('PrometheusQueryHelper implementation', () => {
             const response = {
                 data: {
                     resultType: 'vector',
-                    result : [{value: [111, 1]}]
+                    result: [{ value: [111, 1] }]
                 }
             };
             const value = PrometheusQueryHelper.extractFirstValueFromQueryResponse(response);
@@ -183,7 +189,7 @@ describe('PrometheusQueryHelper implementation', () => {
             const response = {
                 data: {
                     resultType: 'vector',
-                    result : [{value: [111, '1']}]
+                    result: [{ value: [111, '1'] }]
                 }
             };
             const value = PrometheusQueryHelper.extractFirstValueFromQueryResponse(response);
@@ -194,7 +200,7 @@ describe('PrometheusQueryHelper implementation', () => {
             const response = {
                 data: {
                     resultType: 'vector',
-                    result : [{value: [111, '1']}]
+                    result: [{ value: [111, '1'] }]
                 }
             };
             const value = PrometheusQueryHelper.extractFirstValueFromQueryResponse(response, false);
@@ -206,7 +212,7 @@ describe('PrometheusQueryHelper implementation', () => {
                 const response = {
                     data: {
                         resultType: 'penguin',
-                        result : [{value: [111, '1']}]
+                        result: [{ value: [111, '1'] }]
                     }
                 };
                 PrometheusQueryHelper.extractFirstValueFromQueryResponse(response, false);
@@ -218,52 +224,69 @@ describe('PrometheusQueryHelper implementation', () => {
 
     describe('#extractStatisticFromRange', () => {
 
-        it('should retrive the minimum value from a matrix response', () => {
+        it('should retrieve the minimum values from a matrix response', () => {
             const response = {
-                status:'success',
-                data:{
+                status: 'success',
+                data: {
                     resultType: 'matrix',
-                    result:[
-                        {metric: {name:'Name0'},values:[[1565608080.458,3], [1565608080.458,4.8], [1565608080.458,0.2]]},
-                        {metric: {name:'Name1'},values:[[1565608080.458,1], [1565608080.458,8], [1565608080.458,6]]},
-                        {metric: {name:'Name2'},values:[[1565608080.458,0.1], [1565608080.458,-2], [1565608080.458,0.001]]}
+                    result: [{
+                        metric: {
+                            name: 'ca.org1.example.com'
+                        },
+                        values: [[100, 90], [200, 60], [300, 432]]
+                    },
+                    {
+                        metric: {
+                            name: 'ca.org2.example.com'
+                        },
+                        values: [[100, 40], [200, 50], [0.699, 60]]
+                    },
+                    {
+                        metric: {
+                            name: 'cadvisor'
+                        },
+                        values: [[100, 500], [200, 250], [0.699, 10]]
+                    }
                     ]
-                }};
-            const output = PrometheusQueryHelper.extractStatisticFromRange(response,'min');
+                }
+            };
+            const output = PrometheusQueryHelper.extractStatisticFromRange(response, 'min', 'name');
             output.should.be.an('map');
             output.size.should.equal(3);
-            output.get('Name0').should.equal(0.2);
-            output.get('Name1').should.equal(1);
-            output.get('Name2').should.equal(-2);
+            output.get('ca.org1.example.com').should.equal(60);
+            output.get('ca.org2.example.com').should.equal(40);
+            output.get('cadvisor').should.equal(10);
         });
 
-        it('should retrive the minimum value from a matrix response that is numerical but contains no names', () => {
+        it('should retrieve the minimum value from a matrix response that is numerical but contains no names', () => {
             const response = {
-                status:'success',
-                data:{
+                status: 'success',
+                data: {
                     resultType: 'matrix',
-                    result:[
-                        {values:[[1565608080.458,3], [1565608080.458,4.8], [1565608080.458,0.2]]}
+                    result: [
+                        { values: [[1565608080.458, 3], [1565608080.458, 4.8], [1565608080.458, 0.2]] }
                     ]
-                }};
-            const output = PrometheusQueryHelper.extractStatisticFromRange(response,'min');
+                }
+            };
+            const output = PrometheusQueryHelper.extractStatisticFromRange(response, 'min', 'name');
             output.should.be.an('map');
             output.size.should.equal(1);
             output.get('unknown').should.equal(0.2);
         });
 
-        it('should retrive the minimum value from a matrix response that contains a string', () => {
+        it('should retrieve the minimum value from a matrix response that contains a string', () => {
             const response = {
-                status:'success',
-                data:{
+                status: 'success',
+                data: {
                     resultType: 'matrix',
-                    result:[
-                        {metric: {name:'Name0'},values:[[1565608080.458,'banana'], [1565608080.458,'penguin'], [1565608080.458,'0.2']]},
-                        {metric: {name:'Name1'},values:[[1565608080.458,'1'], [1565608080.458,'bob'], [1565608080.458,'6']]},
-                        {metric: {name:'Name2'},values:[[1565608080.458,'sally'], [1565608080.458,'-2'], [1565608080.458,'0.001']]}
+                    result: [
+                        { metric: { name: 'Name0' }, values: [[1565608080.458, 'banana'], [1565608080.458, 'penguin'], [1565608080.458, '0.2']] },
+                        { metric: { name: 'Name1' }, values: [[1565608080.458, '1'], [1565608080.458, 'bob'], [1565608080.458, '6']] },
+                        { metric: { name: 'Name2' }, values: [[1565608080.458, 'sally'], [1565608080.458, '-2'], [1565608080.458, '0.001']] }
                     ]
-                }};
-            const output = PrometheusQueryHelper.extractStatisticFromRange(response,'min');
+                }
+            };
+            const output = PrometheusQueryHelper.extractStatisticFromRange(response, 'min', 'name');
             output.should.be.an('map');
             output.size.should.equal(3);
             output.get('Name0').should.equal('-');
@@ -271,38 +294,40 @@ describe('PrometheusQueryHelper implementation', () => {
             output.get('Name2').should.equal('-');
         });
 
-        it('should retrive the maximum value from a matrix response with a single value', () => {
+        it('should retrieve the maximum value from a matrix response with a single value', () => {
             const response = {
-                status:'success',
-                data:{
+                status: 'success',
+                data: {
                     resultType: 'matrix',
-                    result:[
+                    result: [
                         {
-                            metric: {name:'Name0'},
-                            values:[
-                                [1565608080.458,3]
+                            metric: { name: 'Name0' },
+                            values: [
+                                [1565608080.458, 3]
                             ]
                         }
                     ]
-                }};
-            const output = PrometheusQueryHelper.extractStatisticFromRange(response, 'max');
+                }
+            };
+            const output = PrometheusQueryHelper.extractStatisticFromRange(response, 'max', 'name');
             output.should.be.an('map');
             output.size.should.equal(1);
             output.get('Name0').should.equal(3);
         });
 
-        it('should retrive the maximum value from a matrix response with multiple values', () => {
+        it('should retrieve the maximum value from a matrix response with multiple values', () => {
             const response = {
-                status:'success',
-                data:{
+                status: 'success',
+                data: {
                     resultType: 'matrix',
-                    result:[
-                        {metric: {name:'Name0'},values:[[1565608080.458,3], [1565608080.458,4.8], [1565608080.458,0.2]]},
-                        {metric: {name:'Name1'},values:[[1565608080.458,1], [1565608080.458,8], [1565608080.458,6]]},
-                        {metric: {name:'Name2'},values:[[1565608080.458,0.1], [1565608080.458,-2], [1565608080.458,0.001]]}
+                    result: [
+                        { metric: { name: 'Name0' }, values: [[1565608080.458, 3], [1565608080.458, 4.8], [1565608080.458, 0.2]] },
+                        { metric: { name: 'Name1' }, values: [[1565608080.458, 1], [1565608080.458, 8], [1565608080.458, 6]] },
+                        { metric: { name: 'Name2' }, values: [[1565608080.458, 0.1], [1565608080.458, -2], [1565608080.458, 0.001]] }
                     ]
-                }};
-            const output = PrometheusQueryHelper.extractStatisticFromRange(response, 'max');
+                }
+            };
+            const output = PrometheusQueryHelper.extractStatisticFromRange(response, 'max', 'name');
             output.should.be.an('map');
             output.size.should.equal(3);
             output.get('Name0').should.equal(4.8);
@@ -310,54 +335,38 @@ describe('PrometheusQueryHelper implementation', () => {
             output.get('Name2').should.equal(0.1);
         });
 
-        const bob = {
-            'status':'success',
-            'data':{
-                'resultType':'matrix',
-                'result':[
-                    {
-                        'metric':{},
-                        'values':[
-                            [1565625618.564,'0.324'],
-                            [1565625619.564,'0.324'],
-                            [1565625620.564,'0.35']]
-                    }
-                ]
-            }
-        };
-
-
-        it('should retrive the maximum value from a matrix response with a single value and no name', () => {
+        it('should retrieve the maximum value from a matrix response with a single value and no name', () => {
             const response = {
-                status:'success',
-                data:{
+                status: 'success',
+                data: {
                     resultType: 'matrix',
-                    result:[
+                    result: [
                         {
-                            values:[
-                                [1565608080.458,3]
+                            values: [
+                                [1565608080.458, 3]
                             ]
                         }
                     ]
-                }};
+                }
+            };
             const output = PrometheusQueryHelper.extractStatisticFromRange(response, 'max');
             output.should.be.an('map');
             output.size.should.equal(1);
             output.get('unknown').should.equal(3);
         });
 
-        it.only('should retrive the maximum value from a matrix response that is numerical but contains no names', () => {
+        it('should retrieve the maximum value from a matrix response that is numerical but contains no names', () => {
             const response = {
-                'status':'success',
-                'data':{
-                    'resultType':'matrix',
-                    'result':[
+                'status': 'success',
+                'data': {
+                    'resultType': 'matrix',
+                    'result': [
                         {
-                            'metric':{},
-                            'values':[
-                                [1565625618.564,'0.7'],
-                                [1565625619.564,'0.324'],
-                                [1565625620.564,'0.35']]
+                            'metric': {},
+                            'values': [
+                                [1565625618.564, '0.7'],
+                                [1565625619.564, '0.324'],
+                                [1565625620.564, '0.35']]
                         }
                     ]
                 }
@@ -368,18 +377,19 @@ describe('PrometheusQueryHelper implementation', () => {
             output.get('unknown').should.equal(0.7);
         });
 
-        it('should retrive the maximum value from a matrix response that is string', () => {
+        it('should retrieve the maximum value from a matrix response that is string', () => {
             const response = {
-                status:'success',
-                data:{
+                status: 'success',
+                data: {
                     resultType: 'matrix',
-                    result:[
-                        {metric: {name:'Name0'},values:[[1565608080.458,'banana'], [1565608080.458,'penguin'], [1565608080.458,'0.2']]},
-                        {metric: {name:'Name1'},values:[[1565608080.458,'1'], [1565608080.458,'bob'], [1565608080.458,'6']]},
-                        {metric: {name:'Name2'},values:[[1565608080.458,'sally'], [1565608080.458,'-2'], [1565608080.458,'0.001']]}
+                    result: [
+                        { metric: { name: 'Name0' }, values: [[1565608080.458, 'banana'], [1565608080.458, 'penguin'], [1565608080.458, '0.2']] },
+                        { metric: { name: 'Name1' }, values: [[1565608080.458, '1'], [1565608080.458, 'bob'], [1565608080.458, '6']] },
+                        { metric: { name: 'Name2' }, values: [[1565608080.458, 'sally'], [1565608080.458, '-2'], [1565608080.458, '0.001']] }
                     ]
-                }};
-            const output = PrometheusQueryHelper.extractStatisticFromRange(response, 'max');
+                }
+            };
+            const output = PrometheusQueryHelper.extractStatisticFromRange(response, 'max', 'name');
             output.should.be.an('map');
             output.size.should.equal(3);
             output.get('Name0').should.equal('-');
@@ -388,13 +398,13 @@ describe('PrometheusQueryHelper implementation', () => {
         });
 
         it('should retrieve the average value from a matrix response', () => {
-            const repsonse = {
+            const response = {
                 data: {
                     resultType: 'matrix',
-                    result : [{values: [[111, 1] , [111, 1], [111, 2], [111, 2], [111, 8]]}]
+                    result: [{ values: [[111, 1], [111, 1], [111, 2], [111, 2], [111, 8]] }]
                 }
             };
-            const output = PrometheusQueryHelper.extractStatisticFromRange(repsonse, 'avg');
+            const output = PrometheusQueryHelper.extractStatisticFromRange(response, 'avg');
             output.should.be.an('map');
             output.size.should.equal(1);
             output.get('unknown').should.equal(2.8);
@@ -404,23 +414,23 @@ describe('PrometheusQueryHelper implementation', () => {
             const response = {
                 data: {
                     resultType: 'matrix',
-                    result : [1]
+                    result: [1]
                 }
             };
-            const output = PrometheusQueryHelper.extractStatisticFromRange(response,'min');
+            const output = PrometheusQueryHelper.extractStatisticFromRange(response, 'min');
             output.should.be.an('map');
             output.size.should.equal(1);
             output.get('unknown').should.equal('-');
         });
 
-        it('should return `-` if no values field' , () => {
+        it('should return `-` if no values field', () => {
             const response = {
                 data: {
                     resultType: 'matrix',
-                    result : [{missing: 'yes'}]
+                    result: [{ missing: 'yes' }]
                 }
             };
-            const output = PrometheusQueryHelper.extractStatisticFromRange(response,'min');
+            const output = PrometheusQueryHelper.extractStatisticFromRange(response, 'min');
             output.should.be.an('map');
             output.size.should.equal(1);
             output.get('unknown').should.equal('-');
@@ -446,18 +456,18 @@ describe('PrometheusQueryHelper implementation', () => {
         ];
 
         it('should return numeric values by default', () => {
-            const vals = PrometheusQueryHelper.extractValuesFromTimeSeries(numberSeries);
-            vals.should.be.an('array').of.length(4).that.deep.equals([1,2,3,4]);
+            const values = PrometheusQueryHelper.extractValuesFromTimeSeries(numberSeries);
+            values.should.be.an('array').of.length(4).that.deep.equals([1, 2, 3, 4]);
         });
 
         it('should cast to numeric values if specified', () => {
-            const vals = PrometheusQueryHelper.extractValuesFromTimeSeries(stringSeries, true);
-            vals.should.be.an('array').of.length(4).that.deep.equals([1,2,3,4]);
+            const values = PrometheusQueryHelper.extractValuesFromTimeSeries(stringSeries, true);
+            values.should.be.an('array').of.length(4).that.deep.equals([1, 2, 3, 4]);
         });
 
         it('should return string values if specified', () => {
-            const vals = PrometheusQueryHelper.extractValuesFromTimeSeries(stringSeries, false);
-            vals.should.be.an('array').of.length(4).that.deep.equals(['1','2','3','4']);
+            const values = PrometheusQueryHelper.extractValuesFromTimeSeries(stringSeries, false);
+            values.should.be.an('array').of.length(4).that.deep.equals(['1', '2', '3', '4']);
         });
     });
 


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

The Prometheus enablement PR managed to sneak in a `.only` in a mocha test, which essentially killed all the existing unit tests .... this fixes that!