### PR TITLE
Build Fix- modify web3 level

### DIFF
--- a/packages/caliper-ethereum/package.json
+++ b/packages/caliper-ethereum/package.json
@@ -22,7 +22,7 @@
     "@hyperledger/caliper-core": "0.2.0"
   },
   "devDependencies": {
-    "web3": "^1.2.0",
+    "web3": "1.2.2",
     "chai": "^3.5.0",
     "eslint": "^4.19.1",
     "mocha": "3.4.2",


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

Minor version bump in web3 has broken everything :(

This PR pins the web3 dependancy in the ethereum adaptor to a set (working) level