### PR TITLE
remove chalk usage in fisco adaptor

### DIFF
--- a/packages/caliper-fisco-bcos/lib/common.js
+++ b/packages/caliper-fisco-bcos/lib/common.js
@@ -15,20 +15,10 @@
 'use strict';
 
 const isArray = require('isarray');
-const chalk = require('chalk');
 const path = require('path');
 const fs = require('fs');
 const CaliperUtils = require('@hyperledger/caliper-core').CaliperUtils;
 const commLogger = CaliperUtils.getLogger('common.js');
-
-const Color = {
-    error: chalk.red.bold,
-    warn: chalk.yellow.bold,
-    info: chalk.blue.bold,
-    success: chalk.green.bold,
-    failure: chalk.red.bold
-};
-module.exports.Color = Color;
 
 const TxErrorEnum = {
     NoError: 0,
@@ -38,7 +28,7 @@ module.exports.TxErrorEnum = TxErrorEnum;
 
 module.exports.findContractAddress = function(workspaceRoot, smartContracts, contractID) {
     if (!isArray(smartContracts)) {
-        commLogger.error(Color.error('smartContracts should be an array'));
+        commLogger.error('smartContracts should be an array');
         return null;
     }
 
@@ -47,7 +37,7 @@ module.exports.findContractAddress = function(workspaceRoot, smartContracts, con
     });
 
     if (smartContract === undefined) {
-        commLogger.error(Color.error(`Smart contract ${contractID} undefined`));
+        commLogger.error(`Smart contract ${contractID} undefined`);
         return null;
     }
 
@@ -61,7 +51,7 @@ module.exports.findContractAddress = function(workspaceRoot, smartContracts, con
             return address;
         } catch (error) {
             if (error.code === 'ENOENT') {
-                commLogger.error(Color.error(`Address of smart contract ${smartContract.id} can't be determinied, please install it first!`));
+                commLogger.error(`Address of smart contract ${smartContract.id} can't be determinied, please install it first!`);
             }
             return null;
         }
@@ -69,7 +59,7 @@ module.exports.findContractAddress = function(workspaceRoot, smartContracts, con
         let address = smartContract.address;
         return address;
     } else {
-        commLogger.error(Color.error(`Smart contract of ${contractType} is not supported yet`));
+        commLogger.error(`Smart contract of ${contractType} is not supported yet`);
         return null;
     }
 };

--- a/packages/caliper-fisco-bcos/lib/fiscoBcos.js
+++ b/packages/caliper-fisco-bcos/lib/fiscoBcos.js
@@ -22,7 +22,6 @@ const installSmartContractImpl = require('./installSmartContract');
 const invokeSmartContractImpl = require('./invokeSmartContract');
 const generateRawTransactionImpl = require('./generateRawTransactions');
 const sendRawTransactionImpl = require('./sendRawTransactions');
-const Color = require('./common').Color;
 const commLogger = CaliperUtils.getLogger('fiscoBcos.js');
 
 /**
@@ -59,7 +58,7 @@ class FiscoBcos extends BlockchainInterface {
         try {
             await installSmartContractImpl.run(fiscoBcosSettings, this.workspaceRoot);
         } catch (error) {
-            commLogger.error(Color.error(`FISCO BCOS smart contract install failed: ${(error.stack ? error.stack : error)}`));
+            commLogger.error(`FISCO BCOS smart contract install failed: ${(error.stack ? error.stack : error)}`);
             throw error;
         }
     }
@@ -116,7 +115,7 @@ class FiscoBcos extends BlockchainInterface {
 
             return await Promise.all(promises);
         } catch (error) {
-            commLogger.error(Color.error(`FISCO BCOS smart contract invoke failed: ${(error.stack ? error.stack : JSON.stringify(error))}`));
+            commLogger.error(`FISCO BCOS smart contract invoke failed: ${(error.stack ? error.stack : JSON.stringify(error))}`);
             throw error;
         }
     }
@@ -134,7 +133,7 @@ class FiscoBcos extends BlockchainInterface {
         try {
             return invokeSmartContractImpl.run(context, this.fiscoBcosSettings, contractID, fcn, key, this.workspaceRoot, true);
         } catch (error) {
-            commLogger.error(Color.error(`FISCO BCOS smart contract query failed: ${(error.stack ? error.stack : error)}`));
+            commLogger.error(`FISCO BCOS smart contract query failed: ${(error.stack ? error.stack : error)}`);
             throw error;
         }
     }

--- a/packages/caliper-fisco-bcos/lib/fiscoBcosApi.js
+++ b/packages/caliper-fisco-bcos/lib/fiscoBcosApi.js
@@ -23,7 +23,6 @@ const isArray = require('isarray');
 const web3Sync = require('./web3lib/web3sync');
 const channelPromise = require('./channelPromise');
 const requestPromise = require('request-promise');
-const Color = require('./common').Color;
 const assert = require('assert');
 const events = require('events');
 const commLogger = CaliperUtils.getLogger('fiscoBcosApi.js');
@@ -44,7 +43,7 @@ async function compileContract(contractPath, outputDir) {
             resolve();
         });
         execEmitter.on('error', (stdout, stderr) => {
-            commLogger.error(Color.error(`Compiling error: ${stdout}\n${stderr}`));
+            commLogger.error(`Compiling error: ${stdout}\n${stderr}`);
             reject();
         });
     });
@@ -123,7 +122,7 @@ async function updateCurrentBlockNumber(networkConfig) {
             setTimeout(updateCurrentBlockNumber, 2000, networkConfig);
             return Promise.resolve(true);
         } else {
-            commLogger.warn(Color.warn(`Update current block number failed, result=${JSON.stringify(result)}`));
+            commLogger.warn(`Update current block number failed, result=${JSON.stringify(result)}`);
             return Promise.reject();
         }
     }).catch(async (reason) => {

--- a/packages/caliper-fisco-bcos/lib/generateRawTransactions.js
+++ b/packages/caliper-fisco-bcos/lib/generateRawTransactions.js
@@ -16,7 +16,7 @@
 
 const fs = require('fs');
 const { CaliperUtils, TxStatus } = require('@hyperledger/caliper-core');
-const { Color, TxErrorEnum, findContractAddress } = require('./common');
+const { TxErrorEnum, findContractAddress } = require('./common');
 const uuid = require('uuid/v4');
 const fiscoBcosApi = require('./fiscoBcosApi');
 const commLogger = CaliperUtils.getLogger('generateRawTransactions.js');
@@ -61,7 +61,7 @@ module.exports.run = async function (fiscoBcosSettings, workspaceRoot, context, 
         invokeStatus.SetStatusSuccess();
         return invokeStatus;
     } catch (error) {
-        commLogger.error(Color.error(`FISCO BCOS generate raw transaction failed: ${(error.stack ? error.stack : JSON.stringify(error))}`));
+        commLogger.error(`FISCO BCOS generate raw transaction failed: ${(error.stack ? error.stack : JSON.stringify(error))}`);
         throw error;
     }
 };

--- a/packages/caliper-fisco-bcos/lib/installSmartContract.js
+++ b/packages/caliper-fisco-bcos/lib/installSmartContract.js
@@ -20,7 +20,6 @@ const fs = require('fs-extra');
 const path = require('path');
 const fiscoBcosApi = require('./fiscoBcosApi');
 const assert = require('assert');
-const Color = require('./common').Color;
 const commLogger = CaliperUtils.getLogger('installSmartContract.js');
 
 module.exports.run = async function (fiscoBcosSettings, workspaceRoot) {
@@ -35,10 +34,10 @@ module.exports.run = async function (fiscoBcosSettings, workspaceRoot) {
         throw new Error('No available configuration for smart contracts');
     }
 
-    commLogger.info(Color.info('Deploying smart contracts ...'));
+    commLogger.info('Deploying smart contracts ...');
 
     for (let smartContract of smartContracts) {
-        commLogger.info(Color.info(`Deploying ${smartContract.id} ...`));
+        commLogger.info(`Deploying ${smartContract.id} ...`);
         let contractType = smartContract.language;
         if (contractType === 'solidity') {
             let contractPath = path.join(workspaceRoot, smartContract.path);
@@ -53,23 +52,23 @@ module.exports.run = async function (fiscoBcosSettings, workspaceRoot) {
 
                         let contractName = path.basename(contractPath, '.sol');
                         fs.outputFileSync(path.join(path.dirname(contractPath), `${contractName}.address`), contractAddress);
-                        commLogger.info(Color.success(`Deployed smart contract ${smartContract.id}, path=${smartContract.path}, address=${contractAddress}`));
+                        commLogger.info(`Deployed smart contract ${smartContract.id}, path=${smartContract.path}, address=${contractAddress}`);
                     } else {
-                        commLogger.error(Color.error(`Deploy receipt status error: ${JSON.stringify(body)}`));
+                        commLogger.error(`Deploy receipt status error: ${JSON.stringify(body)}`);
                     }
                 }).catch((reason)=>{
-                    commLogger.error(Color.error(`Depolying error: ${reason}`));
+                    commLogger.error(`Depolying error: ${reason}`);
                 });
 
                 await deployPromise;
             } catch (error) {
-                commLogger.error(Color.failure(`Failed to install smart contract ${smartContract.id}, path=${contractPath}`));
+                commLogger.error(`Failed to install smart contract ${smartContract.id}, path=${contractPath}`);
                 throw error;
             }
         } else if (contractType === 'precompiled') {
-            commLogger.info(Color.success(`Precompiled smart contract ${smartContract.id} appointed, address=${smartContract.address}`));
+            commLogger.info(`Precompiled smart contract ${smartContract.id} appointed, address=${smartContract.address}`);
         } else {
-            commLogger.error(Color.error(`Smart contract of ${contractType} is not supported yet`));
+            commLogger.error(`Smart contract of ${contractType} is not supported yet`);
             throw new Error('Smart contract type not supported');
         }
     }

--- a/packages/caliper-fisco-bcos/lib/invokeSmartContract.js
+++ b/packages/caliper-fisco-bcos/lib/invokeSmartContract.js
@@ -19,7 +19,7 @@ const {
     TxStatus
 } = require('@hyperledger/caliper-core');
 const fiscoBcosApi = require('./fiscoBcosApi');
-const { TxErrorEnum, Color, findContractAddress } = require('./common');
+const { TxErrorEnum, findContractAddress } = require('./common');
 const commLogger = CaliperUtils.getLogger('invokeSmartContract.js');
 
 module.exports.run = async function (context, fiscoBcosSettings, contractID, fcn, args, workspaceRoot, readOnly = false) {
@@ -54,13 +54,13 @@ module.exports.run = async function (context, fiscoBcosSettings, contractID, fcn
         if (receipt.error === undefined && (receipt.status === '0x0' || (receipt.result && receipt.result.status === '0x0'))) {
             invokeStatus.SetStatusSuccess();
         } else {
-            commLogger.error(Color.failure('Failed to invoke smart contract: ' + JSON.stringify(receipt)));
+            commLogger.error('Failed to invoke smart contract: ' + JSON.stringify(receipt));
             invokeStatus.SetStatusFail();
         }
 
         return invokeStatus;
     } catch (error) {
-        commLogger.error(Color.failure(`Failed to invoke smart contract ${contractID}: ${JSON.stringify(error)}`));
+        commLogger.error(`Failed to invoke smart contract ${contractID}: ${JSON.stringify(error)}`);
         throw error;
     }
 };

--- a/packages/caliper-fisco-bcos/lib/sendRawTransactions.js
+++ b/packages/caliper-fisco-bcos/lib/sendRawTransactions.js
@@ -15,7 +15,7 @@
 'use strict';
 
 const { CaliperUtils, TxStatus } = require('@hyperledger/caliper-core');
-const { Color, TxErrorEnum } = require('./common');
+const { TxErrorEnum } = require('./common');
 const uuid = require('uuid/v4');
 const fiscoBcosApi = require('./fiscoBcosApi');
 const commLogger = CaliperUtils.getLogger('generateRawTransactions.js');
@@ -40,7 +40,7 @@ module.exports.run = async function (fiscoBcosSettings, context, transactions) {
             if (receipt.error === undefined && (receipt.status === '0x0' || (receipt.result && receipt.result.status === '0x0'))) {
                 invokeStatus.SetStatusSuccess();
             } else {
-                commLogger.error(Color.failure('Failed to invoke smart contract: ' + JSON.stringify(receipt)));
+                commLogger.error('Failed to invoke smart contract: ' + JSON.stringify(receipt));
                 invokeStatus.SetStatusFail();
             }
 

--- a/packages/caliper-fisco-bcos/package.json
+++ b/packages/caliper-fisco-bcos/package.json
@@ -29,7 +29,6 @@
         "ora": "^1.2.0",
         "uuid": "^3.3.2",
         "tls": "^0.0.1",
-        "chalk": "1.1.3",
         "request-promise": "^4.2.1"
     },
     "devDependencies": {


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

FISCO adaptor includes chalk, which is not required as the Logger can provide colour options. This PR removes the chalk dependancy