### PR TITLE
fix orderer name check in fabric v2

### DIFF
--- a/packages/caliper-fabric/lib/adaptor-versions/v2/fabric-v2.js
+++ b/packages/caliper-fabric/lib/adaptor-versions/v2/fabric-v2.js
@@ -1804,7 +1804,7 @@ class Fabric extends BlockchainInterface {
             let targetOrderer = invokeSettings.orderer || this._getRandomTargetOrderer(invokeSettings.channel);
             let orderer;
 
-            if (!(typeof(targetOrderer) === 'string' || targetOrderer instanceof String)) {
+            if (typeof(targetOrderer) === 'string' || targetOrderer instanceof String) {
                 // Using an orderer name
                 orderer = channel.getOrderer(targetOrderer);
             } else {


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

Fix bug in code for v2 fabric adaptor within the orderer name check.  Bug does not exist in the V1 counterpart.

This does hint towards some anti-practice going on where where have too much code replication.