### PR TITLE
Build orderer objects instead of names in cache

### DIFF
--- a/packages/caliper-ethereum/package.json
+++ b/packages/caliper-ethereum/package.json
@@ -28,7 +28,7 @@
     "devDependencies": {
         "web3": "1.2.2",
         "chai": "^3.5.0",
-        "eslint": "^4.19.1",
+        "eslint": "^5.16.0",
         "mocha": "3.4.2",
         "nyc": "11.1.0",
         "rewire": "^4.0.0",

--- a/packages/caliper-fabric/lib/adaptor-versions/v1/fabric-v1.js
+++ b/packages/caliper-fabric/lib/adaptor-versions/v1/fabric-v1.js
@@ -1793,12 +1793,21 @@ class Fabric extends BlockchainInterface {
             ///////////////////////////////////////////
 
             let targetOrderer = invokeSettings.orderer || this._getRandomTargetOrderer(invokeSettings.channel);
+            let orderer;
+
+            if (typeof(targetOrderer) === 'string' || targetOrderer instanceof String) {
+                // Using an orderer name
+                orderer = channel.getOrderer(targetOrderer);
+            } else {
+                // Have been passed an orderer as an object within invokeSettings.orderer
+                throw new Error('Orderer object passed within invokeSettings: must reference target orderer by name');
+            }
 
             /** @link{TransactionRequest} */
             const transactionRequest = {
                 proposalResponses: proposalResponses,
                 proposal: proposal,
-                orderer: targetOrderer
+                orderer
             };
 
             /** @link{BroadcastResponse} */

--- a/packages/caliper-fabric/lib/adaptor-versions/v2/fabric-v2.js
+++ b/packages/caliper-fabric/lib/adaptor-versions/v2/fabric-v2.js
@@ -1793,12 +1793,21 @@ class Fabric extends BlockchainInterface {
             ///////////////////////////////////////////
 
             let targetOrderer = invokeSettings.orderer || this._getRandomTargetOrderer(invokeSettings.channel);
+            let orderer;
+
+            if (!(typeof(targetOrderer) === 'string' || targetOrderer instanceof String)) {
+                // Using an orderer name
+                orderer = channel.getOrderer(targetOrderer);
+            } else {
+                // Have been passed an orderer as an object within invokeSettings.orderer, which is not permitted
+                throw new Error('Orderer object passed within invokeSettings: must reference target orderer by name');
+            }
 
             /** @link{TransactionRequest} */
             const transactionRequest = {
                 proposalResponses: proposalResponses,
                 proposal: proposal,
-                orderer: targetOrderer
+                orderer
             };
 
             /** @link{BroadcastResponse} */

--- a/packages/caliper-fabric/lib/fabricNetwork.js
+++ b/packages/caliper-fabric/lib/fabricNetwork.js
@@ -572,6 +572,15 @@ class FabricNetwork {
     }
 
     /**
+     * Get the orderer object from the network definition
+     * @param {string} ordererName the orderer name to return
+     * @returns {object} orderer object
+     */
+    getOrdererObject(ordererName) {
+        return this.network.orderers[ordererName];
+    }
+
+    /**
      * Gets the organization that the given CA belongs to.
      * @param {string} ca The name of the CA.
      * @return {string} The name of the organization.

--- a/packages/caliper-gui-server/package.json
+++ b/packages/caliper-gui-server/package.json
@@ -36,7 +36,7 @@
         "mongodb": "^3.3.0",
         "multer": "^1.4.2",
         "shelljs": "^0.8.3",
-        "yargs": "10.0.3"
+        "yargs": "14.2.0"
     },
     "devDependencies": {
         "babel-eslint": "10.0.1",

--- a/packages/caliper-publish/package.json
+++ b/packages/caliper-publish/package.json
@@ -21,7 +21,7 @@
         "npm": ">=5.6.0"
     },
     "dependencies": {
-        "yargs": "^14.2.0"
+        "yargs": "14.2.0"
     },
     "devDependencies": {
         "chai": "^3.5.0",


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>
closes #690 
 - New method with the `FabricNetwork` class to retrieve and orderer object from the  passed network configuration
 - Build orderer objects to use instead of an array of orderer names