### PR TITLE
enable statistic summation on prometheus queries

### DIFF
--- a/packages/caliper-core/lib/common/prometheus/prometheus-query-helper.js
+++ b/packages/caliper-core/lib/common/prometheus/prometheus-query-helper.js
@@ -163,6 +163,8 @@ class PrometheusQueryHelper {
                 return values[0];
             }
         }
+        case 'sum':
+            return values.reduce((x, y) => x + y);
         default:
             Logger.error(`Unknown stat type passed: ${statType}`);
             throw new Error(`Unknown stat type passed: ${statType}`);

--- a/packages/caliper-core/test/common/prometheus/prometheus-query-helper.js
+++ b/packages/caliper-core/test/common/prometheus/prometheus-query-helper.js
@@ -410,6 +410,19 @@ describe('PrometheusQueryHelper implementation', () => {
             output.get('unknown').should.equal(2.8);
         });
 
+        it('should retrieve the sum value from a matrix response', () => {
+            const response = {
+                data: {
+                    resultType: 'matrix',
+                    result: [{ values: [[111, 1], [111, 1], [111, 2], [111, 2], [111, 8]] }]
+                }
+            };
+            const output = PrometheusQueryHelper.extractStatisticFromRange(response, 'sum');
+            output.should.be.an('map');
+            output.size.should.equal(1);
+            output.get('unknown').should.equal(14);
+        });
+
         it('should return `-` if passed too few results', () => {
             const response = {
                 data: {


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>
turns out that enabling a sum to be returned from a query result is *really* handy!

This PR adds the ability to request a sum of returned results, and adds a test for it too.