### PR TITLE
Add none monitor as fallback, fix log target enablement issue

### DIFF
--- a/packages/caliper-core/lib/monitor/monitor-orchestrator.js
+++ b/packages/caliper-core/lib/monitor/monitor-orchestrator.js
@@ -42,7 +42,8 @@ class MonitorOrchestrator {
         // Parse the config and retrieve the monitor types
         const m = this.config.monitor;
         if(typeof m === 'undefined') {
-            throw new Error('Failed to find a monitor in the config file');
+            logger.info('No monitor specified, will default to "none"');
+            return;
         }
 
         if(typeof m.type === 'undefined') {

--- a/packages/caliper-core/lib/utils/log-formats.js
+++ b/packages/caliper-core/lib/utils/log-formats.js
@@ -30,7 +30,11 @@ const colorizeExtra = format((info, opts) => {
         if (info[key] !== undefined && (opts.all || opts[key])) {
             // surround the value with the style codes one by one
             for (let style of colorStyles) {
-                info[key] = colors[style](info[key]);
+                try {
+                    info[key] = colors[style](info[key]);
+                } catch (e) {
+                    // silent fail, can't log here
+                }
             }
         }
     }

--- a/packages/caliper-core/lib/utils/logging-util.js
+++ b/packages/caliper-core/lib/utils/logging-util.js
@@ -298,7 +298,7 @@ function _createConfiguredLogger() {
         // skip disabled targets
         // NOTE: read property directly from config, so it can be overridden
         let enabled = conf.get(`caliper-logging-targets-${target}-enabled`);
-        if (enabled && enabled === false) {
+        if (enabled !== undefined && enabled === false) {
             continue;
         }
 

--- a/packages/caliper-tests-integration/fabric_tests/phase1/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase1/benchconfig.yaml
@@ -30,9 +30,3 @@ test:
       txNumber: [100]
       rateControl: [{ type: 'linear-rate', opts: { startingTps: 10, finishingTps: 20 } }]
       callback: ../query.js
-observer:
-    interval: 1
-    type: none
-monitor:
-    interval: 1
-    type: ['none']

--- a/packages/caliper-tests-integration/fabric_tests/run.sh
+++ b/packages/caliper-tests-integration/fabric_tests/run.sh
@@ -13,9 +13,8 @@
 # limitations under the License.
 #
 
-# Exit on first error, print all commands.
-set -ev
-set -o pipefail
+# Print all commands.
+set -v
 
 # Grab the parent (fabric_tests) directory.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -34,10 +33,16 @@ export CALL_METHOD="node ../../caliper-cli/caliper.js"
 # change default settings (add config paths too)
 export CALIPER_PROJECTCONFIG=../caliper.yaml
 
+dispose () {
+    ${CALL_METHOD} benchmark run --caliper-workspace phase5 --caliper-flow-only-end
+}
+
 # PHASE 1: just starting the network
 ${CALL_METHOD} benchmark run --caliper-workspace phase1 --caliper-flow-only-start
 rc=$?
 if [[ ${rc} != 0 ]]; then
+    echo "Failed CI step 1";
+    dispose;
     exit ${rc};
 fi
 
@@ -46,6 +51,8 @@ fi
 ${CALL_METHOD} benchmark run --caliper-workspace phase2 --caliper-flow-only-init
 rc=$?
 if [[ ${rc} != 0 ]]; then
+    echo "Failed CI step 2";
+    dispose;
     exit ${rc};
 fi
 
@@ -53,6 +60,8 @@ fi
 ${CALL_METHOD} benchmark run --caliper-workspace phase3 --caliper-flow-skip-start --caliper-flow-skip-end --caliper-flow-skip-test
 rc=$?
 if [[ ${rc} != 0 ]]; then
+    echo "Failed CI step 3";
+    dispose;
     exit ${rc};
 fi
 
@@ -60,6 +69,8 @@ fi
 ${CALL_METHOD} benchmark run --caliper-workspace phase3 --caliper-flow-skip-start --caliper-flow-skip-end --caliper-flow-skip-test
 rc=$?
 if [[ ${rc} != 0 ]]; then
+    echo "Failed CI step 4";
+    dispose;
     exit ${rc};
 fi
 
@@ -67,6 +78,8 @@ fi
 ${CALL_METHOD} benchmark run --caliper-workspace phase4 --caliper-flow-only-test
 rc=$?
 if [[ ${rc} != 0 ]]; then
+    echo "Failed CI step 5";
+    dispose;
     exit ${rc};
 fi
 
@@ -74,6 +87,8 @@ fi
 ${CALL_METHOD} benchmark run --caliper-workspace phase4 --caliper-flow-only-test --caliper-fabric-usegateway
 rc=$?
 if [[ ${rc} != 0 ]]; then
+    echo "Failed CI step 6";
+    dispose;
     exit ${rc};
 fi
 
@@ -81,5 +96,6 @@ fi
 ${CALL_METHOD} benchmark run --caliper-workspace phase5 --caliper-flow-only-end
 rc=$?
 if [[ ${rc} != 0 ]]; then
+    echo "Failed CI step 7";
     exit ${rc};
 fi


### PR DESCRIPTION
Signed-off-by: Attila Klenik <a.klenik@gmail.com>

PR includes the following small fixes:
1. Add `none` monitor as fallback value when not set. Also testing this during CI.
2. Fix bug when disabling logging targets.
3. Treat unknown coloring styles with silent failure.
4. Disposing network after unsuccessful CI steps (mainly for local testing, doesn't matter on Travis)