### PR TITLE
Enable charts to be included in output report

### DIFF
--- a/packages/caliper-core/lib/common/config/Config.js
+++ b/packages/caliper-core/lib/common/config/Config.js
@@ -29,7 +29,13 @@ const keys = {
     },
     Report: {
         Path: 'caliper-report-path',
-        Options: 'caliper-report-options'
+        Options: 'caliper-report-options',
+        Precision: 'caliper-report-precision',
+        Charting: {
+            Hue: 'caliper-report-charting-hue',
+            Scheme: 'caliper-report-charting-scheme',
+            Transparency: 'caliper-report-charting-transparency'
+        }
     },
     Workspace: 'caliper-workspace',
     ProjectConfig: 'caliper-projectconfig',

--- a/packages/caliper-core/lib/common/config/default.yaml
+++ b/packages/caliper-core/lib/common/config/default.yaml
@@ -31,6 +31,13 @@ caliper:
         options:
             flag: 'w'
             mode: 0666
+        # Precision (significant figures) for the report output
+        precision: 3
+        # Charting options
+        charting:
+            hue: 21
+            scheme: 'triade'
+            transparency: 0.6
     # Workspace directory that contains all configuration information
     workspace: './'
     # The file path for the project-level configuration file. Can be relative to the workspace.
@@ -43,10 +50,6 @@ caliper:
     benchconfig:
     # Path to the blockchain configuration file that contains information required to interact with the SUT
     networkconfig:
-    # Address of a ZooKeeper node used by distributed clients
-    zooaddress:
-    # Path to a zookeeper service yaml file
-    zooconfig:
     # Sets the frequency of the progress reports in milliseconds
     txupdatetime: 1000
     # Configurations related to the logging mechanism

--- a/packages/caliper-core/lib/master/charts/chart-builder.js
+++ b/packages/caliper-core/lib/master/charts/chart-builder.js
@@ -1,0 +1,252 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
+'use strict';
+
+const Util = require('../../common/utils/caliper-utils');
+const Logger = Util.getLogger('chart-builder');
+const ConfigUtil = require('../../common/config/config-util');
+
+const ColorScheme = require('color-scheme');
+
+/**
+ * ChartBuilder class for generating chart information to include in a test report
+ */
+class ChartBuilder {
+
+    /**
+     * Return chart statistics for the passed resourceStats
+     * @param {string} callingMonitor the calling class name of the monitor, required to create a UUID
+     * @param {Object} chartTypes the chart information for a monitor
+     * @param {string} testLabel the current test label, required to create a UUID
+     * @param {Map<string, string>[]} resourceStatsArray the resource stats to work with
+     * @returns {Object[]} an array of chart stats object
+     */
+    static retrieveChartStats(callingMonitor, chartTypes, testLabel, resourceStatsArray) {
+        const chartArray = [];
+        // Produce each chart type requested
+        for (const chartType of Object.keys(chartTypes)) {
+            const metrics = chartTypes[chartType].metrics;
+            const includeMetrics = ChartBuilder.retrieveIncludedMetrics(callingMonitor, chartType, metrics, resourceStatsArray[0]);
+            switch (chartType) {
+            case 'bar': {
+                const barCharts = ChartBuilder.barChart(callingMonitor, testLabel, includeMetrics, resourceStatsArray);
+                chartArray.push(...barCharts);
+                break;
+            }
+            case 'polar': {
+                const polarCharts = ChartBuilder.polarChart(callingMonitor, testLabel, includeMetrics, resourceStatsArray);
+                chartArray.push(...polarCharts);
+                break;
+            }
+            default:
+                Logger.error(`Unknown chart type named "${chartType}" requested`);
+            }
+        }
+
+        return chartArray;
+    }
+
+    /**
+     * Determine the metric names to include
+     * @param {string} callingMonitor calling className
+     * @param {string} chartType chart type
+     * @param {string[]} includeMetrics items to include ['all'] or ['item0', 'item1', ...]
+     * @param {Map<string, string>} resourceStats a resource stat
+     * @returns {string[]} a string array of metric names
+     */
+    static retrieveIncludedMetrics(callingMonitor, chartType, includeMetrics, resourceStats) {
+        // includeMetrics must exist!
+        if (!includeMetrics) {
+            Logger.error(`Required "metrics" not provided for ${chartType} chart generation for monitor ${callingMonitor}`);
+            return [];
+        }
+
+        // Cannot have 'all' with other items
+        if (includeMetrics.indexOf('all') !== -1 && includeMetrics.length > 1) {
+            Logger.error(`Cannot list "all" option with other metrics for ${chartType} chart generation for monitor ${callingMonitor}`);
+            return [];
+        }
+
+        const metrics = [];
+        for (const metric of resourceStats.keys()) {
+            // Do not include 'Name'
+            if ((metric.localeCompare('Name') === 0) || (metric.localeCompare('Type') === 0)) {
+                continue;
+            }
+
+            // filter on all
+            if (includeMetrics[0].toLowerCase().localeCompare('all') === 0) {
+                Logger.debug(`Detected "all" option for ${chartType} chart generation for monitor ${callingMonitor}: including metric ${metric}`);
+                metrics.push(metric);
+                continue;
+            }
+
+            // filter on include
+            for (const include of includeMetrics) {
+                // beware of appended units to metric
+                if (metric.includes(include)) {
+                    Logger.debug(`Detected metric match on ${include} for ${chartType} chart generation for monitor ${callingMonitor}: including metric ${metric}`);
+                    metrics.push(metric);
+                    continue;
+                }
+            }
+        }
+        return metrics;
+    }
+
+    /**
+     * Extract red component from hex value
+     * @param {hex} h the hex code
+     * @returns {number} the R component (0 -> 256)
+     */
+    static hexToR(h) {
+        return parseInt((ChartBuilder.cutHex(h)).substring(0,2),16);
+    }
+
+    /**
+     * Extract green component from hex value
+     * @param {hex} h the hex code
+     * @returns {number} the G component (0 -> 256)
+     */
+    static hexToG(h) {
+        return parseInt((ChartBuilder.cutHex(h)).substring(2,4),16);
+    }
+
+    /**
+     * Extract blue component from hex value
+     * @param {hex} h the hex code
+     * @returns {number} the B component (0 -> 256)
+     */
+    static hexToB(h) {
+        return parseInt((ChartBuilder.cutHex(h)).substring(4,6),16);
+    }
+
+    /**
+     * Extract red component from hex value
+     * @param {hex} h the hex code
+     * @returns {hex} the hex code without the leading #
+     */
+    static cutHex(h) {
+        return (h.charAt(0)==='#') ? h.substring(1,7) : h;
+    }
+
+    /**
+     * Use for building a bar or polar chart
+     *  {
+            'chart-id': 'UUID for chart',
+            'chart-data': JSON.stringify({
+                labels: [obj0, obj1, obj2, ...]
+                type: 'bar' | 'polar',
+                title: metric name,
+                legend: false,
+                datasets: [
+                    {
+                        backgroundColor,
+                        data: [obj0_data, obj1_data, obj2_data, ...],
+                    }
+                ]
+            })
+        }
+     *
+     * @param {string} callingMonitor the calling class name used to create a UUID
+     * @param {string} testLabel the current test label, required for creating a UUID
+     * @param {string[]} includeMetrics the metrics to include in the chart
+     * @param {Map<string, string>[]} resourceStatsArray all resource stats
+     * @param {string} chartType the chart type (bar or polar)
+     * @param {boolean} legend boolean flag to include legend or not
+     * @returns {Object[]} an array of charting objects
+     */
+    static _basicChart(callingMonitor, testLabel, includeMetrics, resourceStatsArray, chartType, legend){
+        // Loop over desired metrics
+        const charts = [];
+        let chartIndex = 0;
+        for (const metricName of includeMetrics) {
+
+            // Top Level Item
+            const chart = {
+                'chart-id': `${callingMonitor}_${testLabel}_${chartType}${chartIndex++}`,
+            };
+
+            // Chart Data - building on names
+            const chartData = {
+                type: chartType,
+                title: metricName,
+                legend: legend,
+            };
+
+            // Pull charting options from config to retrieve charting colours
+            const hue = ConfigUtil.get(ConfigUtil.keys.Report.Charting.Hue, 21);
+            const scheme = ConfigUtil.get(ConfigUtil.keys.Report.Charting.Scheme, 'triade');
+            const transparency = ConfigUtil.get(ConfigUtil.keys.Report.Charting.Transparency, 0.6);
+            const labels = [];
+            const data = [];
+            const backgroundColor = [];
+            const colourScheme = new ColorScheme;
+            const colours = colourScheme.from_hue(hue).scheme(scheme).colors();
+            let i=0;
+            for (const stat of resourceStatsArray) {
+                // condition the retrieved value (numeric or zero)
+                const value = stat.get(metricName);
+                data.push(isNaN(value) ? 0 : value);
+                labels.push(stat.get('Name'));
+                // use rgba values so that we can include a transparency
+                backgroundColor.push(`rgb(${ChartBuilder.hexToR(colours[i])},${ChartBuilder.hexToG(colours[i])},${ChartBuilder.hexToB(colours[i])},${transparency})`);
+                i++;
+                // We might have more data points than available colours, so reset the index if required
+                if (i>=colours.length) {
+                    i = 0;
+                }
+            }
+
+            chartData.labels = labels;
+            chartData.datasets = [{backgroundColor, data}];
+            chart['chart-data'] = JSON.stringify(chartData);
+            charts.push(chart);
+        }
+        return charts;
+    }
+
+    /**
+     * Output an object that may be used by the template engine to render a bar chart within charting.js
+     *
+     * Bar charts assume the output of a single chart per metric, for all known names
+     *
+     * @param {string} callingMonitor the calling class, required for creating a UUID
+     * @param {string} testLabel the current test label, required for creating a UUID
+     * @param {string[]} includeMetrics metrics to be included in the output chart
+     * @param {Map<string, string>[]} resourceStatsArray resource statistics to inspect and extract information from
+     * @returns {Object[]} an array of charting objects
+     */
+    static barChart(callingMonitor, testLabel, includeMetrics, resourceStatsArray) {
+        return ChartBuilder._basicChart(callingMonitor, testLabel, includeMetrics, resourceStatsArray, 'horizontalBar', false);
+    }
+
+    /**
+     * Polar charts assume the output of a single chart per metric, for all known names
+     *
+     * @param {string} callingMonitor the calling class, required for creating a UUID
+     * @param {string} testLabel the current test label, required for creating a UUID
+     * @param {string[]} includeMetrics metrics to be included in the output chart
+     * @param {Map<string, string>[]} resourceStatsArray resource statistics to inspect and extract information from
+     * @returns {Object[]} an array of charting objects
+     */
+    static polarChart(callingMonitor, testLabel, includeMetrics, resourceStatsArray) {
+        return ChartBuilder._basicChart(callingMonitor, testLabel, includeMetrics, resourceStatsArray, 'polarArea', true);
+    }
+
+}
+
+module.exports = ChartBuilder;

--- a/packages/caliper-core/lib/master/monitor/monitor-orchestrator.js
+++ b/packages/caliper-core/lib/master/monitor/monitor-orchestrator.js
@@ -150,11 +150,12 @@ class MonitorOrchestrator {
     /**
     * Get an Array of statistics maps for a named resource monitor
     * @param {String} type the monitor type
+    * @param {String} testLabel the current test label
     * @return {Map<string, string>[]} an array of resource maps
     * @async
     */
-    async getStatisticsForMonitor(type) {
-        return await this.monitors.get(type).getStatistics();
+    async getStatisticsForMonitor(type, testLabel) {
+        return await this.monitors.get(type).getStatistics(testLabel);
     }
 }
 

--- a/packages/caliper-core/lib/master/report/template/report.html
+++ b/packages/caliper-core/lib/master/report/template/report.html
@@ -1,4 +1,25 @@
 <!doctype html>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.min.js"></script>
+<script>
+    function plotChart(divId, chartData) {
+        // Convert from stringified html, to valid JSON
+        const chartDetails = JSON.parse(chartData.replace(/&quot;/g,'"'));
+        new Chart(document.getElementById(divId), {
+            type: chartDetails.type,
+            data: {
+                labels: chartDetails.labels,
+                datasets: chartDetails.datasets
+            },
+            options: {
+                legend: { display: chartDetails.legend },
+                title: {
+                    display: true,
+                    text: chartDetails.title
+                }
+            }
+        });
+    }
+</script>
 <html>
 <head>
     <title>Hyperledger Caliper Report</title>
@@ -7,38 +28,34 @@
         .left-column {
             position: fixed;
             width:20%;
-            border-radius: 5px;
-            background-color: #f2f2f2;
-            -webkit-border-radius: 5px;
-            -moz-border-radius: 5px;
-            -khtml-border-radius: 5px;
+        }
+        .left-column ul {
+            display: block;
+            padding: 0;
+            list-style: none;
+            border-bottom: 1px solid #d9d9d9;
+            font-size: 14px;
+        }
+        .left-column h2{
+            font-size: 24px;
+            font-weight: 400;
+            margin-block-end: 0.5em;
+        }
+        .left-column h3{
+            font-size: 18px;
+            font-weight: 400;
+            margin-block-end: 0.5em;
+        }
+        .left-column li{
+            margin-left: 10px;
+            margin-bottom: 5px;
+            color: #5e6b73;
         }
         .right-column {
             margin-left: 22%;
             width:60%;
         }
-        .left-column ul,h2 {
-            display: block;
-            margin: 10px;
-            padding: 0;
-            list-style: none;
-        }
-        .left-column ul{
-            border-top: 1px solid #d9d9d9;
-            font-size: 14px;
-        }
-        .left-column li{
-            margin-bottom: 5px;
-            color: #5e6b73;
-        }
-        .left-column h3 {
-            border-left: 5px solid #009a61;
-        }
-        .right-column>div {
-            border-top: 1px solid #d9d9d9;
-        }
         .right-column table {
-            font-family: verdana,arial,sans-serif;
             font-size:11px;
             color:#333333;
             border-width: 1px;
@@ -46,8 +63,19 @@
             border-collapse: collapse;
             margin-bottom: 10px;
         }
+        .right-column h2{
+            font-weight: 400;
+        }
+        .right-column h3{
+            font-weight: 400;
+        }
+        .right-column h4 {
+            font-weight: 400;
+            margin-block-end: 0;
+        }
         .right-column th {
             border-width: 1px;
+            font-size: small;
             padding: 8px;
             border-style: solid;
             border-color: #666666;
@@ -55,24 +83,16 @@
         }
         .right-column td {
             border-width: 1px;
+            font-size: small;
             padding: 8px;
             border-style: solid;
             border-color: #666666;
             background-color: #ffffff;
+            font-weight: 400;
         }
         .tag {
-            display: inline-block;
             margin-bottom: 10px;
             padding: 5px 10px;
-            background-color: rgba(1,126,102,0.08);
-            font-family: verdana,arial,sans-serif;
-            font-size:11px;
-            color: #017E66;
-            text-align: center;
-            border-radius: 5px;
-            -webkit-border-radius: 5px;
-            -moz-border-radius: 5px;
-            -khtml-border-radius: 5px;
         }
         pre {
             padding: 10px;
@@ -86,101 +106,120 @@
             max-height:300px;
             font-size:12px;
         }
+        .charting {
+            display:flex;
+            flex-direction:row;
+            flex-wrap: wrap;
+            page-break-inside: auto;
+        }
+        .chart {
+            display:flex;
+            flex:1;
+            max-width: 50%;
+        }
     </style>
 </head>
-<body>
-
-<main>
-    <div class="left-column">
-        <h2>Caliper Report</h2>
-        <ul>
-            <h3>&nbspBasic information</h3>
-            {{#summary.meta}}
-            <li><strong>{{name}}: &nbsp</strong><span>{{value}}</span></li>
-            {{/summary.meta}}
-            <li><a href="#benchmarkInfo">Details</a></li>
-        </ul>
-        <ul>
-            <h3>&nbspBenchmark results</h3>
-            <li><a href="#benchmarksummary">Summary</a></li>
-            {{#tests}}
-                <li><a href="#{{label}}">{{label}}</a></li>
-            {{/tests}}
-        </ul>
-        <ul>
-            <h3>&nbspSystem Under Test</h3>
-            {{#sut.meta}}
-            <li><strong>{{name}}: &nbsp</strong><span>{{value}}</span></li>
-            {{/sut.meta}}
-            <li><a href="#sutdetails">Details</a></li>
-        </ul>
-    </div>
-
-    <div class="right-column">
-        <div id="benchmarksummary">
-            {{#summary}}
-            <table>
-                <h3>Summary</h3>
-                <tr>
-                    {{#head}} <th>{{.}}</th>{{/head}}
-                </tr>
-
-                {{#results}}
-                <tr>
-                    {{#result}} <td>{{.}}</td>{{/result}}
-                </tr>
-                {{/results}}
-            </table>
-            {{/summary}}
+<body style="font-family: IBM Plex Sans; font-weight: 200;">
+    <main>
+        <div class="left-column">
+            <img src="https://hyperledger.github.io/caliper/assets/img/hyperledger_caliper_logo_color.png" style="width:95%;" alt="">
+            <ul>
+                <h3>&nbspBasic information</h3>
+                {{#summary.meta}}
+                <li>{{name}}: &nbsp<span style="font-weight: 500;">{{value}}</span></li>
+                {{/summary.meta}}
+                <li><a href="#benchmarkInfo">Details</a></li>
+            </ul>
+            <ul>
+                <h3>&nbspBenchmark results</h3>
+                <li><a href="#benchmarksummary">Summary</a></li>
+                {{#tests}}
+                    <li><a href="#{{label}}">{{label}}</a></li>
+                {{/tests}}
+            </ul>
+            <ul>
+                <h3>&nbspSystem under test</h3>
+                {{#sut.meta}}
+                <li>{{name}}: &nbsp<span style="font-weight: 500;">{{value}}</span></li>
+                {{/sut.meta}}
+                <li><a href="#sutdetails">Details</a></li>
+            </ul>
         </div>
-        {{#tests}}
-        <div id="{{label}}">
-            <h3>{{label}}</h3>
-            <p>{{description}}</p>
-                {{#rounds}}
-                <h3>{{id}}</h3>
-                <strong class="tag">Performance metrics</strong>
-                {{#performance}}
-                <table>
+
+        <div class="right-column">
+            <h1 style="padding-top: 3em; font-weight: 500;">Caliper report</h1>
+            <div style="border-bottom: 1px solid #d9d9d9; margin-bottom: 10px;" id="benchmarksummary">
+                {{#summary}}
+                <table style="min-width: 100%;">
+                    <h3>Summary of performance metrics</h3>
                     <tr>
                         {{#head}} <th>{{.}}</th>{{/head}}
                     </tr>
+
+                    {{#results}}
                     <tr>
                         {{#result}} <td>{{.}}</td>{{/result}}
                     </tr>
+                    {{/results}}
                 </table>
-                {{/performance}}
-                <strong class="tag">Resource consumption</strong>
-                {{#resources}}
-                <table>
-                    <tr>
-                    <table>
-                        <tr>
-                            {{#head}} <th>{{.}}</th>{{/head}}
-                        </tr>
-                        {{#results}}
-                        <tr>
-                            {{#result}} <td>{{.}}</td>{{/result}}
-                        </tr>
-                        {{/results}}
-                    </table>
-                    </tr>
-                </table>
-                {{/resources}}
-                {{/rounds}}
+                {{/summary}}
+            </div>
+            {{#tests}}
+            <div style="border-bottom: 1px solid #d9d9d9; padding-bottom: 10px;" id="{{label}}">
+                <h2>Benchmark round: {{label}}</h2>
+                <p>{{description}}</p>
+                <pre style="overflow: visible;white-space: pre-wrap;max-height:100%;">{{config}}</pre>
+                    {{#rounds}}
+                        <h3>Performance metrics for {{label}}</h3>
+                        {{#performance}}
+                            <table style="min-width: 100%;">
+                                <tr>
+                                    {{#head}} <th>{{.}}</th>{{/head}}
+                                </tr>
+                                <tr>
+                                    {{#result}} <td>{{.}}</td>{{/result}}
+                                </tr>
+                            </table>
+                        {{/performance}}
+                        <h3>Resource utilization for {{label}}</h3>
+                        {{#resources}}
+                            <h4>Resource monitor: {{monitor}}</h4>
+                            <table style="min-width: 100%;">
+                                <tr>
+                                <table>
+                                    <tr>
+                                        {{#head}} <th>{{.}}</th>{{/head}}
+                                    </tr>
+                                    {{#results}}
+                                    <tr>
+                                        {{#result}} <td>{{.}}</td>{{/result}}
+                                    </tr>
+                                    {{/results}}
+                                </table>
+                                </tr>
+                            </table>
+                            <div class="charting">
+                                {{#charts}}
+                                <div class="chart">
+                                    <canvas id="{{chart-id}}">
+                                        <script>plotChart("{{chart-id}}", "{{chart-data}}")</script>
+                                    </canvas>
+                                </div>
+                                {{/charts}}
+                            </div>
+                        {{/resources}}
+                    {{/rounds}}
+            </div>
+
+            {{/tests}}
+            <div style="border-bottom: 1px solid #d9d9d9; padding-bottom: 10px;">
+                <h2>Test Environment</h2>
+                <h3>benchmark config</h3>
+                <pre id="benchmarkInfo" style="overflow: visible;white-space: pre-wrap;max-height:100%;">{{benchmarkInfo}}</pre>
+                <h3>SUT</h3>
+                <pre id="sutdetails">{{sut.details}}</pre>
+            </div>
         </div>
-        {{/tests}}
-        <div>
-            <h3>Test Environment</h3>
-            <strong class="tag">benchmark config</strong>
-            <pre id="benchmarkInfo" style="overflow: visible;white-space: pre-wrap;max-height:100%;">{{benchmarkInfo}}</pre>
-            <strong class="tag">SUT</strong>
-            <pre id="sutdetails">{{sut.details}}</pre>
-        </div>
-    </div>
-
-
-</main>
-
+    </main>
 </body>
 </html>

--- a/packages/caliper-core/lib/master/test-runners/round-orchestrator.js
+++ b/packages/caliper-core/lib/master/test-runners/round-orchestrator.js
@@ -190,9 +190,9 @@ class RoundOrchestrator {
                 // - TPS
                 let idx;
                 if (this.monitorOrchestrator.hasMonitor('prometheus')) {
-                    idx = await this.report.processPrometheusTPSResults({start, end}, roundConfig.label, index);
+                    idx = await this.report.processPrometheusTPSResults({start, end}, roundConfig, index);
                 } else {
-                    idx = await this.report.processLocalTPSResults(results, roundConfig.label);
+                    idx = await this.report.processLocalTPSResults(results, roundConfig);
                 }
 
                 // - Resource utilization
@@ -214,8 +214,6 @@ class RoundOrchestrator {
             }
         }
 
-        let benchEndTime = Date.now();
-
         // clean up, with "silent" failure handling
         try {
             this.report.printResultsByRound();
@@ -236,6 +234,7 @@ class RoundOrchestrator {
             logger.error(`Error while stopping clients: ${err.stack || err}`);
         }
 
+        let benchEndTime = Date.now();
         logger.info(`Benchmark finished in ${(benchEndTime - benchStartTime)/1000.0} seconds. Total rounds: ${success + failed}. Successful rounds: ${success}. Failed rounds: ${failed}.`);
     }
 }

--- a/packages/caliper-core/package.json
+++ b/packages/caliper-core/package.json
@@ -19,6 +19,7 @@
     "npm": ">=5.6.0"
   },
   "dependencies": {
+    "color-scheme": "^1.0.1",
     "compare-versions": "^3.4.0",
     "dockerode": "^2.5.0",
     "fs-extra": "^8.0.1",

--- a/packages/caliper-core/test/master/charts/chart-builder.js
+++ b/packages/caliper-core/test/master/charts/chart-builder.js
@@ -1,0 +1,292 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+const rewire = require('rewire');
+const ChartBuilder = require('../../../lib/master/charts/chart-builder');
+const ChartBuilderRewire = rewire('../../../lib/master/charts/chart-builder');
+
+const chai = require('chai');
+chai.should();
+
+const sinon = require('sinon');
+
+describe('chart builder implementation', () => {
+
+    let sandbox;
+    let revert;
+    let FakeLogger;
+
+    const defaultType = 'bar';
+    const testMonitor = 'CallingMonitor';
+
+    const resource0 = new Map();
+    resource0.set('Name', 'resource0');
+    resource0.set('item0 [MB]', '510');
+    resource0.set('item1 [MB]', '1e4');
+
+    const resource1 = new Map();
+    resource1.set('Name', 'resource1');
+    resource1.set('item0 [MB]', '4.77e-8');
+    resource1.set('item1 [MB]', '23');
+
+    const resource2 = new Map();
+    resource2.set('Name', 'resource2');
+    resource2.set('item0 [MB]', '100');
+    resource2.set('item1 [MB]', '24');
+
+    describe('#retrieveIncludedMetrics', () => {
+
+        const resource0 = new Map();
+        resource0.set('Name', 'resource0');
+        resource0.set('item0 [MB]', '53');
+        resource0.set('item1 [MB]', '876');
+
+        beforeEach(() => {
+            revert = [];
+            sandbox = sinon.createSandbox();
+
+            FakeLogger = {
+                debug: () => {
+                },
+                error: () => {
+                },
+                warn: () => {
+                }
+            };
+            sandbox.stub(FakeLogger);
+        });
+
+        afterEach(() => {
+            if (revert.length) {
+                revert.forEach(Function.prototype.call, Function.prototype.call);
+            }
+            sandbox.restore();
+        });
+
+        it('should log an error and return an empty array if not provided any metrics', () => {
+            revert.push(ChartBuilderRewire.__set__('Logger', FakeLogger));
+            const all = ChartBuilderRewire.retrieveIncludedMetrics(testMonitor, defaultType, undefined, resource0);
+
+            // all should be empty
+            all.length.should.equal(0);
+            sinon.assert.called(FakeLogger.error);
+            sinon.assert.calledWith(FakeLogger.error, 'Required "metrics" not provided for bar chart generation for monitor CallingMonitor');
+
+        });
+
+        it('should log an error and return an empty array if the "all" option is listed with other metrics', () => {
+            revert.push(ChartBuilderRewire.__set__('Logger', FakeLogger));
+            const all = ChartBuilderRewire.retrieveIncludedMetrics(testMonitor, defaultType, ['all', 'anotherMetric'], resource0);
+
+            // all should be empty
+            all.length.should.equal(0);
+            sinon.assert.called(FakeLogger.error);
+            sinon.assert.calledWith(FakeLogger.error, 'Cannot list "all" option with other metrics for bar chart generation for monitor CallingMonitor');
+        });
+
+        it('should provide all metrics if the `all` option is provided', () => {
+            const all = ChartBuilder.retrieveIncludedMetrics(testMonitor, defaultType, ['all'], resource0);
+            all.should.deep.equal(['item0 [MB]', 'item1 [MB]']);
+
+        });
+
+        it('should provide filtered metrics if a named list is provided option is provided', () => {
+            const all = ChartBuilder.retrieveIncludedMetrics(testMonitor, defaultType, ['item1'], resource0);
+            all.should.deep.equal(['item1 [MB]']);
+
+        });
+    });
+
+    describe('ChartBuilder.retrieveChartStats', () => {
+
+        beforeEach(() => {
+            revert = [];
+            sandbox = sinon.createSandbox();
+
+            FakeLogger = {
+                debug: () => {
+                },
+                error: () => {
+                },
+                warn: () => {
+                }
+            };
+            sandbox.stub(FakeLogger);
+        });
+
+        afterEach(() => {
+            if (revert.length) {
+                revert.forEach(Function.prototype.call, Function.prototype.call);
+            }
+            sandbox.restore();
+        });
+
+        it('should call "barChart" if requested', () => {
+            const myBarStub = sinon.stub().returns([]);
+            sandbox.replace(ChartBuilder, 'barChart', myBarStub);
+            const myPolarStub = sinon.stub().returns([]);
+            sandbox.replace(ChartBuilder, 'polarChart', myPolarStub);
+
+            const resources = [resource0, resource1, resource2];
+            const chartTypes = {bar: {metrics: ['all']}};
+            ChartBuilder.retrieveChartStats(testMonitor, chartTypes, 'TEST', resources);
+
+            sinon.assert.calledOnce(myBarStub);
+            sinon.assert.notCalled(myPolarStub);
+        });
+
+        it('should call "polarChart" if requested', () => {
+            const myBarStub = sinon.stub().returns([]);
+            sandbox.replace(ChartBuilder, 'barChart', myBarStub);
+            const myPolarStub = sinon.stub().returns([]);
+            sandbox.replace(ChartBuilder, 'polarChart', myPolarStub);
+
+            const resources = [resource0, resource1, resource2];
+            const chartTypes = {polar: {metrics: ['all']}};
+            ChartBuilder.retrieveChartStats(testMonitor, chartTypes, 'TEST', resources);
+
+            sinon.assert.calledOnce(myPolarStub);
+            sinon.assert.notCalled(myBarStub);
+
+        });
+
+        it('should call all chart types passed', () => {
+            const myBarStub = sinon.stub().returns([]);
+            sandbox.replace(ChartBuilder, 'barChart', myBarStub);
+            const myPolarStub = sinon.stub().returns([]);
+            sandbox.replace(ChartBuilder, 'polarChart', myPolarStub);
+
+            const resources = [resource0, resource1, resource2];
+            const chartTypes = {bar: {metrics: ['all']}, polar: {metrics: ['all']}};
+            ChartBuilder.retrieveChartStats(testMonitor, chartTypes, 'TEST', resources);
+
+            sinon.assert.calledOnce(myBarStub);
+            sinon.assert.calledOnce(myPolarStub);
+
+        });
+        it('should call log error and return empty array if unknown chart type', () => {
+            revert.push(ChartBuilderRewire.__set__('Logger', FakeLogger));
+
+            const resources = [resource0, resource1, resource2];
+            const chartTypes = {unknown: {metrics: ['all']}};
+
+            const output = ChartBuilderRewire.retrieveChartStats(testMonitor, chartTypes, 'TEST', resources);
+
+            output.length.should.equal(0);
+            sinon.assert.called(FakeLogger.error);
+            sinon.assert.calledWith(FakeLogger.error, 'Unknown chart type named "unknown" requested');
+
+        });
+
+        it('should return an array of all items when the `all` option is specified', () => {
+
+            const resources = [resource0, resource1, resource2];
+            const chartTypes = {bar: {metrics: ['all']}};
+            const chart = ChartBuilder.retrieveChartStats(testMonitor, chartTypes, 'TEST', resources);
+
+            // expect 2 metric charts
+            chart.length.should.equal(2);
+
+            // chart should have correct structure
+            chart[0]['chart-id'].should.equal('CallingMonitor_TEST_horizontalBar0');
+            const chartData0 = JSON.parse(chart[0]['chart-data']);
+            chartData0.type.should.equal('horizontalBar');
+            chartData0.title.should.equal('item0 [MB]');
+            chartData0.legend.should.equal(false);
+            chartData0.labels.should.deep.equal(['resource0','resource1','resource2']);
+            chartData0.datasets[0].data.should.deep.equal(['510','4.77e-8','100']);
+
+
+            chart[1]['chart-id'].should.equal('CallingMonitor_TEST_horizontalBar1');
+            const chartData1 = JSON.parse(chart[1]['chart-data']);
+            chartData1.type.should.equal('horizontalBar');
+            chartData1.title.should.equal('item1 [MB]');
+            chartData1.legend.should.equal(false);
+            chartData1.labels.should.deep.equal(['resource0','resource1','resource2']);
+            chartData1.datasets[0].data.should.deep.equal(['1e4','23','24']);
+        });
+
+        it('should return an array of filtered items when named options are specified', () => {
+
+            const resources = [resource0, resource1, resource2];
+            const chartTypes = {bar: {metrics: ['item1']}};
+            const chart = ChartBuilder.retrieveChartStats(testMonitor, chartTypes, 'TEST', resources);
+
+            // one metric chart
+            chart.length.should.equal(1);
+
+            // chart should have correct structure
+            chart[0]['chart-id'].should.equal('CallingMonitor_TEST_horizontalBar0');
+            const chartData0 = JSON.parse(chart[0]['chart-data']);
+            chartData0.type.should.equal('horizontalBar');
+            chartData0.title.should.equal('item1 [MB]');
+            chartData0.legend.should.equal(false);
+            chartData0.labels.should.deep.equal(['resource0','resource1','resource2']);
+            chartData0.datasets[0].data.should.deep.equal(['1e4','23','24']);
+        });
+    });
+
+    describe('ChartBuilder.barChart', () => {
+
+        const testLabel = 'testLabel';
+        const include = {};
+
+        beforeEach(() => {
+            sandbox = sinon.createSandbox();
+        });
+
+        afterEach(() => {
+            sandbox.restore();
+        });
+
+        it('should call through to _basicChart with "horizontalBar" and no labels', () => {
+            const myStub = sinon.stub().returns([]);
+            sandbox.replace(ChartBuilder, '_basicChart', myStub);
+
+            const resources = [resource0, resource1, resource2];
+            ChartBuilder.barChart(testMonitor, testLabel, include, resources);
+
+
+            sinon.assert.calledOnce(myStub);
+            myStub.getCall(0).args.should.deep.equal([testMonitor, testLabel, include, resources, 'horizontalBar', false]);
+        });
+    });
+
+    describe('ChartBuilder.polarChart', () => {
+
+        const testLabel = 'testLabel';
+        const include = {};
+
+        beforeEach(() => {
+            sandbox = sinon.createSandbox();
+        });
+
+        afterEach(() => {
+            sandbox.restore();
+        });
+
+        it('should call through to _basicChart with "polarArea" and labels', () => {
+            const myStub = sinon.stub().returns([]);
+            sandbox.replace(ChartBuilder, '_basicChart', myStub);
+
+            const resources = [resource0, resource1, resource2];
+            ChartBuilder.polarChart(testMonitor, testLabel, include, resources);
+
+
+            sinon.assert.calledOnce(myStub);
+            myStub.getCall(0).args.should.deep.equal([testMonitor, testLabel, include, resources, 'polarArea', true]);
+        });
+    });
+});

--- a/packages/caliper-core/test/master/monitor/monitor-utilities.js
+++ b/packages/caliper-core/test/master/monitor/monitor-utilities.js
@@ -1,0 +1,174 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const Utilities = require('../../../lib/master/monitor/monitor-utilities');
+
+const mocha = require('mocha');
+const fail = mocha.fail;
+const chai = require('chai');
+chai.should;
+
+describe('Monitor utilities', () => {
+
+    describe('#Utilities.normalizeStats', () => {
+
+        let valuesMap0;
+        let valuesMap1;
+        let valuesMap2;
+        let mapArray;
+
+        beforeEach(() => {
+            // Dummy data
+            valuesMap0 = new Map();
+            valuesMap0.set('CPU', 500);
+            valuesMap0.set('Memory', 80000000);
+            valuesMap0.set('Disc', 200000000000);
+
+            valuesMap1 = new Map();
+            valuesMap1.set('CPU', 70000);
+            valuesMap1.set('Memory', 100000);
+            valuesMap1.set('Disc', 100000000000);
+
+            valuesMap2 = new Map();
+            valuesMap2.set('CPU', 4500);
+            valuesMap2.set('Memory', 500000);
+            valuesMap2.set('Disc', 300000000000);
+
+            mapArray = [valuesMap0, valuesMap1, valuesMap2];
+        });
+
+        it('should normalize all values to the hightest KB value present in the passed map', () => {
+
+            // Run static method
+            Utilities.normalizeStats('CPU', mapArray);
+
+            // Values for all 'CPU' items should be normalized to 70000 bytes
+            // We are also changing the name of the metric to include a unit, so we need to check what that might be too
+
+            let newName;
+            for (const name of valuesMap0.keys()) {
+                if (name.includes('CPU')) {
+                    newName = name;
+                    break;
+                }
+            }
+
+            // Should have modified to be 'CPU [KB]'
+            if (!newName) {
+                fail('Unable to determine modified name within Map array');
+            } else {
+                newName.should.equal('CPU [KB]');
+            }
+
+            // Values should have been modified to ref
+            valuesMap0.get(newName).should.equal('0.488');
+            valuesMap1.get(newName).should.equal('68.4');
+            valuesMap2.get(newName).should.equal('4.39');
+
+        });
+
+        it('should normalize all values to the hightest MB value present in the passed map', () => {
+            // Run static method
+            Utilities.normalizeStats('Memory', mapArray);
+
+            // Values for all 'CPU' items should be normalized to 70000 bytes
+            // We are also changing the name of the metric to include a unit, so we need to check what that might be too
+
+            let newName;
+            for (const name of valuesMap0.keys()) {
+                if (name.includes('Memory')) {
+                    newName = name;
+                    break;
+                }
+            }
+
+            // Should have modified to be 'Memory [MB]'
+            if (!newName) {
+                fail('Unable to determine modified name within Map array');
+            } else {
+                newName.should.equal('Memory [MB]');
+            }
+
+            // Values should have been modified to ref
+            valuesMap0.get(newName).should.equal('76.3');
+            valuesMap1.get(newName).should.equal('0.0954');
+            valuesMap2.get(newName).should.equal('0.477');
+        });
+
+        it('should normalize all values to the hightest GB value present in the passed map', () => {
+            // Run static method
+            Utilities.normalizeStats('Disc', mapArray);
+
+            // Values for all 'CPU' items should be normalized to 70000 bytes
+            // We are also changing the name of the metric to include a unit, so we need to check what that might be too
+
+            let newName;
+            for (const name of valuesMap0.keys()) {
+                if (name.includes('Disc')) {
+                    newName = name;
+                    break;
+                }
+            }
+
+            // Should have modified to be 'Disc [GB]'
+            if (!newName) {
+                fail('Unable to determine modified name within Map array');
+            } else {
+                newName.should.equal('Disc [GB]');
+            }
+
+            // Values should have been modified to ref
+            valuesMap0.get(newName).should.equal('186');
+            valuesMap1.get(newName).should.equal('93.1');
+            valuesMap2.get(newName).should.equal('279');
+        });
+
+        it('should return a normalized value that includes at least one significant figure', () => {
+
+            // New item with small relative value
+            const valuesMap3 = new Map();
+            valuesMap3.set('Memory', 0.05);
+
+            const newArray = [...mapArray, valuesMap3];
+            // Run static method
+            Utilities.normalizeStats('Memory', newArray);
+
+            // Check for modified name
+            let newName;
+            for (const name of valuesMap0.keys()) {
+                if (name.includes('Memory')) {
+                    newName = name;
+                    break;
+                }
+            }
+
+            // Should have modified to be 'Memory [MB]'
+            if (!newName) {
+                fail('Unable to determine modified name within Map array');
+            } else {
+                newName.should.equal('Memory [MB]');
+            }
+
+            // Values should have been modified to ref
+            valuesMap0.get(newName).should.equal('76.3');
+            valuesMap1.get(newName).should.equal('0.0954');
+            valuesMap2.get(newName).should.equal('0.477');
+            valuesMap3.get(newName).should.equal('4.77e-8');
+        });
+
+    });
+
+});

--- a/packages/caliper-tests-integration/fabric_tests/phase2/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase2/benchconfig.yaml
@@ -36,4 +36,5 @@ observer:
 monitor:
     interval: 1
     type: ['process']
-    process: [{ command: 'node', arguments: 'fabricClientWorker.js', multiOutput: 'avg' }]
+    process:
+        processes: [{ command: 'node', arguments: 'fabricClientWorker.js', multiOutput: 'avg' }]

--- a/packages/caliper-tests-integration/fabric_tests/phase3/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase3/benchconfig.yaml
@@ -36,6 +36,7 @@ observer:
 monitor:
     interval: 1
     type: ['process', 'docker']
-    process: [{ command: 'node', arguments: 'fabricClientWorker.js', multiOutput: 'avg' }]
+    process:
+        processes: [{ command: 'node', arguments: 'fabricClientWorker.js', multiOutput: 'avg' }]
     docker:
-        name: ['peer0.org1.example.com', 'peer0.org2.example.com', 'orderer0.example.com', 'orderer1.example.com']
+        containers: ['peer0.org1.example.com', 'peer0.org2.example.com', 'orderer0.example.com', 'orderer1.example.com']

--- a/packages/caliper-tests-integration/fabric_tests/phase4/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase4/benchconfig.yaml
@@ -53,3 +53,8 @@ monitor:
                     label: name
                     statistic: max
                     multiplier: 0.000001
+        charting:
+            polar:
+                metrics: [Max Memory (MB)]
+            bar:
+                metrics: [all]

--- a/packages/caliper-tests-integration/fabric_tests/phase5/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase5/benchconfig.yaml
@@ -36,4 +36,5 @@ observer:
 monitor:
     interval: 1
     type: ['process']
-    process: [{ command: 'node', arguments: 'fabricClientWorker.js', multiOutput: 'avg' }]
+    process:
+        processes: [{ command: 'node', arguments: 'fabricClientWorker.js', multiOutput: 'avg' }]


### PR DESCRIPTION
This PR provides enhanced report outputs for a user

Breaking changes:
- monitor configuration for docker and process monitors.
  - docker monitor `name` filter changed to `container`, to better reflect what it is filtering
  - process monitor now has the array of process to monitor under a `processes` block

Other Changes:
- Main report styling change
- Conversion of report tables to be normalised to a single metric. Each column is normalised to the largest value, to a user configurable precision. 
- Addition of charts to output report (user opt-in, for each monitor)

Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>
