### PR TITLE
Fix CI workloads and enhance error handling

### DIFF
--- a/packages/caliper-sawtooth/lib/sawtooth.js
+++ b/packages/caliper-sawtooth/lib/sawtooth.js
@@ -36,7 +36,7 @@ const {
 const request = require('request-promise');
 const _ = require('lodash');
 
-let configPath;
+let config;
 let lastKnownBlockId=null;
 //let blockCommitSatus = new Map();
 let batchCommitStatus = new Map();
@@ -48,7 +48,6 @@ let currentEndpoint= 0;
 * @return {String} rest endpoint url
 */
 function getRESTUrl() {
-    let config = require(configPath);
     let restApiUrls = config.sawtooth.network.restapi.urls;
     currentEndpoint++;
     if(currentEndpoint >= restApiUrls.length) {
@@ -270,7 +269,6 @@ function getState(address) {
  * @return {Promise<object>} The promise for the result of the execution.
  */
 function querybycontext(context, contractID, contractVer, address, workspaceRoot) {
-    let config = require(configPath);
     const builder = BatchBuilderFactory.getBatchBuilder(contractID, contractVer, config, workspaceRoot);
     const addr = builder.calculateAddress(address);
     if(context.engine) {
@@ -323,7 +321,8 @@ class Sawtooth extends BlockchainInterface {
      */
     constructor(workerIndex) {
         super();
-        configPath = CaliperUtils.resolvePath(ConfigUtil.get(ConfigUtil.keys.NetworkConfig));
+        let configPath = CaliperUtils.resolvePath(ConfigUtil.get(ConfigUtil.keys.NetworkConfig));
+        config = require(configPath);
         this.bcType = 'sawtooth';
         this.workspaceRoot = path.resolve(ConfigUtil.get(ConfigUtil.keys.Workspace));
         this.clientIndex = workerIndex;
@@ -365,7 +364,6 @@ class Sawtooth extends BlockchainInterface {
      * @return {Promise} The return promise.
      */
     getContext(name, args) {
-        let config  = require(this.configPath);
         let context = config.sawtooth.context;
         if(typeof context === 'undefined') {
             let validatorUrl = config.sawtooth.network.validator.url;
@@ -403,7 +401,6 @@ class Sawtooth extends BlockchainInterface {
      */
     async invokeSmartContract(context, contractID, contractVer, args, timeout) {
         try {
-            let config = require(configPath);
             let builder = BatchBuilderFactory.getBatchBuilder(contractID, contractVer, config, this.workspaceRoot);
             const batchBytes = builder.buildBatch(args);
             if(context.engine) {

--- a/packages/caliper-tests-integration/besu_tests/open.js
+++ b/packages/caliper-tests-integration/besu_tests/open.js
@@ -74,12 +74,12 @@ function generateWorkload() {
         let acc_id = generateAccount();
         account_array.push(acc_id);
 
-        if (bc.bcType === 'fabric') {
+        if (bc.getType() === 'fabric') {
             workload.push({
                 chaincodeFunction: 'open',
                 chaincodeArguments: [acc_id, initMoney.toString()],
             });
-        } else if (bc.bcType === 'ethereum') {
+        } else if (bc.getType() === 'ethereum') {
                 workload.push({
                     verb: 'open',
                     args: [acc_id, initMoney]

--- a/packages/caliper-tests-integration/besu_tests/query.js
+++ b/packages/caliper-tests-integration/besu_tests/query.js
@@ -32,7 +32,7 @@ module.exports.init = function(blockchain, context, args) {
 module.exports.run = function() {
     const acc  = account_array[Math.floor(Math.random()*(account_array.length))];
 
-    if (bc.bcType === 'fabric') {
+    if (bc.getType() === 'fabric') {
         let args = {
             chaincodeFunction: 'query',
             chaincodeArguments: [acc],

--- a/packages/caliper-tests-integration/besu_tests/transfer.js
+++ b/packages/caliper-tests-integration/besu_tests/transfer.js
@@ -39,12 +39,12 @@ module.exports.run = function () {
     const account2 = account_array[Math.floor(Math.random() * (account_array.length))];
     let args;
 
-    if (bc.bcType === 'fabric') {
+    if (bc.getType() === 'fabric') {
         args = {
             chaincodeFunction: 'transfer',
             chaincodeArguments: [account1, account2, initmoney.toString()],
         };
-    } else if (bc.bcType === 'ethereum') {
+    } else if (bc.getType() === 'ethereum') {
         args = {
             verb: 'transfer',
             args: [account1, account2, initmoney]

--- a/packages/caliper-tests-integration/ethereum_tests/open.js
+++ b/packages/caliper-tests-integration/ethereum_tests/open.js
@@ -74,12 +74,12 @@ function generateWorkload() {
         let acc_id = generateAccount();
         account_array.push(acc_id);
 
-        if (bc.bcType === 'fabric') {
+        if (bc.getType() === 'fabric') {
             workload.push({
                 chaincodeFunction: 'open',
                 chaincodeArguments: [acc_id, initMoney.toString()],
             });
-        } else if (bc.bcType === 'ethereum') {
+        } else if (bc.getType() === 'ethereum') {
                 workload.push({
                     verb: 'open',
                     args: [acc_id, initMoney]

--- a/packages/caliper-tests-integration/ethereum_tests/query.js
+++ b/packages/caliper-tests-integration/ethereum_tests/query.js
@@ -32,7 +32,7 @@ module.exports.init = function(blockchain, context, args) {
 module.exports.run = function() {
     const acc  = account_array[Math.floor(Math.random()*(account_array.length))];
 
-    if (bc.bcType === 'fabric') {
+    if (bc.getType() === 'fabric') {
         let args = {
             chaincodeFunction: 'query',
             chaincodeArguments: [acc],

--- a/packages/caliper-tests-integration/ethereum_tests/transfer.js
+++ b/packages/caliper-tests-integration/ethereum_tests/transfer.js
@@ -39,12 +39,12 @@ module.exports.run = function () {
     const account2 = account_array[Math.floor(Math.random() * (account_array.length))];
     let args;
 
-    if (bc.bcType === 'fabric') {
+    if (bc.getType() === 'fabric') {
         args = {
             chaincodeFunction: 'transfer',
             chaincodeArguments: [account1, account2, initmoney.toString()],
         };
-    } else if (bc.bcType === 'ethereum') {
+    } else if (bc.getType() === 'ethereum') {
         args = {
             verb: 'transfer',
             args: [account1, account2, initmoney]


### PR DESCRIPTION
Signed-off-by: Attila Klenik <a.klenik@gmail.com>

* The `bcType` => `getType()` fix is applied to the Ethereum and Besu CI workload modules.
* The TX and unexpected errors are separated in the Ethereum adapter. The latter now halt and fails the benchmark.
* Worker-side errors are now reported with a stack trace in the logs.
* Sawtooth adapter bug fixed, referenced non-existing instance variable.