### PR TITLE
move orchestrators under orchestrator folder

### DIFF
--- a/packages/caliper-core/index.js
+++ b/packages/caliper-core/index.js
@@ -23,3 +23,6 @@ module.exports.ConfigUtil = require('./lib/common/config/config-util');
 module.exports.MessageHandler = require('./lib/worker/client/message-handler');
 module.exports.Messenger = require('./lib/common/messaging/messenger');
 module.exports.CaliperEngine = require('./lib/master/caliper-engine');
+module.exports.MonitorOrchestrator = require('./lib/master/orchestrators/monitor-orchestrator');
+module.exports.RoundOrchestrator = require('./lib/master/orchestrators/round-orchestrator');
+module.exports.WorkerOrchestrator = require('./lib/master/orchestrators/worker-orchestrator');

--- a/packages/caliper-core/lib/master/caliper-engine.js
+++ b/packages/caliper-core/lib/master/caliper-engine.js
@@ -17,7 +17,7 @@
 const Blockchain = require('../common/core/blockchain');
 const CaliperUtils = require('../common/utils/caliper-utils');
 const ConfigUtils = require('../common/config/config-util');
-const RoundOrchestrator = require('./test-runners/round-orchestrator');
+const RoundOrchestrator = require('./orchestrators/round-orchestrator');
 const BenchValidator = require('../common/utils/benchmark-validator');
 
 const logger = CaliperUtils.getLogger('caliper-engine');

--- a/packages/caliper-core/lib/master/orchestrators/monitor-orchestrator.js
+++ b/packages/caliper-core/lib/master/orchestrators/monitor-orchestrator.js
@@ -15,9 +15,9 @@
 
 'use strict';
 
-const DockerMonitor = require('./monitor-docker.js');
-const ProcessMonitor = require('./monitor-process.js');
-const PrometheusMonitor = require('./monitor-prometheus.js');
+const DockerMonitor = require('../monitors/monitor-docker.js');
+const ProcessMonitor = require('../monitors/monitor-process.js');
+const PrometheusMonitor = require('../monitors/monitor-prometheus.js');
 const Util  = require('../../common/utils/caliper-utils');
 const logger= Util.getLogger('monitor.js');
 

--- a/packages/caliper-core/lib/master/orchestrators/round-orchestrator.js
+++ b/packages/caliper-core/lib/master/orchestrators/round-orchestrator.js
@@ -15,8 +15,8 @@
 
 'use strict';
 
-const WorkerOrchestrator  = require('../orchestrators/worker-orchestrator');
-const MonitorOrchestrator = require('../monitors/monitor-orchestrator');
+const WorkerOrchestrator  = require('./worker-orchestrator');
+const MonitorOrchestrator = require('./monitor-orchestrator');
 const Report = require('../report/report');
 const TestObserver = require('../test-observers/test-observer');
 const CaliperUtils = require('../../common/utils/caliper-utils');


### PR DESCRIPTION
Code tidy: file relocation

The round orchestrator is an orchestrator, and so lives quite neatly under the orchestrators folder, alongside the worker-orchestrator.

The same is true for the monitor-orchestrator.

The GUI attempts to import numerous items (including orchestrators) that are not currently exported, so this PR also exports the items (namely the orchestrators) that it is trying (or might want to try) to import and use.

Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>
