### PR TITLE
update dockerode to 3.1.0

### DIFF
--- a/packages/caliper-core/package.json
+++ b/packages/caliper-core/package.json
@@ -24,7 +24,7 @@
     "dependencies": {
         "color-scheme": "^1.0.1",
         "compare-versions": "^3.4.0",
-        "dockerode": "^2.5.0",
+        "dockerode": "3.1.0",
         "fs-extra": "8.1.0",
         "js-yaml": "^3.12.0",
         "mustache": "^2.3.0",


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

Closes #764 

Seems we can bump the consumed version of dockerode to 3.1.0 without any additional updates as there are no breaking changes in the functions that we are using.

Ran locally and witnessed disc i/o results 👌 

![Screenshot 2020-03-16 at 13 13 08](https://user-images.githubusercontent.com/8394544/76761750-e8129800-6787-11ea-999e-2df2cfc5df6a.png)


