### PR TITLE
Fix incorrect docker charting spec

### DIFF
--- a/docs/vNext/MonitorsAndObservers.md
+++ b/docs/vNext/MonitorsAndObservers.md
@@ -268,9 +268,9 @@ monitor:
     - all
     charting:
     bar:
-    - metrics: [Memory(avg), CPU%(avg)]
+      metrics: [Memory(avg), CPU%(avg)]
     polar:
-    - metrics: [all]
+      metrics: [all]
 ```
 
 ### Prometheus Charting


### PR DESCRIPTION
There was an error in the docs for docker charting, with the metrics being show as an array, when it needed to be an object, like all the other specs

Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>
