### PR TITLE
be more explicit in monitor/observer check

### DIFF
--- a/packages/caliper-core/lib/common/utils/benchmark-validator.js
+++ b/packages/caliper-core/lib/common/utils/benchmark-validator.js
@@ -57,9 +57,9 @@ class BenchmarkValidator {
             BenchmarkValidator.throwInvalidPropertyBenchmarkError('observer.type', benchConfig.observer.type);
         }
 
-        // If prometheus monitor specified, must be a prometheus observer
+        // If prometheus monitor specified, must be a prometheus observer or none
         if (benchConfig.monitor && benchConfig.monitor.type &&
-            benchConfig.monitor.type.includes('prometheus') && !(benchConfig.observer.type.localeCompare('prometheus') === 0) ) {
+            benchConfig.monitor.type.includes('prometheus') && (benchConfig.observer.type.localeCompare('local') === 0) ) {
             BenchmarkValidator.throwIncompatibleTypeBenchmarkError('observer.type.local', 'monitor.type.prometheus');
         }
     }


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

It is perfectly valid to use a prometheus based monitor and 'none' option for the observer ... this PR enables this specification by correctly conditioning the validation check