### PR TITLE
Fix ethereum adapter zero nonce issue

### DIFF
--- a/packages/caliper-ethereum/lib/ethereum.js
+++ b/packages/caliper-ethereum/lib/ethereum.js
@@ -198,7 +198,7 @@ class Ethereum extends BlockchainInterface {
             let methodType = 'send';
             if (methodCall.isView) {
                 methodType = 'call';
-            } else if (context.nonces && context.nonces[context.fromAddress]) {
+            } else if (context.nonces && (typeof context.nonces[context.fromAddress] !== 'undefined')) {
                 let nonce = context.nonces[context.fromAddress];
                 context.nonces[context.fromAddress] = nonce + 1;
                 params.nonce = nonce;


### PR DESCRIPTION
Javascript "Truthy" of zero keeps us from going down the fork where nonces
are set.  Use typeof !== 'undefined' instead.

Signed-off-by: Danno Ferrin \<danno.ferrin@gmail.com\>

<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
<!--- What issue / user story is this for -->

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-caliper)
- [ ] [GitHub Issues](https://github.com/hyperledger/caliper/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/caliper)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->
