### PR TITLE
remove whitespace between CPU% and (val)

### DIFF
--- a/packages/caliper-core/lib/master/monitors/monitor-docker.js
+++ b/packages/caliper-core/lib/master/monitors/monitor-docker.js
@@ -359,8 +359,8 @@ class MonitorDocker extends MonitorInterface {
                     watchItemStat.set('Name', container.name);
                     watchItemStat.set('Memory(max)', mem_stat.max);
                     watchItemStat.set('Memory(avg)', mem_stat.avg);
-                    watchItemStat.set('CPU% (max)', cpu_stat.max.toFixed(2));
-                    watchItemStat.set('CPU% (avg)', cpu_stat.avg.toFixed(2));
+                    watchItemStat.set('CPU%(max)', cpu_stat.max.toFixed(2));
+                    watchItemStat.set('CPU%(avg)', cpu_stat.avg.toFixed(2));
                     watchItemStat.set('Traffic In', (net.in[net.in.length - 1] - net.in[0]));
                     watchItemStat.set('Traffic Out', (net.out[net.out.length - 1] - net.out[0]));
                     watchItemStat.set('Disc Write', (disc.write[disc.write.length - 1] - disc.write[0]));

--- a/packages/caliper-core/lib/master/monitors/monitor-process.js
+++ b/packages/caliper-core/lib/master/monitors/monitor-process.js
@@ -288,15 +288,15 @@ class MonitorProcess extends MonitorInterface {
                 watchItemStat.set('Name', key);
                 watchItemStat.set('Memory(max)', MonitorUtilities.byteNormalize(mem_stat.max));
                 watchItemStat.set('Memory(avg)', MonitorUtilities.byteNormalize(mem_stat.avg));
-                watchItemStat.set('CPU% (max)', cpu_stat.max.toFixed(2));
-                watchItemStat.set('CPU% (avg)', cpu_stat.avg.toFixed(2));
+                watchItemStat.set('CPU%(max)', cpu_stat.max.toFixed(2));
+                watchItemStat.set('CPU%(avg)', cpu_stat.avg.toFixed(2));
 
                 // append return array
                 resourceStats.push(watchItemStat);
             }
 
             // Normalize the resource stats to a single unit
-            const normalizeStats = ['Memory(max)', 'Memory(avg)', 'CPU% (max)', 'CPU% (avg)'];
+            const normalizeStats = ['Memory(max)', 'Memory(avg)'];
             for (const stat of normalizeStats) {
                 MonitorUtilities.normalizeStats(stat, resourceStats);
             }


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

Additional columns were appearing in report file- this was a result of non-matching column names :
- CPU% (max) and CPU%(max)
- CPU% (av) and CPU%(av)

Fix is to remove the whitespace so that they all match - we also do not need to normalize on % values (🤦‍♂ )

Pre-fix
![Screenshot 2020-01-30 at 14 09 15](https://user-images.githubusercontent.com/8394544/73456656-2e43a180-436a-11ea-9bd4-4b1606d25a44.png)

post-fix
![Screenshot 2020-01-30 at 14 08 59](https://user-images.githubusercontent.com/8394544/73456692-3a2f6380-436a-11ea-9e54-1a473c1cbc18.png)

corresponding report
![Screenshot 2020-01-30 at 14 11 01](https://user-images.githubusercontent.com/8394544/73456778-6814a800-436a-11ea-9706-513f9ffc10e3.png)
