### PR TITLE
Made the CI jobs conditional and fixed lerna publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,31 +26,40 @@ jobs:
       name: Show various information about the CI build
       script: ./.travis/build-info.sh
     - name: Package name check, license check, lint check, unit tests
+      if: env(TRAVIS_SECURE_ENV_VARS) is false
       script: ./.travis/checks-and-unit-tests.sh
 
     # parallel integrations tests
     - stage: benchmark integration tests
       name: HL Fabric integration test
+      if: env(TRAVIS_SECURE_ENV_VARS) is false
       script: BENCHMARK=fabric ./.travis/benchmark-integration-test-direct.sh
     - name: Ethereum integration test
+      if: env(TRAVIS_SECURE_ENV_VARS) is false
       script: BENCHMARK=ethereum ./.travis/benchmark-integration-test-direct.sh
     - name: HL Sawtooth integration test
+      if: env(TRAVIS_SECURE_ENV_VARS) is false
       script: BENCHMARK=sawtooth ./.travis/benchmark-integration-test-direct.sh
     - name: HL Besu integration test
+      if: env(TRAVIS_SECURE_ENV_VARS) is false
       script: BENCHMARK=besu ./.travis/benchmark-integration-test-direct.sh
     - name: FISCO-BCOS integration test
+      if: env(TRAVIS_SECURE_ENV_VARS) is false
       script: BENCHMARK=fisco-bcos ./.travis/benchmark-integration-test-direct.sh
     - name: Generator integration test
+      if: env(TRAVIS_SECURE_ENV_VARS) is false
       script: BENCHMARK=generator ./.travis/benchmark-integration-test-direct.sh
 
     # publish npm packages
     - stage: npm publish
       name: Publishing to NPM
+      if: env(TRAVIS_SECURE_ENV_VARS) is true
       script: ./.travis/npm-publish.sh
 
       # publish docker image
     - stage: docker publish
       name: Publishing to Docker Hub
+      if: env(TRAVIS_SECURE_ENV_VARS) is true
       script: ./.travis/docker-publish.sh
 
 cache:

--- a/.travis/benchmark-integration-test-direct.sh
+++ b/.travis/benchmark-integration-test-direct.sh
@@ -17,12 +17,6 @@
 set -e
 set -o pipefail
 
-if [[ ! -z "${NPM_TOKEN}" ]]
-then
-      echo "Encrypted variables detected, skipping PR checks"
-      exit 0
-fi
-
 # Bootstrap the project again
 npm i && npm run repoclean -- --yes && npm run bootstrap
 

--- a/.travis/checks-and-unit-tests.sh
+++ b/.travis/checks-and-unit-tests.sh
@@ -17,12 +17,6 @@
 set -e
 set -o pipefail
 
-if [[ ! -z "${NPM_TOKEN}" ]]
-then
-      echo "Encrypted variables detected, skipping PR checks"
-      exit 0
-fi
-
 # check reference Caliper package names
 # publishNpmPackages.js contains the package dir names as caliper-*, those are fine
 if grep -rnE --exclude="publishNpmPackages.js" "['\"]caliper-(cli|core|burrow|composer|ethereum|fabric|fisco-bcos|iroha|sawtooth)['\"]" . ; then

--- a/.travis/docker-publish.sh
+++ b/.travis/docker-publish.sh
@@ -18,8 +18,8 @@ set -e
 
 if [[ -z "${DOCKER_TOKEN}" ]]
 then
-      echo "No encrypted variables detected, skipping publish steps"
-      exit 0
+      echo "ERROR: No decrypted DOCKER_TOKEN variable detected"
+      exit 1
 fi
 
 # login to docker with secret token

--- a/.travis/npm-publish.sh
+++ b/.travis/npm-publish.sh
@@ -18,15 +18,20 @@ set -e
 
 if [[ -z "${NPM_TOKEN}" ]]
 then
-      echo "No encrypted variables detected, skipping publish steps"
-      exit 0
+      echo "ERROR: No decrypted NPM_TOKEN variable detected"
+      exit 1
 fi
 
 # Set the NPM access token we will use to publish.
 npm config set registry https://registry.npmjs.org/
 npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
 
-export DIST_TAG=unstable
+if grep '"version": ".*\-unstable",$' ./package.json
+then
+    export DIST_TAG=unstable
+else
+    export DIST_TAG=latest
+fi
 
 # Only install lerna, other package deps are not needed for publishing
 npm i

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "pretest": "npm run licchk",
     "licchk": "license-check-and-add",
     "test": "lerna run test",
-    "publish_npm": "lerna publish --dist-tag ${DIST_TAG} --yes --force-publish=* --ignore-scripts --ignore-prepublish -- -f"
+    "publish_npm": "lerna publish --dist-tag ${DIST_TAG} --yes --force-publish=* --ignore-scripts --no-git-reset"
   },
   "engines": {
     "node": ">=8.10.0",


### PR DESCRIPTION
Signed-off-by: Attila Klenik <a.klenik@gmail.com>

* The CI jobs are conditional based on whether there are any decrypted vars (should speed up the build a bit)
* The NPM packages are tagged `unstable` or `latest` based on the version string in the root package.json
* Lerna should avoid any git magic now which previously broke the build