### PR TITLE
enable gui

### DIFF
--- a/packages/caliper-gui-dashboard/.gitignore
+++ b/packages/caliper-gui-dashboard/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# We really wanna keep that index.html
+!/public/index.html
+
 # dependencies
 /node_modules
 package-lock.json

--- a/packages/caliper-gui-dashboard/README.md
+++ b/packages/caliper-gui-dashboard/README.md
@@ -3,17 +3,18 @@
 
 ## Get Started
 
-Open two terminal windows:
+Both the dashboard and server must be started:
+1. Start `caliper-gui-server` with the command `npm start`
+2. Start `caliper-gui-dashboard` with the command `npm start`
 
-1. Change both terminals into `caliper-gui` directory, and then run `npm run server` and `npm run client` in two directories respectively.
-2. If using MongDB or some other databases, pleaes make sure the DB are installed and connected.
+If using MongDB or some other databases, please make sure the DB are installed and connected.
 
 ## Caliper Server
 The server provides an API that supports the configuration files and testing result data transmission between Caliper GUI and Caliper-core modules.
 
 **MongoDB** is required to start the API and Server.
 
-*TODO: integrate with stable version of caliper-cli and caliper-core modules, and re-format the received data into the format that can be easily visualizaed by Caliper GUI visualizations.*
+*TODO: integrate with stable version of caliper-cli and caliper-core modules, and re-format the received data into the format that can be easily visualized by Caliper GUI visualizations.*
 
 ## Caliper GUI
 Caliper GUI provides multiple visualizations for the benchmark data from Caliper CLI. The supported visualizations are:
@@ -23,7 +24,7 @@ Caliper GUI provides multiple visualizations for the benchmark data from Caliper
 - Read latency
 - Read throughput
 
-*TODO: using Redux to support global state tree, and making all the test functionties globally accessible in the GUI applications*
+*TODO: using Redux to support global state tree, and making all the test functionalities globally accessible in the GUI applications*
 
 *TODO: consider using Electron to wrap the GUI and make it a desktop application for Mac/Linux/Windows.*
 

--- a/packages/caliper-gui-dashboard/package.json
+++ b/packages/caliper-gui-dashboard/package.json
@@ -51,7 +51,7 @@
         "reactstrap": "8.0.0"
     },
     "devDependencies": {
-        "babel-eslint": "^10.0.3",
+        "babel-eslint": "10.0.1",
         "chai": "^3.5.0",
         "eslint": "^5.16.0",
         "eslint-plugin-react": "^7.16.0",

--- a/packages/caliper-gui-dashboard/public/index.html
+++ b/packages/caliper-gui-dashboard/public/index.html
@@ -1,0 +1,90 @@
+<!--
+/*!
+
+=========================================================
+* Hyperledger Caliper GUI
+=========================================================
+
+* Author: Jason You
+* GitHub:
+* Licensed under the Apache 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+Copyright (c) 2019 Jason You
+
+*/
+/*!
+
+=========================================================
+* Paper Dashboard React - v1.1.0
+=========================================================
+
+* Product Page: https://www.creative-tim.com/product/paper-dashboard-react
+* Copyright 2019 Creative Tim (https://www.creative-tim.com)
+
+* Licensed under MIT (https://github.com/creativetimofficial/paper-dashboard-react/blob/master/LICENSE.md)
+
+* Coded by Creative Tim
+
+=========================================================
+
+* The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+*/
+-->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <meta name="theme-color" content="#000000" />
+    <!--
+            manifest.json provides metadata used when your web app is added to the
+            homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
+        -->
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link
+      rel="apple-touch-icon"
+      sizes="76x76"
+      href="%PUBLIC_URL%/apple-icon.png"
+    />
+    <!--
+            Notice the use of %PUBLIC_URL% in the tags above.
+            It will be replaced with the URL of the `public` folder during the build.
+            Only files inside the `public` folder can be referenced from the HTML.
+
+            Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+            work correctly both with client-side routing and a non-root public URL.
+            Learn how to configure a non-root public URL by running `npm run build`.
+        -->
+
+    <!--     Fonts and icons     -->
+    <link
+      href="https://fonts.googleapis.com/css?family=Montserrat:400,700,200"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://use.fontawesome.com/releases/v5.3.1/css/all.css"
+    />
+
+    <title>Hyperledger Caliper Dashboard</title>
+  </head>
+  <body>
+    <noscript> You need to enable JavaScript to run this app. </noscript>
+    <div id="root"></div>
+    <!--
+            This HTML file is a template.
+            If you open it directly in the browser, you will see an empty page.
+
+            You can add webfonts, meta tags, or analytics to this file.
+            The build step will place the bundled scripts into the <body> tag.
+
+            To begin the development, run `npm start` or `yarn start`.
+            To create a production bundle, use `npm run build` or `yarn build`.
+        -->
+  </body>
+</html>

--- a/packages/caliper-gui-server/README.md
+++ b/packages/caliper-gui-server/README.md
@@ -3,10 +3,11 @@
 
 ## Get Started
 
-Open two terminal windows:
+Both the dashboard and server must be started:
+1. Start `caliper-gui-server` with the command `npm start`
+2. Start `caliper-gui-dashboard` with the command `npm start`
 
-1. Change both terminals into `caliper-gui` directory, and then run `npm run server` and `npm run client` in two directories respectively.
-2. If using MongDB or some other databases, pleaes make sure the DB are installed and connected.
+If using MongDB or some other databases, please make sure the DB are installed and connected.
 
 ## Caliper Server
 The server provides an API that supports the configuration files and testing result data transmission between Caliper GUI and Caliper-core modules.
@@ -23,7 +24,7 @@ Caliper GUI provides multiple visualizations for the benchmark data from Caliper
 - Read latency
 - Read throughput
 
-*TODO: using Redux to support global state tree, and making all the test functionties globally accessible in the GUI applications*
+*TODO: using Redux to support global state tree, and making all the test functionalities globally accessible in the GUI applications*
 
 *TODO: consider using Electron to wrap the GUI and make it a desktop application for Mac/Linux/Windows.*
 

--- a/packages/caliper-gui-server/app.js
+++ b/packages/caliper-gui-server/app.js
@@ -31,7 +31,7 @@
 
 let express = require('express');
 const PORT = 3001;
-let apiV1 = require('./src/api/api1.js.js.js');
+let apiV1 = require('./src/api/api1.js');
 // var apiV2 = require("./src/api/api2.js");
 let app = express();
 const cors = require('cors');

--- a/packages/caliper-gui-server/package.json
+++ b/packages/caliper-gui-server/package.json
@@ -39,7 +39,7 @@
         "yargs": "10.0.3"
     },
     "devDependencies": {
-        "babel-eslint": "^10.0.3",
+        "babel-eslint": "10.0.1",
         "chai": "^3.5.0",
         "eslint": "^5.16.0",
         "license-check-and-add": "2.3.6",


### PR DESCRIPTION
Currently it is not possible to stand up the GUI, this PR:
- pins npm requirement to fixed version
- fixes a typo
- adds the required html file and modifies the gitignore file so it is tracked
- modifies readme files to match required commands for standing up the GUI

Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>
