### PR TITLE
add new 1.4.5 release to supported fabric sdks in cli

### DIFF
--- a/packages/caliper-cli/lib/bind/config.yaml
+++ b/packages/caliper-cli/lib/bind/config.yaml
@@ -52,8 +52,10 @@ sut:
             packages: ['grpc@1.14.2', 'fabric-ca-client@1.4.1', 'fabric-client@1.4.1', 'fabric-protos@2.0.0-snapshot.1', 'fabric-network@1.4.1']
         1.4.3:
             packages: ['grpc@1.14.2', 'fabric-ca-client@1.4.2', 'fabric-client@1.4.3', 'fabric-protos@2.0.0-snapshot.1', 'fabric-network@1.4.2']
-        1.4.4: &fabric-latest
+        1.4.4:
             packages: ['grpc@1.14.2', 'fabric-ca-client@1.4.4', 'fabric-client@1.4.4', 'fabric-protos@2.0.0-snapshot.1', 'fabric-network@1.4.4']
+        1.4.5: &fabric-latest
+            packages: ['fabric-ca-client@1.4.5', 'fabric-client@1.4.5', 'fabric-protos@2.0.0-snapshot.1', 'fabric-network@1.4.5']
         latest: *fabric-latest
 
     sawtooth:


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

Modifies CLI binding configuration file to:
- add released 1.4.5 SDK
- make the added 1.4.5 the latest 