### PR TITLE
Enable fabric adaptor with most recent snapshot of v2 fabric sdk

### DIFF
--- a/packages/caliper-cli/lib/lib/config.yaml
+++ b/packages/caliper-cli/lib/lib/config.yaml
@@ -60,6 +60,8 @@ sut:
             packages: ['fabric-client@1.4.6', 'fabric-protos@2.0.0-snapshot.1', 'fabric-network@1.4.6']
         1.4.7: &fabric-latest
             packages: ['fabric-client@1.4.7', 'fabric-protos@2.0.0-snapshot.1', 'fabric-network@1.4.7']
+        2.0.0:
+            packages: ['fabric-common@2.0.0-snapshot.387', 'fabric-protos@2.0.0-snapshot.245', 'fabric-network@2.0.0-snapshot.351']
         latest: *fabric-latest
 
     sawtooth:

--- a/packages/caliper-fabric/.eslintrc.yml
+++ b/packages/caliper-fabric/.eslintrc.yml
@@ -5,8 +5,7 @@ env:
 extends: 'eslint:recommended'
 parserOptions:
     ecmaVersion: 8
-    sourceType:
-        - script
+    sourceType: script
 rules:
     indent:
         - error
@@ -14,6 +13,8 @@ rules:
     linebreak-style:
         - error
         - unix
+    prefer-const:
+        - error
     quotes:
         - error
         - single

--- a/packages/caliper-fabric/lib/adapterFactory.js
+++ b/packages/caliper-fabric/lib/adapterFactory.js
@@ -23,7 +23,7 @@ const FabricAdapter = require('./fabric');
  * @async
  */
 async function adapterFactory(workerIndex) {
-    let adapter = new FabricAdapter(workerIndex);
+    const adapter = new FabricAdapter(workerIndex);
 
     // the master process explicitly calls "init"
     if (workerIndex > -1) {

--- a/packages/caliper-fabric/lib/adaptor-versions/v1/fabric-gateway-v1.js
+++ b/packages/caliper-fabric/lib/adaptor-versions/v1/fabric-gateway-v1.js
@@ -143,7 +143,7 @@ class Fabric extends BlockchainInterface {
 
         this.network = undefined;
         if (typeof networkConfig === 'string') {
-            let configPath = CaliperUtils.resolvePath(networkConfig, workspace_root);
+            const configPath = CaliperUtils.resolvePath(networkConfig, workspace_root);
             this.network = CaliperUtils.parseYaml(configPath);
         } else if (typeof networkConfig === 'object' && networkConfig !== null) {
             // clone the object to prevent modification by other objects
@@ -209,16 +209,16 @@ class Fabric extends BlockchainInterface {
      * @private
      */
     _assembleTargetEventSources(channel, targetPeers) {
-        let eventSources = [];
+        const eventSources = [];
         if (this.networkUtil.isInCompatibilityMode()) {
             // NOTE: for old event hubs we have a single connection to every peer set as an event source
             const EventHub = require('fabric-client/lib/EventHub.js');
 
-            for (let peer of targetPeers) {
-                let org = this.networkUtil.getOrganizationOfPeer(peer);
-                let admin = this.adminProfiles.get(org);
+            for (const peer of targetPeers) {
+                const org = this.networkUtil.getOrganizationOfPeer(peer);
+                const admin = this.adminProfiles.get(org);
 
-                let eventHub = new EventHub(admin);
+                const eventHub = new EventHub(admin);
                 eventHub.setPeerAddr(this.networkUtil.getPeerEventUrl(peer),
                     this.networkUtil.getGrpcOptionsOfPeer(peer));
 
@@ -229,11 +229,11 @@ class Fabric extends BlockchainInterface {
                 });
             }
         } else {
-            for (let peer of targetPeers) {
-                let org = this.networkUtil.getOrganizationOfPeer(peer);
-                let admin = this.adminProfiles.get(org);
+            for (const peer of targetPeers) {
+                const org = this.networkUtil.getOrganizationOfPeer(peer);
+                const admin = this.adminProfiles.get(org);
 
-                let eventHub = admin.getChannel(channel, true).newChannelEventHub(peer);
+                const eventHub = admin.getChannel(channel, true).newChannelEventHub(peer);
 
                 eventSources.push({
                     channel: [channel], // unused during chaincode instantiation
@@ -253,11 +253,11 @@ class Fabric extends BlockchainInterface {
      * @async
      */
     async _createChannels() {
-        let channels = this.networkUtil.getChannels();
+        const channels = this.networkUtil.getChannels();
         let channelCreated = false;
 
-        for (let channel of channels) {
-            let channelObject = this.networkUtil.getNetworkObject().channels[channel];
+        for (const channel of channels) {
+            const channelObject = this.networkUtil.getNetworkObject().channels[channel];
 
             if (CaliperUtils.checkProperty(channelObject, 'created') && channelObject.created) {
                 logger.info(`Channel '${channel}' is configured as created, skipping creation`);
@@ -285,10 +285,10 @@ class Fabric extends BlockchainInterface {
             }
 
             // NOTE: without knowing the system channel policies, signing with every org admin is a safe bet
-            let orgs = this.networkUtil.getOrganizationsOfChannel(channel);
+            const orgs = this.networkUtil.getOrganizationsOfChannel(channel);
             let admin; // declared here to keep the admin of the last org of the channel
-            let signatures = [];
-            for (let org of orgs) {
+            const signatures = [];
+            for (const org of orgs) {
                 admin = this.adminProfiles.get(org);
                 try {
                     signatures.push(admin.signChannelConfig(configUpdate));
@@ -297,8 +297,8 @@ class Fabric extends BlockchainInterface {
                 }
             }
 
-            let txId = admin.newTransactionID(true);
-            let request = {
+            const txId = admin.newTransactionID(true);
+            const request = {
                 config: configUpdate,
                 signatures: signatures,
                 name: channel,
@@ -307,7 +307,7 @@ class Fabric extends BlockchainInterface {
 
             try {
                 /** @link{BroadcastResponse} */
-                let broadcastResponse = await admin.createChannel(request);
+                const broadcastResponse = await admin.createChannel(request);
 
                 CaliperUtils.assertDefined(broadcastResponse, `The returned broadcast response for creating Channel '${channel}' is undefined`);
                 CaliperUtils.assertProperty(broadcastResponse, 'broadcastResponse', 'status');
@@ -364,7 +364,7 @@ class Fabric extends BlockchainInterface {
     async _enrollUser(profile, id, secret, profileName) {
         // this call will throw an error if the CA configuration is not found
         // this error should propagate up
-        let ca = profile.getCertificateAuthority();
+        const ca = profile.getCertificateAuthority();
         try {
             return await ca.enroll({
                 enrollmentID: id,
@@ -503,7 +503,7 @@ class Fabric extends BlockchainInterface {
      */
     _getChannelConfigFromFile(channelObject, channelName) {
         // extracting the config from the binary file
-        let binaryPath = CaliperUtils.resolvePath(channelObject.configBinary, this.workspaceRoot);
+        const binaryPath = CaliperUtils.resolvePath(channelObject.configBinary, this.workspaceRoot);
         let envelopeBytes;
 
         try {
@@ -517,23 +517,6 @@ class Fabric extends BlockchainInterface {
         } catch (err) {
             throw new Error(`Couldn't extract configuration object for ${channelName}: ${err.message}`);
         }
-    }
-
-    /**
-     * Calculates the remaining time to timeout based on the original timeout and a starting time.
-     * @param {number} start The epoch of the start time in ms.
-     * @param {number} original The original timeout in ms.
-     * @returns {number} The remaining time until the timeout in ms.
-     * @private
-     */
-    _getRemainingTimeout(start, original) {
-        let newTimeout = original - (Date.now() - start);
-        if (newTimeout < this.configSmallestTimeout) {
-            logger.warn(`Timeout is too small, default value of ${this.configSmallestTimeout}ms is used instead`);
-            newTimeout = this.configSmallestTimeout;
-        }
-
-        return newTimeout;
     }
 
     /**
@@ -563,15 +546,15 @@ class Fabric extends BlockchainInterface {
      * @async
      */
     async _initializeAdmins(workerInit) {
-        let orgs = this.networkUtil.getOrganizations();
-        for (let org of orgs) {
-            let adminName = `admin.${org}`;
+        const orgs = this.networkUtil.getOrganizations();
+        for (const org of orgs) {
+            const adminName = `admin.${org}`;
             // build the common part of the profile
-            let adminProfile = await this._prepareClientProfile(org, undefined, `${org}'s admin`);
+            const adminProfile = await this._prepareClientProfile(org, undefined, `${org}'s admin`);
 
             // Check if the materials already exist locally in file system key-value stores. Only valid if not using a file wallet
             if (!this.fileWalletPath){
-                let admin = await this._getUserContext(adminProfile, adminName, `${org}'s admin`);
+                const admin = await this._getUserContext(adminProfile, adminName, `${org}'s admin`);
                 if (admin) {
                     this.adminProfiles.set(org, adminProfile);
 
@@ -638,15 +621,15 @@ class Fabric extends BlockchainInterface {
      * @async
      */
     async _initializeRegistrars(workerInit) {
-        let orgs = this.networkUtil.getOrganizations();
-        for (let org of orgs) {
+        const orgs = this.networkUtil.getOrganizations();
+        for (const org of orgs) {
 
             // providing registrar information is optional and only needed for user registration and enrollment
             if (this.fileWalletPath) {
                 logger.info('skipping registrar initialization due to presence of file system wallet');
                 continue;
             }
-            let registrarInfo = this.networkUtil.getRegistrarOfOrganization(org);
+            const registrarInfo = this.networkUtil.getRegistrarOfOrganization(org);
             if (!registrarInfo) {
                 if (!workerInit) {
                     logger.warn(`${org}'s registrar information not provided.`);
@@ -655,9 +638,9 @@ class Fabric extends BlockchainInterface {
             }
 
             // build the common part of the profile
-            let registrarProfile = await this._prepareClientProfile(org, undefined, 'registrar');
+            const registrarProfile = await this._prepareClientProfile(org, undefined, 'registrar');
             // check if the materials already exist locally in the file system key-value stores
-            let registrar = await this._getUserContext(registrarProfile, registrarInfo.enrollId, `${org}'s registrar`);
+            const registrar = await this._getUserContext(registrarProfile, registrarInfo.enrollId, `${org}'s registrar`);
 
             if (registrar) {
                 if (!workerInit) {
@@ -686,14 +669,14 @@ class Fabric extends BlockchainInterface {
      * @async
      */
     async _initializeUsers(workerInit) {
-        let clients = this.networkUtil.getClients();
+        const clients = this.networkUtil.getClients();
 
         // register and enroll each client with its organization's CA
-        for (let client of clients) {
-            let org = this.networkUtil.getOrganizationOfClient(client);
+        for (const client of clients) {
+            const org = this.networkUtil.getOrganizationOfClient(client);
 
             // create the profile based on the connection profile
-            let clientProfile = await this._prepareClientProfile(org, client, client);
+            const clientProfile = await this._prepareClientProfile(org, client, client);
             this.clientProfiles.set(client, clientProfile);
 
             // check if the materials already exist locally in the file system key-value stores
@@ -733,7 +716,7 @@ class Fabric extends BlockchainInterface {
                 user = await this._createUser(clientProfile, org, client, cryptoContent, client);
                 if (this.networkUtil.isMutualTlsEnabled()) {
                     // the materials are included in the configuration file
-                    let crypto = this.networkUtil.getClientCryptoContent(client);
+                    const crypto = this.networkUtil.getClientCryptoContent(client);
                     clientProfile.setTlsClientCertAndKey(crypto.signedCertPEM.toString(), crypto.privateKeyPEM.toString());
                 }
 
@@ -751,9 +734,9 @@ class Fabric extends BlockchainInterface {
             // The user needs to be enrolled or even registered
 
             // if the enrollment ID and secret is provided, then enroll the already registered user
-            let enrollmentSecret = this.networkUtil.getClientEnrollmentSecret(client);
+            const enrollmentSecret = this.networkUtil.getClientEnrollmentSecret(client);
             if (enrollmentSecret) {
-                let enrollment = await this._enrollUser(clientProfile, client, enrollmentSecret, client);
+                const enrollment = await this._enrollUser(clientProfile, client, enrollmentSecret, client);
 
                 // create the new user based on the retrieved materials
                 user = await this._createUser(clientProfile, org, client,
@@ -780,22 +763,22 @@ class Fabric extends BlockchainInterface {
             // Otherwise, register then enroll the user
             let secret;
             try {
-                let registrarProfile = this.registrarProfiles.get(org);
+                const registrarProfile = this.registrarProfiles.get(org);
 
                 if (!registrarProfile) {
                     throw new Error(`Registrar identity is not provided for ${org}`);
                 }
 
-                let registrarInfo = this.networkUtil.getRegistrarOfOrganization(org);
-                let registrar = await registrarProfile.getUserContext(registrarInfo.enrollId, true);
+                const registrarInfo = this.networkUtil.getRegistrarOfOrganization(org);
+                const registrar = await registrarProfile.getUserContext(registrarInfo.enrollId, true);
                 // this call will throw an error if the CA configuration is not found
                 // this error should propagate up
-                let ca = clientProfile.getCertificateAuthority();
-                let userAffiliation = this.networkUtil.getAffiliationOfUser(client);
+                const ca = clientProfile.getCertificateAuthority();
+                const userAffiliation = this.networkUtil.getAffiliationOfUser(client);
 
                 // if not in compatibility mode (i.e., at least SDK v1.1), check whether the affiliation is already registered or not
                 if (!this.networkUtil.isInCompatibilityMode()) {
-                    let affService = ca.newAffiliationService();
+                    const affService = ca.newAffiliationService();
                     let affiliationExists = false;
                     try {
                         await affService.getOne(userAffiliation, registrar);
@@ -814,7 +797,7 @@ class Fabric extends BlockchainInterface {
                     }
                 }
 
-                let attributes = this.networkUtil.getAttributesOfUser(client);
+                const attributes = this.networkUtil.getAttributesOfUser(client);
                 attributes.push({name: 'hf.Registrar.Roles', value: 'client'});
 
                 secret = await ca.register({
@@ -831,7 +814,7 @@ class Fabric extends BlockchainInterface {
                 logger.info(`${client} successfully registered`);
             }
 
-            let enrollment = await this._enrollUser(clientProfile, client, secret, client);
+            const enrollment = await this._enrollUser(clientProfile, client, secret, client);
 
             // create the new user based on the retrieved materials
             user = await this._createUser(clientProfile, org, client,
@@ -962,34 +945,34 @@ class Fabric extends BlockchainInterface {
             process.env.GOPATH = CaliperUtils.resolvePath('.', this.workspaceRoot);
         }
 
-        let errors = [];
+        const errors = [];
 
-        let channels = this.networkUtil.getChannels();
-        for (let channel of channels) {
+        const channels = this.networkUtil.getChannels();
+        for (const channel of channels) {
             logger.info(`Installing chaincodes for ${channel}...`);
 
             // proceed cc by cc for the channel
-            let chaincodeInfos = this.networkUtil.getChaincodesOfChannel(channel);
-            for (let chaincodeInfo of chaincodeInfos) {
-                let ccObject = this.networkUtil.getNetworkObject().channels[channel].chaincodes.find(
+            const chaincodeInfos = this.networkUtil.getChaincodesOfChannel(channel);
+            for (const chaincodeInfo of chaincodeInfos) {
+                const ccObject = this.networkUtil.getNetworkObject().channels[channel].chaincodes.find(
                     cc => cc.id === chaincodeInfo.id && cc.version === chaincodeInfo.version);
 
-                let targetPeers = this.networkUtil.getTargetPeersOfChaincodeOfChannel(chaincodeInfo, channel);
+                const targetPeers = this.networkUtil.getTargetPeersOfChaincodeOfChannel(chaincodeInfo, channel);
                 if (targetPeers.size < 1) {
                     logger.info(`No target peers are defined for ${chaincodeInfo.id}@${chaincodeInfo.version} on ${channel}, skipping it`);
                     continue;
                 }
 
                 // find the peers that don't have the cc installed
-                let installTargets = [];
+                const installTargets = [];
 
-                for (let peer of targetPeers) {
-                    let org = this.networkUtil.getOrganizationOfPeer(peer);
-                    let admin = this.adminProfiles.get(org);
+                for (const peer of targetPeers) {
+                    const org = this.networkUtil.getOrganizationOfPeer(peer);
+                    const admin = this.adminProfiles.get(org);
 
                     try {
                         /** {@link ChaincodeQueryResponse} */
-                        let resp = await admin.queryInstalledChaincodes(peer, true);
+                        const resp = await admin.queryInstalledChaincodes(peer, true);
                         if (resp.chaincodes.some(cc => cc.name === chaincodeInfo.id && cc.version === chaincodeInfo.version)) {
                             logger.info(`${chaincodeInfo.id}@${chaincodeInfo.version} is already installed on ${peer}`);
                             continue;
@@ -1003,7 +986,7 @@ class Fabric extends BlockchainInterface {
 
                 if (errors.length > 0) {
                     let errorMsg = `Could not query whether ${chaincodeInfo.id}@${chaincodeInfo.version} is installed on some peers of ${channel}:`;
-                    for (let err of errors) {
+                    for (const err of errors) {
                         errorMsg += `\n\t- ${err.message}`;
                     }
 
@@ -1017,22 +1000,22 @@ class Fabric extends BlockchainInterface {
                 }
 
                 // install chaincodes org by org
-                let orgs = this.networkUtil.getOrganizationsOfChannel(channel);
-                for (let org of orgs) {
-                    let peersOfOrg = this.networkUtil.getPeersOfOrganization(org);
+                const orgs = this.networkUtil.getOrganizationsOfChannel(channel);
+                for (const org of orgs) {
+                    const peersOfOrg = this.networkUtil.getPeersOfOrganization(org);
                     // selecting the target peers for this org
-                    let orgPeerTargets = installTargets.filter(p => peersOfOrg.has(p));
+                    const orgPeerTargets = installTargets.filter(p => peersOfOrg.has(p));
 
                     // cc is installed on every target peer of the org in the channel
                     if (orgPeerTargets.length < 1) {
                         continue;
                     }
 
-                    let admin = this.adminProfiles.get(org);
+                    const admin = this.adminProfiles.get(org);
 
-                    let txId = admin.newTransactionID(true);
+                    const txId = admin.newTransactionID(true);
                     /** @{ChaincodeInstallRequest} */
-                    let request = {
+                    const request = {
                         targets: orgPeerTargets,
                         chaincodePath: ccObject.language === 'golang' ? ccObject.path : CaliperUtils.resolvePath(ccObject.path, this.workspaceRoot),
                         chaincodeId: ccObject.id,
@@ -1053,16 +1036,16 @@ class Fabric extends BlockchainInterface {
                     // install to necessary peers of org and process the results
                     try {
                         /** @link{ProposalResponseObject} */
-                        let propRespObject = await admin.installChaincode(request);
+                        const propRespObject = await admin.installChaincode(request);
                         CaliperUtils.assertDefined(propRespObject);
 
                         /** Array of @link{ProposalResponse} objects */
-                        let proposalResponses = propRespObject[0];
+                        const proposalResponses = propRespObject[0];
                         CaliperUtils.assertDefined(proposalResponses);
 
                         proposalResponses.forEach((propResponse, index) => {
                             if (propResponse instanceof Error) {
-                                let errMsg = `Install proposal error for ${chaincodeInfo.id}@${chaincodeInfo.version} on ${orgPeerTargets[index]}: ${propResponse.message}`;
+                                const errMsg = `Install proposal error for ${chaincodeInfo.id}@${chaincodeInfo.version} on ${orgPeerTargets[index]}: ${propResponse.message}`;
                                 errors.push(new Error(errMsg));
                                 return;
                             }
@@ -1071,11 +1054,11 @@ class Fabric extends BlockchainInterface {
                             CaliperUtils.assertProperty(propResponse, 'propResponse', 'response');
 
                             /** @link{ResponseObject} */
-                            let response = propResponse.response;
+                            const response = propResponse.response;
                             CaliperUtils.assertProperty(response, 'response', 'status');
 
                             if (response.status !== 200) {
-                                let errMsg = `Unsuccessful install status for ${chaincodeInfo.id}@${chaincodeInfo.version} on ${orgPeerTargets[index]}: ${propResponse.response.message}`;
+                                const errMsg = `Unsuccessful install status for ${chaincodeInfo.id}@${chaincodeInfo.version} on ${orgPeerTargets[index]}: ${propResponse.response.message}`;
                                 errors.push(new Error(errMsg));
                             }
                         });
@@ -1093,7 +1076,7 @@ class Fabric extends BlockchainInterface {
 
                 if (errors.length > 0) {
                     let errorMsg = `Could not install ${chaincodeInfo.id}@${chaincodeInfo.version} on some peers of ${channel}:`;
-                    for (let err of errors) {
+                    for (const err of errors) {
                         errorMsg += `\n\t- ${err.message}`;
                     }
 
@@ -1111,17 +1094,17 @@ class Fabric extends BlockchainInterface {
      * @async
      */
     async _instantiateChaincodes() {
-        let channels = this.networkUtil.getChannels();
+        const channels = this.networkUtil.getChannels();
         let chaincodeInstantiated = false;
 
         // chaincodes needs to be installed channel by channel
-        for (let channel of channels) {
-            let chaincodeInfos = this.networkUtil.getChaincodesOfChannel(channel);
+        for (const channel of channels) {
+            const chaincodeInfos = this.networkUtil.getChaincodesOfChannel(channel);
 
-            for (let chaincodeInfo of chaincodeInfos) {
+            for (const chaincodeInfo of chaincodeInfos) {
                 logger.info(`Instantiating ${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel}. This might take some time...`);
 
-                let ccObject = this.networkUtil.getNetworkObject().channels[channel].chaincodes.find(
+                const ccObject = this.networkUtil.getNetworkObject().channels[channel].chaincodes.find(
                     cc => cc.id === chaincodeInfo.id && cc.version === chaincodeInfo.version);
 
                 // check chaincode language
@@ -1130,7 +1113,7 @@ class Fabric extends BlockchainInterface {
                     throw new Error(`${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel}: unknown chaincode type ${ccObject.language}`);
                 }
 
-                let targetPeers = Array.from(this.networkUtil.getTargetPeersOfChaincodeOfChannel(chaincodeInfo, channel));
+                const targetPeers = Array.from(this.networkUtil.getTargetPeersOfChaincodeOfChannel(chaincodeInfo, channel));
                 if (targetPeers.length < 1) {
                     logger.info(`No target peers are defined for ${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel}, skipping it`);
                     continue;
@@ -1139,8 +1122,8 @@ class Fabric extends BlockchainInterface {
                 // select a target peer for the chaincode to see if it's instantiated
                 // these are the same as the install targets, so if one of the peers has already instantiated the chaincode,
                 // then the other targets also had done the same
-                let org = this.networkUtil.getOrganizationOfPeer(targetPeers[0]);
-                let admin = this.adminProfiles.get(org);
+                const org = this.networkUtil.getOrganizationOfPeer(targetPeers[0]);
+                const admin = this.adminProfiles.get(org);
 
                 /** @link{ChaincodeQueryResponse} */
                 let queryResponse;
@@ -1161,9 +1144,9 @@ class Fabric extends BlockchainInterface {
 
                 chaincodeInstantiated = true;
 
-                let txId = admin.newTransactionID(true);
+                const txId = admin.newTransactionID(true);
                 /** @link{ChaincodeInstantiateUpgradeRequest} */
-                let request = {
+                const request = {
                     targets: targetPeers,
                     chaincodeId: ccObject.id,
                     chaincodeVersion: ccObject.version,
@@ -1192,9 +1175,9 @@ class Fabric extends BlockchainInterface {
                 CaliperUtils.assertDefined(response);
 
                 /** @link{Array<ProposalResponse>} */
-                let proposalResponses = response[0];
+                const proposalResponses = response[0];
                 /** @link{Proposal} */
-                let proposal = response[1];
+                const proposal = response[1];
                 CaliperUtils.assertDefined(proposalResponses);
                 CaliperUtils.assertDefined(proposal);
 
@@ -1210,15 +1193,15 @@ class Fabric extends BlockchainInterface {
                 });
 
                 // connect to every event source of every org in the channel
-                let eventSources = this._assembleTargetEventSources(channel, targetPeers);
-                let eventPromises = [];
+                const eventSources = this._assembleTargetEventSources(channel, targetPeers);
+                const eventPromises = [];
 
                 try {
                     // NOTE: everything is resolved, errors are signaled through an Error object
                     // this makes error handling and reporting easier
                     eventSources.forEach((es) => {
-                        let promise = new Promise((resolve) => {
-                            let timeoutHandle = setTimeout(() => {
+                        const promise = new Promise((resolve) => {
+                            const timeoutHandle = setTimeout(() => {
                                 // unregister manually
                                 es.eventHub.unregisterTxEvent(txId.getTransactionID(), false);
                                 resolve(new Error(`Commit timeout for ${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel} from ${es.peer}`));
@@ -1243,7 +1226,7 @@ class Fabric extends BlockchainInterface {
                     });
 
                     /** @link{TransactionRequest} */
-                    let ordererRequest = {
+                    const ordererRequest = {
                         txId: txId,
                         proposalResponses: proposalResponses,
                         proposal: proposal
@@ -1265,13 +1248,13 @@ class Fabric extends BlockchainInterface {
                     }
 
                     // since every event promise is resolved, this shouldn't throw an error
-                    let eventResults = await Promise.all(eventPromises);
+                    const eventResults = await Promise.all(eventPromises);
 
                     // if we received an error, propagate it
                     if (eventResults.some(er => er instanceof Error)) {
                         let errMsg = `The following errors occured while instantiating ${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel}:`;
                         let err; // keep the last error
-                        for (let eventResult of eventResults) {
+                        for (const eventResult of eventResults) {
                             if (eventResult instanceof Error) {
                                 err = eventResult;
                                 errMsg += `\n\t- ${eventResult.message}`;
@@ -1303,25 +1286,25 @@ class Fabric extends BlockchainInterface {
      * @async
      */
     async _joinChannels() {
-        let channels = this.networkUtil.getChannels();
+        const channels = this.networkUtil.getChannels();
         let channelJoined = false;
-        let errors = [];
+        const errors = [];
 
-        for (let channelName of channels) {
+        for (const channelName of channels) {
             let genesisBlock = null;
-            let orgs = this.networkUtil.getOrganizationsOfChannel(channelName);
+            const orgs = this.networkUtil.getOrganizationsOfChannel(channelName);
 
-            for (let org of orgs) {
-                let admin = this.adminProfiles.get(org);
-                let channelObject = admin.getChannel(channelName, true);
+            for (const org of orgs) {
+                const admin = this.adminProfiles.get(org);
+                const channelObject = admin.getChannel(channelName, true);
 
-                let peers = this.networkUtil.getPeersOfOrganizationAndChannel(org, channelName);
-                let peersToJoin = [];
+                const peers = this.networkUtil.getPeersOfOrganizationAndChannel(org, channelName);
+                const peersToJoin = [];
 
-                for (let peer of peers) {
+                for (const peer of peers) {
                     try {
                         /** {@link ChannelQueryResponse} */
-                        let resp = await admin.queryChannels(peer, true);
+                        const resp = await admin.queryChannels(peer, true);
                         if (resp.channels.some(ch => ch.channel_id === channelName)) {
                             logger.info(`${peer} has already joined ${channelName}`);
                             continue;
@@ -1335,7 +1318,7 @@ class Fabric extends BlockchainInterface {
 
                 if (errors.length > 0) {
                     let errMsg = `The following errors occurred while querying ${channelName} information from ${org}'s peers:`;
-                    for (let err of errors) {
+                    for (const err of errors) {
                         errMsg += `\n\t- ${err.message}`;
                     }
 
@@ -1353,9 +1336,9 @@ class Fabric extends BlockchainInterface {
                 // only retrieve the genesis block once, and "cache" it
                 if (genesisBlock === null) {
                     try {
-                        let genesisTxId = admin.newTransactionID(true);
+                        const genesisTxId = admin.newTransactionID(true);
                         /** @link{OrdererRequest} */
-                        let genesisRequest = {
+                        const genesisRequest = {
                             txId: genesisTxId
                         };
                         genesisBlock = await channelObject.getGenesisBlock(genesisRequest);
@@ -1364,8 +1347,8 @@ class Fabric extends BlockchainInterface {
                     }
                 }
 
-                let joinTxId = admin.newTransactionID(true);
-                let joinRequest = {
+                const joinTxId = admin.newTransactionID(true);
+                const joinRequest = {
                     block: genesisBlock,
                     txId: joinTxId,
                     targets: peersToJoin
@@ -1373,7 +1356,7 @@ class Fabric extends BlockchainInterface {
 
                 try {
                     /**{@link ProposalResponse} array*/
-                    let joinRespArray = await channelObject.joinChannel(joinRequest);
+                    const joinRespArray = await channelObject.joinChannel(joinRequest);
                     CaliperUtils.assertDefined(joinRespArray);
 
                     // Some errors are returned as Error instances, some as error messages
@@ -1390,7 +1373,7 @@ class Fabric extends BlockchainInterface {
 
                 if (errors.length > 0) {
                     let errMsg = `The following errors occurred while ${org}'s peers tried to join ${channelName}:`;
-                    for (let err of errors) {
+                    for (const err of errors) {
                         errMsg += `\n\t- ${err.message}`;
                     }
 
@@ -1434,7 +1417,7 @@ class Fabric extends BlockchainInterface {
         if (!client) {
             CaliperUtils.assertDefined(org);
             // base it on the first client connection profile of the org
-            let clients = this.networkUtil.getClientsOfOrganization(org);
+            const clients = this.networkUtil.getClientsOfOrganization(org);
 
             // NOTE: this assumes at least one client per org, which is reasonable, the clients will interact with the network
             if (clients.size < 1) {
@@ -1447,7 +1430,7 @@ class Fabric extends BlockchainInterface {
         // load the general network data from a clone of the network object
         // NOTE: if we provide a common object instead, the Client class will use it directly,
         // and it will be overwritten when loading the next client
-        let profile = FabricClient.loadFromConfig(this.networkUtil.getNewNetworkObject());
+        const profile = FabricClient.loadFromConfig(this.networkUtil.getNewNetworkObject());
         profile.loadFromConfig({
             version: '1.0',
             client: this.networkUtil.getClientObject(client)
@@ -1470,8 +1453,8 @@ class Fabric extends BlockchainInterface {
      * @private
      */
     _setTlsAdminCertAndKey(org) {
-        let profile = this.adminProfiles.get(org);
-        let crypto = this.networkUtil.getAdminCryptoContentOfOrganization(org);
+        const profile = this.adminProfiles.get(org);
+        const crypto = this.networkUtil.getAdminCryptoContentOfOrganization(org);
         profile.setTlsClientCertAndKey(crypto.signedCertPEM.toString(), crypto.privateKeyPEM.toString());
     }
 
@@ -1497,73 +1480,69 @@ class Fabric extends BlockchainInterface {
     }
 
     /**
-     * Submit a transaction using a Gateway contract
+     * Perform a transaction using a Gateway contract
      * @param {object} context The context previously created by the Fabric adapter.
-     * @param {ChaincodeInvokeSettings} invokeSettings The settings associated with the transaction submission.
+     * @param {ChaincodeInvokeSettings | ChaincodeQuerySettings} invokeSettings The settings associated with the transaction submission.
+     * @param {boolean} isSubmit boolean flag to indicate if the transaction is a submit or evaluate
      * @return {Promise<TxStatus>} The result and stats of the transaction invocation.
      * @async
      */
-    async _submitGatewayTransaction(context, invokeSettings) {
+    async _performGatewayTransaction(context, invokeSettings, isSubmit) {
 
         // Retrieve the existing contract and a client
-        const contract = await this._getUserContract(invokeSettings.invokerIdentity, invokeSettings.chaincodeId);
-        const client = this.clientProfiles.get(invokeSettings.invokerIdentity);
+        const smartContract = await this._getUserContract(invokeSettings.invokerIdentity, invokeSettings.chaincodeId);
 
-        // Build the Caliper TxStatus, this is a reduced item when compared to the low level API capabilities
-        const txIdObject = client.newTransactionID();
-        const txId = txIdObject.getTransactionID();
-        let invokeStatus = new TxStatus(txId);
-        invokeStatus.Set('request_type', 'transaction');
+        // Create a transaction
+        const transaction = smartContract.createTransaction(invokeSettings.chaincodeFunction);
 
-        if(context.engine) {
-            context.engine.submitCallback(1);
+        // Build the Caliper TxStatus
+        const invokeStatus = new TxStatus(transaction.getTransactionID());
+
+        // Add transient data if present
+        // - passed as key value pairing such as {"hello":"world"}
+        if (invokeSettings.transientData) {
+            const transientData = {};
+            const keys = Array.from(Object.keys(invokeSettings.transientData));
+            keys.forEach((key) => {
+                transientData[key] = Buffer.from(invokeSettings.transientData[key]);
+            });
+            transaction.setTransient(transientData);
+        }
+
+        // Set endorsing peers if passed as a string array
+        if (invokeSettings.targetPeers) {
+            // Retrieved cached peer objects
+            const targetPeerObjects = [];
+            for (const name of invokeSettings.targetPeers) {
+                const peer = this.peerCache.get(name);
+                targetPeerObjects.push(peer);
+            }
+            // Set the peer objects in the transaction
+            transaction.setEndorsingPeers(targetPeerObjects);
         }
 
         try {
-            const result = await contract.submitTransaction(invokeSettings.chaincodeFunction, ...invokeSettings.chaincodeArguments);
+            let result;
+            if (isSubmit) {
+                if (context.engine) {
+                    context.engine.submitCallback(1);
+                }
+                invokeStatus.Set('request_type', 'transaction');
+                result = await transaction.submit(...invokeSettings.chaincodeArguments);
+            } else {
+                const countAsLoad = invokeSettings.countAsLoad === undefined ? this.configCountQueryAsLoad : invokeSettings.countAsLoad;
+                if (context.engine && countAsLoad) {
+                    context.engine.submitCallback(1);
+                }
+                invokeStatus.Set('request_type', 'query');
+                result = await transaction.evaluate(...invokeSettings.chaincodeArguments);
+            }
             invokeStatus.result = result;
             invokeStatus.verified = true;
             invokeStatus.SetStatusSuccess();
             return invokeStatus;
         } catch (err) {
-            logger.error(`Failed to submit transaction [${invokeSettings.chaincodeFunction}] using arguments [${invokeSettings.chaincodeArguments}],  with error: ${err.stack ? err.stack : err}`);
-            invokeStatus.SetStatusFail();
-            invokeStatus.result = [];
-            return invokeStatus;
-        }
-    }
-
-    /**
-     * Submit a transaction using a Gateway contract
-     * @param {object} context The context previously created by the Fabric adapter.
-     * @param {ChaincodeQuerySettings} querySettings The settings associated with the transaction evaluation.
-     * @return {Promise<TxStatus>} The result and stats of the transaction invocation.
-     * @async
-     */
-    async _evaluateGatewayTransaction(context, querySettings) {
-
-        // Retrieve the existing contract and a client
-        const contract = await this._getUserContract(querySettings.invokerIdentity, querySettings.chaincodeId);
-        const client = this.clientProfiles.get(querySettings.invokerIdentity);
-
-        // Build the Caliper TxStatus, this is a reduced item when compared to the low level API capabilities
-        const txIdObject = client.newTransactionID();
-        const txId = txIdObject.getTransactionID();
-        let invokeStatus = new TxStatus(txId);
-        invokeStatus.Set('request_type', 'query');
-
-        if(context.engine) {
-            context.engine.submitCallback(1);
-        }
-
-        try {
-            const result = await contract.evaluateTransaction(querySettings.chaincodeFunction, ...querySettings.chaincodeArguments);
-            invokeStatus.result = result;
-            invokeStatus.verified = true;
-            invokeStatus.SetStatusSuccess();
-            return invokeStatus;
-        } catch (err) {
-            logger.error(`Failed to evaluate transaction [${querySettings.chaincodeFunction}] using arguments [${querySettings.chaincodeArguments}],  with error: ${err.stack ? err.stack : err}`);
+            logger.error(`Failed to perform ${isSubmit ? 'submit' : 'query' } transaction [${invokeSettings.chaincodeFunction}] using arguments [${invokeSettings.chaincodeArguments}],  with error: ${err.stack ? err.stack : err}`);
             invokeStatus.SetStatusFail();
             invokeStatus.result = [];
             return invokeStatus;
@@ -1649,9 +1628,9 @@ class Fabric extends BlockchainInterface {
      * @async
      */
     async init(workerInit = false) {
-        let tlsInfo = this.networkUtil.isMutualTlsEnabled() ? 'mutual'
+        const tlsInfo = this.networkUtil.isMutualTlsEnabled() ? 'mutual'
             : (this.networkUtil.isTlsEnabled() ? 'server' : 'none');
-        let compMode = this.networkUtil.isInCompatibilityMode() ? '; Fabric v1.0 compatibility mode' : '';
+        const compMode = this.networkUtil.isInCompatibilityMode() ? '; Fabric v1.0 compatibility mode' : '';
         logger.info(`Fabric SDK version: ${this.version.toString()}; TLS: ${tlsInfo}${compMode}`);
 
         await this._initializeRegistrars(workerInit);
@@ -1702,7 +1681,7 @@ class Fabric extends BlockchainInterface {
      * @return {Promise<TxStatus[]>} The result and stats of the transaction invocation.
      */
     async invokeSmartContract(context, contractID, contractVersion, invokeSettings, timeout) {
-        let promises = [];
+        const promises = [];
         let settingsArray;
 
         if (!Array.isArray(invokeSettings)) {
@@ -1711,8 +1690,8 @@ class Fabric extends BlockchainInterface {
             settingsArray = invokeSettings;
         }
 
-        for (let settings of settingsArray) {
-            let contractDetails = this.networkUtil.getContractDetails(contractID);
+        for (const settings of settingsArray) {
+            const contractDetails = this.networkUtil.getContractDetails(contractID);
             if (!contractDetails) {
                 throw new Error(`Could not find details for contract ID ${contractID}`);
             }
@@ -1725,7 +1704,7 @@ class Fabric extends BlockchainInterface {
                 settings.invokerIdentity = this.defaultInvoker;
             }
 
-            promises.push(this._submitGatewayTransaction(context, settings));
+            promises.push(this._performGatewayTransaction(context, settings, true));
         }
 
         return await Promise.all(promises);
@@ -1742,7 +1721,7 @@ class Fabric extends BlockchainInterface {
      * @return {Promise<TxStatus[]>} The result and stats of the transaction query.
      */
     async querySmartContract(context, contractID, contractVersion, querySettings, timeout) {
-        let promises = [];
+        const promises = [];
         let settingsArray;
 
         if (!Array.isArray(querySettings)) {
@@ -1751,8 +1730,8 @@ class Fabric extends BlockchainInterface {
             settingsArray = querySettings;
         }
 
-        for (let settings of settingsArray) {
-            let contractDetails = this.networkUtil.getContractDetails(contractID);
+        for (const settings of settingsArray) {
+            const contractDetails = this.networkUtil.getContractDetails(contractID);
             if (!contractDetails) {
                 throw new Error(`Could not find details for contract ID ${contractID}`);
             }
@@ -1765,7 +1744,7 @@ class Fabric extends BlockchainInterface {
                 settings.invokerIdentity = this.defaultInvoker;
             }
 
-            promises.push(this._evaluateGatewayTransaction(context, settings));
+            promises.push(this._performGatewayTransaction(context, settings, false));
         }
 
         return await Promise.all(promises);

--- a/packages/caliper-fabric/lib/adaptor-versions/v1/fabric-v1.js
+++ b/packages/caliper-fabric/lib/adaptor-versions/v1/fabric-v1.js
@@ -138,7 +138,7 @@ class Fabric extends BlockchainInterface {
 
         this.network = undefined;
         if (typeof networkConfig === 'string') {
-            let configPath = CaliperUtils.resolvePath(networkConfig, workspace_root);
+            const configPath = CaliperUtils.resolvePath(networkConfig, workspace_root);
             this.network = CaliperUtils.parseYaml(configPath);
         } else if (typeof networkConfig === 'object' && networkConfig !== null) {
             // clone the object to prevent modification by other objects
@@ -205,16 +205,16 @@ class Fabric extends BlockchainInterface {
      * @private
      */
     _assembleTargetEventSources(channel, targetPeers) {
-        let eventSources = [];
+        const eventSources = [];
         if (this.networkUtil.isInCompatibilityMode()) {
             // NOTE: for old event hubs we have a single connection to every peer set as an event source
             const EventHub = require('fabric-client/lib/EventHub.js');
 
-            for (let peer of targetPeers) {
-                let org = this.networkUtil.getOrganizationOfPeer(peer);
-                let admin = this.adminProfiles.get(org);
+            for (const peer of targetPeers) {
+                const org = this.networkUtil.getOrganizationOfPeer(peer);
+                const admin = this.adminProfiles.get(org);
 
-                let eventHub = new EventHub(admin);
+                const eventHub = new EventHub(admin);
                 eventHub.setPeerAddr(this.networkUtil.getPeerEventUrl(peer),
                     this.networkUtil.getGrpcOptionsOfPeer(peer));
 
@@ -225,11 +225,11 @@ class Fabric extends BlockchainInterface {
                 });
             }
         } else {
-            for (let peer of targetPeers) {
-                let org = this.networkUtil.getOrganizationOfPeer(peer);
-                let admin = this.adminProfiles.get(org);
+            for (const peer of targetPeers) {
+                const org = this.networkUtil.getOrganizationOfPeer(peer);
+                const admin = this.adminProfiles.get(org);
 
-                let eventHub = admin.getChannel(channel, true).newChannelEventHub(peer);
+                const eventHub = admin.getChannel(channel, true).newChannelEventHub(peer);
 
                 eventSources.push({
                     channel: [channel], // unused during chaincode instantiation
@@ -251,14 +251,14 @@ class Fabric extends BlockchainInterface {
      * @private
      */
     _assembleRandomTargetPeers(channel, chaincodeId, chaincodeVersion) {
-        let targets = [];
-        let chaincodeOrgs = this.randomTargetPeerCache.get(channel).get(`${chaincodeId}@${chaincodeVersion}`);
+        const targets = [];
+        const chaincodeOrgs = this.randomTargetPeerCache.get(channel).get(`${chaincodeId}@${chaincodeVersion}`);
 
-        for (let entries of chaincodeOrgs.entries()) {
-            let peers = entries[1];
+        for (const entries of chaincodeOrgs.entries()) {
+            const peers = entries[1];
 
             // represents the load balancing mechanism
-            let loadBalancingCounter = this.configClientBasedLoadBalancing ? this.clientIndex : this.txIndex;
+            const loadBalancingCounter = this.configClientBasedLoadBalancing ? this.clientIndex : this.txIndex;
             targets.push(peers[loadBalancingCounter % peers.length]);
         }
 
@@ -272,11 +272,11 @@ class Fabric extends BlockchainInterface {
      * @async
      */
     async _createChannels() {
-        let channels = this.networkUtil.getChannels();
+        const channels = this.networkUtil.getChannels();
         let channelCreated = false;
 
-        for (let channel of channels) {
-            let channelObject = this.networkUtil.getNetworkObject().channels[channel];
+        for (const channel of channels) {
+            const channelObject = this.networkUtil.getNetworkObject().channels[channel];
 
             if (CaliperUtils.checkProperty(channelObject, 'created') && channelObject.created) {
                 logger.info(`Channel '${channel}' is configured as created, skipping creation`);
@@ -304,10 +304,10 @@ class Fabric extends BlockchainInterface {
             }
 
             // NOTE: without knowing the system channel policies, signing with every org admin is a safe bet
-            let orgs = this.networkUtil.getOrganizationsOfChannel(channel);
+            const orgs = this.networkUtil.getOrganizationsOfChannel(channel);
             let admin; // declared here to keep the admin of the last org of the channel
-            let signatures = [];
-            for (let org of orgs) {
+            const signatures = [];
+            for (const org of orgs) {
                 admin = this.adminProfiles.get(org);
                 try {
                     signatures.push(admin.signChannelConfig(configUpdate));
@@ -316,8 +316,8 @@ class Fabric extends BlockchainInterface {
                 }
             }
 
-            let txId = admin.newTransactionID(true);
-            let request = {
+            const txId = admin.newTransactionID(true);
+            const request = {
                 config: configUpdate,
                 signatures: signatures,
                 name: channel,
@@ -326,7 +326,7 @@ class Fabric extends BlockchainInterface {
 
             try {
                 /** @link{BroadcastResponse} */
-                let broadcastResponse = await admin.createChannel(request);
+                const broadcastResponse = await admin.createChannel(request);
 
                 CaliperUtils.assertDefined(broadcastResponse, `The returned broadcast response for creating Channel '${channel}' is undefined`);
                 CaliperUtils.assertProperty(broadcastResponse, 'broadcastResponse', 'status');
@@ -356,13 +356,13 @@ class Fabric extends BlockchainInterface {
      */
     _createEventRegistrationPromise(eventSource, txId, invokeStatus, startTime, timeout) {
         return new Promise(resolve => {
-            let handle = setTimeout(() => {
+            const handle = setTimeout(() => {
                 // give the other event hub connections a chance
                 // to verify the Tx status, so resolve the promise
 
                 eventSource.eventHub.unregisterTxEvent(txId);
 
-                let time = Date.now();
+                const time = Date.now();
                 invokeStatus.Set(`commit_timeout_${eventSource.peer}`, 'TIMEOUT');
 
                 // resolve the failed transaction with the current time and error message
@@ -375,7 +375,7 @@ class Fabric extends BlockchainInterface {
 
             eventSource.eventHub.registerTxEvent(txId, (tx, code) => {
                 clearTimeout(handle);
-                let time = Date.now();
+                const time = Date.now();
                 eventSource.eventHub.unregisterTxEvent(txId);
 
                 // either explicit invalid event or valid event, verified in both cases by at least one peer
@@ -401,7 +401,7 @@ class Fabric extends BlockchainInterface {
             }, (err) => {
                 clearTimeout(handle);
                 eventSource.eventHub.unregisterTxEvent(txId);
-                let time = Date.now();
+                const time = Date.now();
 
                 // we don't know what happened, but give the other event hub connections a chance
                 // to verify the Tx status, so resolve this promise
@@ -455,7 +455,7 @@ class Fabric extends BlockchainInterface {
     async _enrollUser(profile, id, secret, profileName) {
         // this call will throw an error if the CA configuration is not found
         // this error should propagate up
-        let ca = profile.getCertificateAuthority();
+        const ca = profile.getCertificateAuthority();
         try {
             return await ca.enroll({
                 enrollmentID: id,
@@ -594,7 +594,7 @@ class Fabric extends BlockchainInterface {
      */
     _getChannelConfigFromFile(channelObject, channelName) {
         // extracting the config from the binary file
-        let binaryPath = CaliperUtils.resolvePath(channelObject.configBinary, this.workspaceRoot);
+        const binaryPath = CaliperUtils.resolvePath(channelObject.configBinary, this.workspaceRoot);
         let envelopeBytes;
 
         try {
@@ -617,10 +617,10 @@ class Fabric extends BlockchainInterface {
      * @private
      */
     _getRandomTargetOrderer(channel) {
-        let orderers = this.randomTargetOrdererCache.get(channel);
+        const orderers = this.randomTargetOrdererCache.get(channel);
 
         // represents the load balancing mechanism
-        let loadBalancingCounter = this.configClientBasedLoadBalancing ? this.clientIndex : this.txIndex;
+        const loadBalancingCounter = this.configClientBasedLoadBalancing ? this.clientIndex : this.txIndex;
 
         return orderers[loadBalancingCounter % orderers.length];
     }
@@ -669,14 +669,14 @@ class Fabric extends BlockchainInterface {
      * @async
      */
     async _initializeAdmins(workerInit) {
-        let orgs = this.networkUtil.getOrganizations();
-        for (let org of orgs) {
-            let adminName = `admin.${org}`;
+        const orgs = this.networkUtil.getOrganizations();
+        for (const org of orgs) {
+            const adminName = `admin.${org}`;
             // build the common part of the profile
-            let adminProfile = await this._prepareClientProfile(org, undefined, `${org}'s admin`);
+            const adminProfile = await this._prepareClientProfile(org, undefined, `${org}'s admin`);
 
             // Check if the materials already exist locally in file system key-value stores.
-            let admin = await this._getUserContext(adminProfile, adminName, `${org}'s admin`);
+            const admin = await this._getUserContext(adminProfile, adminName, `${org}'s admin`);
             if (admin) {
                 this.adminProfiles.set(org, adminProfile);
 
@@ -715,16 +715,16 @@ class Fabric extends BlockchainInterface {
      */
     async _initializeChannel(profiles, channel, admin) {
         // initialize the channel for every client profile from the local config
-        for (let profile of profiles.entries()) {
-            let profileOrg = admin ? profile[0] : this.networkUtil.getOrganizationOfClient(profile[0]);
-            let channelOrgs = this.networkUtil.getOrganizationsOfChannel(channel);
+        for (const profile of profiles.entries()) {
+            const profileOrg = admin ? profile[0] : this.networkUtil.getOrganizationOfClient(profile[0]);
+            const channelOrgs = this.networkUtil.getOrganizationsOfChannel(channel);
 
             // skip init for profiles whose org is a not a member of the channel
             if (!channelOrgs.has(profileOrg)) {
                 continue;
             }
 
-            let ch = profile[1].getChannel(channel, false);
+            const ch = profile[1].getChannel(channel, false);
             if (ch) {
                 try {
                     await ch.initialize();
@@ -744,11 +744,11 @@ class Fabric extends BlockchainInterface {
      * @async
      */
     async _initializeRegistrars(workerInit) {
-        let orgs = this.networkUtil.getOrganizations();
-        for (let org of orgs) {
+        const orgs = this.networkUtil.getOrganizations();
+        for (const org of orgs) {
 
             // providing registrar information is optional and only needed for user registration and enrollment
-            let registrarInfo = this.networkUtil.getRegistrarOfOrganization(org);
+            const registrarInfo = this.networkUtil.getRegistrarOfOrganization(org);
             if (!registrarInfo) {
                 if (!workerInit) {
                     logger.warn(`${org}'s registrar information not provided.`);
@@ -757,9 +757,9 @@ class Fabric extends BlockchainInterface {
             }
 
             // build the common part of the profile
-            let registrarProfile = await this._prepareClientProfile(org, undefined, 'registrar');
+            const registrarProfile = await this._prepareClientProfile(org, undefined, 'registrar');
             // check if the materials already exist locally in the file system key-value stores
-            let registrar = await this._getUserContext(registrarProfile, registrarInfo.enrollId, `${org}'s registrar`);
+            const registrar = await this._getUserContext(registrarProfile, registrarInfo.enrollId, `${org}'s registrar`);
 
             if (registrar) {
                 if (!workerInit) {
@@ -788,18 +788,18 @@ class Fabric extends BlockchainInterface {
      * @async
      */
     async _initializeUsers(workerInit) {
-        let clients = this.networkUtil.getClients();
+        const clients = this.networkUtil.getClients();
 
         // register and enroll each client with its organization's CA
-        for (let client of clients) {
-            let org = this.networkUtil.getOrganizationOfClient(client);
+        for (const client of clients) {
+            const org = this.networkUtil.getOrganizationOfClient(client);
 
             // create the profile based on the connection profile
-            let clientProfile = await this._prepareClientProfile(org, client, client);
+            const clientProfile = await this._prepareClientProfile(org, client, client);
             this.clientProfiles.set(client, clientProfile);
 
             // check if the materials already exist locally in the file system key-value stores
-            let user = await this._getUserContext(clientProfile, client, client);
+            const user = await this._getUserContext(clientProfile, client, client);
             if (user) {
                 if (this.networkUtil.isMutualTlsEnabled()) {
                     // "retrieve" and set the deserialized cert and key
@@ -820,7 +820,7 @@ class Fabric extends BlockchainInterface {
                 await this._createUser(clientProfile, org, client, cryptoContent, client);
                 if (this.networkUtil.isMutualTlsEnabled()) {
                     // the materials are included in the configuration file
-                    let crypto = this.networkUtil.getClientCryptoContent(client);
+                    const crypto = this.networkUtil.getClientCryptoContent(client);
                     clientProfile.setTlsClientCertAndKey(crypto.signedCertPEM.toString(), crypto.privateKeyPEM.toString());
                 }
 
@@ -834,9 +834,9 @@ class Fabric extends BlockchainInterface {
             // The user needs to be enrolled or even registered
 
             // if the enrollment ID and secret is provided, then enroll the already registered user
-            let enrollmentSecret = this.networkUtil.getClientEnrollmentSecret(client);
+            const enrollmentSecret = this.networkUtil.getClientEnrollmentSecret(client);
             if (enrollmentSecret) {
-                let enrollment = await this._enrollUser(clientProfile, client, enrollmentSecret, client);
+                const enrollment = await this._enrollUser(clientProfile, client, enrollmentSecret, client);
 
                 // create the new user based on the retrieved materials
                 await this._createUser(clientProfile, org, client,
@@ -860,22 +860,22 @@ class Fabric extends BlockchainInterface {
             // Otherwise, register then enroll the user
             let secret;
             try {
-                let registrarProfile = this.registrarProfiles.get(org);
+                const registrarProfile = this.registrarProfiles.get(org);
 
                 if (!registrarProfile) {
                     throw new Error(`Registrar identity is not provided for ${org}`);
                 }
 
-                let registrarInfo = this.networkUtil.getRegistrarOfOrganization(org);
-                let registrar = await registrarProfile.getUserContext(registrarInfo.enrollId, true);
+                const registrarInfo = this.networkUtil.getRegistrarOfOrganization(org);
+                const registrar = await registrarProfile.getUserContext(registrarInfo.enrollId, true);
                 // this call will throw an error if the CA configuration is not found
                 // this error should propagate up
-                let ca = clientProfile.getCertificateAuthority();
-                let userAffiliation = this.networkUtil.getAffiliationOfUser(client);
+                const ca = clientProfile.getCertificateAuthority();
+                const userAffiliation = this.networkUtil.getAffiliationOfUser(client);
 
                 // if not in compatibility mode (i.e., at least SDK v1.1), check whether the affiliation is already registered or not
                 if (!this.networkUtil.isInCompatibilityMode()) {
-                    let affService = ca.newAffiliationService();
+                    const affService = ca.newAffiliationService();
                     let affiliationExists = false;
                     try {
                         await affService.getOne(userAffiliation, registrar);
@@ -894,7 +894,7 @@ class Fabric extends BlockchainInterface {
                     }
                 }
 
-                let attributes = this.networkUtil.getAttributesOfUser(client);
+                const attributes = this.networkUtil.getAttributesOfUser(client);
                 attributes.push({name: 'hf.Registrar.Roles', value: 'client'});
 
                 secret = await ca.register({
@@ -911,7 +911,7 @@ class Fabric extends BlockchainInterface {
                 logger.info(`${client} successfully registered`);
             }
 
-            let enrollment = await this._enrollUser(clientProfile, client, secret, client);
+            const enrollment = await this._enrollUser(clientProfile, client, secret, client);
 
             // create the new user based on the retrieved materials
             await this._createUser(clientProfile, org, client,
@@ -939,34 +939,34 @@ class Fabric extends BlockchainInterface {
             process.env.GOPATH = CaliperUtils.resolvePath('.', this.workspaceRoot);
         }
 
-        let errors = [];
+        const errors = [];
 
-        let channels = this.networkUtil.getChannels();
-        for (let channel of channels) {
+        const channels = this.networkUtil.getChannels();
+        for (const channel of channels) {
             logger.info(`Installing chaincodes for ${channel}...`);
 
             // proceed cc by cc for the channel
-            let chaincodeInfos = this.networkUtil.getChaincodesOfChannel(channel);
-            for (let chaincodeInfo of chaincodeInfos) {
-                let ccObject = this.networkUtil.getNetworkObject().channels[channel].chaincodes.find(
+            const chaincodeInfos = this.networkUtil.getChaincodesOfChannel(channel);
+            for (const chaincodeInfo of chaincodeInfos) {
+                const ccObject = this.networkUtil.getNetworkObject().channels[channel].chaincodes.find(
                     cc => cc.id === chaincodeInfo.id && cc.version === chaincodeInfo.version);
 
-                let targetPeers = this.networkUtil.getTargetPeersOfChaincodeOfChannel(chaincodeInfo, channel);
+                const targetPeers = this.networkUtil.getTargetPeersOfChaincodeOfChannel(chaincodeInfo, channel);
                 if (targetPeers.size < 1) {
                     logger.info(`No target peers are defined for ${chaincodeInfo.id}@${chaincodeInfo.version} on ${channel}, skipping it`);
                     continue;
                 }
 
                 // find the peers that don't have the cc installed
-                let installTargets = [];
+                const installTargets = [];
 
-                for (let peer of targetPeers) {
-                    let org = this.networkUtil.getOrganizationOfPeer(peer);
-                    let admin = this.adminProfiles.get(org);
+                for (const peer of targetPeers) {
+                    const org = this.networkUtil.getOrganizationOfPeer(peer);
+                    const admin = this.adminProfiles.get(org);
 
                     try {
                         /** {@link ChaincodeQueryResponse} */
-                        let resp = await admin.queryInstalledChaincodes(peer, true);
+                        const resp = await admin.queryInstalledChaincodes(peer, true);
                         if (resp.chaincodes.some(cc => cc.name === chaincodeInfo.id && cc.version === chaincodeInfo.version)) {
                             logger.info(`${chaincodeInfo.id}@${chaincodeInfo.version} is already installed on ${peer}`);
                             continue;
@@ -980,7 +980,7 @@ class Fabric extends BlockchainInterface {
 
                 if (errors.length > 0) {
                     let errorMsg = `Could not query whether ${chaincodeInfo.id}@${chaincodeInfo.version} is installed on some peers of ${channel}:`;
-                    for (let err of errors) {
+                    for (const err of errors) {
                         errorMsg += `\n\t- ${err.message}`;
                     }
 
@@ -994,22 +994,22 @@ class Fabric extends BlockchainInterface {
                 }
 
                 // install chaincodes org by org
-                let orgs = this.networkUtil.getOrganizationsOfChannel(channel);
-                for (let org of orgs) {
-                    let peersOfOrg = this.networkUtil.getPeersOfOrganization(org);
+                const orgs = this.networkUtil.getOrganizationsOfChannel(channel);
+                for (const org of orgs) {
+                    const peersOfOrg = this.networkUtil.getPeersOfOrganization(org);
                     // selecting the target peers for this org
-                    let orgPeerTargets = installTargets.filter(p => peersOfOrg.has(p));
+                    const orgPeerTargets = installTargets.filter(p => peersOfOrg.has(p));
 
                     // cc is installed on every target peer of the org in the channel
                     if (orgPeerTargets.length < 1) {
                         continue;
                     }
 
-                    let admin = this.adminProfiles.get(org);
+                    const admin = this.adminProfiles.get(org);
 
-                    let txId = admin.newTransactionID(true);
+                    const txId = admin.newTransactionID(true);
                     /** @{ChaincodeInstallRequest} */
-                    let request = {
+                    const request = {
                         targets: orgPeerTargets,
                         chaincodePath: ccObject.language === 'golang' ? ccObject.path : CaliperUtils.resolvePath(ccObject.path, this.workspaceRoot),
                         chaincodeId: ccObject.id,
@@ -1030,16 +1030,16 @@ class Fabric extends BlockchainInterface {
                     // install to necessary peers of org and process the results
                     try {
                         /** @link{ProposalResponseObject} */
-                        let propRespObject = await admin.installChaincode(request);
+                        const propRespObject = await admin.installChaincode(request);
                         CaliperUtils.assertDefined(propRespObject);
 
                         /** Array of @link{ProposalResponse} objects */
-                        let proposalResponses = propRespObject[0];
+                        const proposalResponses = propRespObject[0];
                         CaliperUtils.assertDefined(proposalResponses);
 
                         proposalResponses.forEach((propResponse, index) => {
                             if (propResponse instanceof Error) {
-                                let errMsg = `Install proposal error for ${chaincodeInfo.id}@${chaincodeInfo.version} on ${orgPeerTargets[index]}: ${propResponse.message}`;
+                                const errMsg = `Install proposal error for ${chaincodeInfo.id}@${chaincodeInfo.version} on ${orgPeerTargets[index]}: ${propResponse.message}`;
                                 errors.push(new Error(errMsg));
                                 return;
                             }
@@ -1048,11 +1048,11 @@ class Fabric extends BlockchainInterface {
                             CaliperUtils.assertProperty(propResponse, 'propResponse', 'response');
 
                             /** @link{ResponseObject} */
-                            let response = propResponse.response;
+                            const response = propResponse.response;
                             CaliperUtils.assertProperty(response, 'response', 'status');
 
                             if (response.status !== 200) {
-                                let errMsg = `Unsuccessful install status for ${chaincodeInfo.id}@${chaincodeInfo.version} on ${orgPeerTargets[index]}: ${propResponse.response.message}`;
+                                const errMsg = `Unsuccessful install status for ${chaincodeInfo.id}@${chaincodeInfo.version} on ${orgPeerTargets[index]}: ${propResponse.response.message}`;
                                 errors.push(new Error(errMsg));
                             }
                         });
@@ -1070,7 +1070,7 @@ class Fabric extends BlockchainInterface {
 
                 if (errors.length > 0) {
                     let errorMsg = `Could not install ${chaincodeInfo.id}@${chaincodeInfo.version} on some peers of ${channel}:`;
-                    for (let err of errors) {
+                    for (const err of errors) {
                         errorMsg += `\n\t- ${err.message}`;
                     }
 
@@ -1088,20 +1088,20 @@ class Fabric extends BlockchainInterface {
      * @async
      */
     async _instantiateChaincodes() {
-        let channels = this.networkUtil.getChannels();
+        const channels = this.networkUtil.getChannels();
         let chaincodeInstantiated = false;
 
         // chaincodes needs to be installed channel by channel
-        for (let channel of channels) {
-            let chaincodeInfos = this.networkUtil.getChaincodesOfChannel(channel);
+        for (const channel of channels) {
+            const chaincodeInfos = this.networkUtil.getChaincodesOfChannel(channel);
 
-            for (let chaincodeInfo of chaincodeInfos) {
+            for (const chaincodeInfo of chaincodeInfos) {
                 logger.info(`Instantiating ${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel}. This might take some time...`);
 
-                let ccObject = this.networkUtil.getNetworkObject().channels[channel].chaincodes.find(
+                const ccObject = this.networkUtil.getNetworkObject().channels[channel].chaincodes.find(
                     cc => cc.id === chaincodeInfo.id && cc.version === chaincodeInfo.version);
 
-                let targetPeers = Array.from(this.networkUtil.getTargetPeersOfChaincodeOfChannel(chaincodeInfo, channel));
+                const targetPeers = Array.from(this.networkUtil.getTargetPeersOfChaincodeOfChannel(chaincodeInfo, channel));
                 if (targetPeers.length < 1) {
                     logger.info(`No target peers are defined for ${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel}, skipping it`);
                     continue;
@@ -1110,8 +1110,8 @@ class Fabric extends BlockchainInterface {
                 // select a target peer for the chaincode to see if it's instantiated
                 // these are the same as the install targets, so if one of the peers has already instantiated the chaincode,
                 // then the other targets also had done the same
-                let org = this.networkUtil.getOrganizationOfPeer(targetPeers[0]);
-                let admin = this.adminProfiles.get(org);
+                const org = this.networkUtil.getOrganizationOfPeer(targetPeers[0]);
+                const admin = this.adminProfiles.get(org);
 
                 /** @link{ChaincodeQueryResponse} */
                 let queryResponse;
@@ -1132,9 +1132,9 @@ class Fabric extends BlockchainInterface {
 
                 chaincodeInstantiated = true;
 
-                let txId = admin.newTransactionID(true);
+                const txId = admin.newTransactionID(true);
                 /** @link{ChaincodeInstantiateUpgradeRequest} */
-                let request = {
+                const request = {
                     targets: targetPeers,
                     chaincodeId: ccObject.id,
                     chaincodeVersion: ccObject.version,
@@ -1183,9 +1183,9 @@ class Fabric extends BlockchainInterface {
                 CaliperUtils.assertDefined(response);
 
                 /** @link{Array<ProposalResponse>} */
-                let proposalResponses = response[0];
+                const proposalResponses = response[0];
                 /** @link{Proposal} */
-                let proposal = response[1];
+                const proposal = response[1];
                 CaliperUtils.assertDefined(proposalResponses);
                 CaliperUtils.assertDefined(proposal);
 
@@ -1201,15 +1201,15 @@ class Fabric extends BlockchainInterface {
                 });
 
                 // connect to every event source of every org in the channel
-                let eventSources = this._assembleTargetEventSources(channel, targetPeers);
-                let eventPromises = [];
+                const eventSources = this._assembleTargetEventSources(channel, targetPeers);
+                const eventPromises = [];
 
                 try {
                     // NOTE: everything is resolved, errors are signaled through an Error object
                     // this makes error handling and reporting easier
                     eventSources.forEach((es) => {
-                        let promise = new Promise((resolve) => {
-                            let timeoutHandle = setTimeout(() => {
+                        const promise = new Promise((resolve) => {
+                            const timeoutHandle = setTimeout(() => {
                                 // unregister manually
                                 es.eventHub.unregisterTxEvent(txId.getTransactionID(), false);
                                 resolve(new Error(`Commit timeout for ${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel} from ${es.peer}`));
@@ -1234,7 +1234,7 @@ class Fabric extends BlockchainInterface {
                     });
 
                     /** @link{TransactionRequest} */
-                    let ordererRequest = {
+                    const ordererRequest = {
                         txId: txId,
                         proposalResponses: proposalResponses,
                         proposal: proposal
@@ -1256,13 +1256,13 @@ class Fabric extends BlockchainInterface {
                     }
 
                     // since every event promise is resolved, this shouldn't throw an error
-                    let eventResults = await Promise.all(eventPromises);
+                    const eventResults = await Promise.all(eventPromises);
 
                     // if we received an error, propagate it
                     if (eventResults.some(er => er instanceof Error)) {
                         let errMsg = `The following errors occured while instantiating ${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel}:`;
                         let err; // keep the last error
-                        for (let eventResult of eventResults) {
+                        for (const eventResult of eventResults) {
                             if (eventResult instanceof Error) {
                                 err = eventResult;
                                 errMsg += `\n\t- ${eventResult.message}`;
@@ -1294,25 +1294,25 @@ class Fabric extends BlockchainInterface {
      * @async
      */
     async _joinChannels() {
-        let channels = this.networkUtil.getChannels();
+        const channels = this.networkUtil.getChannels();
         let channelJoined = false;
-        let errors = [];
+        const errors = [];
 
-        for (let channelName of channels) {
+        for (const channelName of channels) {
             let genesisBlock = null;
-            let orgs = this.networkUtil.getOrganizationsOfChannel(channelName);
+            const orgs = this.networkUtil.getOrganizationsOfChannel(channelName);
 
-            for (let org of orgs) {
-                let admin = this.adminProfiles.get(org);
-                let channelObject = admin.getChannel(channelName, true);
+            for (const org of orgs) {
+                const admin = this.adminProfiles.get(org);
+                const channelObject = admin.getChannel(channelName, true);
 
-                let peers = this.networkUtil.getPeersOfOrganizationAndChannel(org, channelName);
-                let peersToJoin = [];
+                const peers = this.networkUtil.getPeersOfOrganizationAndChannel(org, channelName);
+                const peersToJoin = [];
 
-                for (let peer of peers) {
+                for (const peer of peers) {
                     try {
                         /** {@link ChannelQueryResponse} */
-                        let resp = await admin.queryChannels(peer, true);
+                        const resp = await admin.queryChannels(peer, true);
                         if (resp.channels.some(ch => ch.channel_id === channelName)) {
                             logger.info(`${peer} has already joined ${channelName}`);
                             continue;
@@ -1326,7 +1326,7 @@ class Fabric extends BlockchainInterface {
 
                 if (errors.length > 0) {
                     let errMsg = `The following errors occurred while querying ${channelName} information from ${org}'s peers:`;
-                    for (let err of errors) {
+                    for (const err of errors) {
                         errMsg += `\n\t- ${err.message}`;
                     }
 
@@ -1344,9 +1344,9 @@ class Fabric extends BlockchainInterface {
                 // only retrieve the genesis block once, and "cache" it
                 if (genesisBlock === null) {
                     try {
-                        let genesisTxId = admin.newTransactionID(true);
+                        const genesisTxId = admin.newTransactionID(true);
                         /** @link{OrdererRequest} */
-                        let genesisRequest = {
+                        const genesisRequest = {
                             txId: genesisTxId
                         };
                         genesisBlock = await channelObject.getGenesisBlock(genesisRequest);
@@ -1355,8 +1355,8 @@ class Fabric extends BlockchainInterface {
                     }
                 }
 
-                let joinTxId = admin.newTransactionID(true);
-                let joinRequest = {
+                const joinTxId = admin.newTransactionID(true);
+                const joinRequest = {
                     block: genesisBlock,
                     txId: joinTxId,
                     targets: peersToJoin
@@ -1364,7 +1364,7 @@ class Fabric extends BlockchainInterface {
 
                 try {
                     /**{@link ProposalResponse} array*/
-                    let joinRespArray = await channelObject.joinChannel(joinRequest);
+                    const joinRespArray = await channelObject.joinChannel(joinRequest);
                     CaliperUtils.assertDefined(joinRespArray);
 
                     // Some errors are returned as Error instances, some as error messages
@@ -1381,7 +1381,7 @@ class Fabric extends BlockchainInterface {
 
                 if (errors.length > 0) {
                     let errMsg = `The following errors occurred while ${org}'s peers tried to join ${channelName}:`;
-                    for (let err of errors) {
+                    for (const err of errors) {
                         errMsg += `\n\t- ${err.message}`;
                     }
 
@@ -1402,24 +1402,24 @@ class Fabric extends BlockchainInterface {
      */
     _prepareCaches() {
         // assemble random target peer cache for each channel's each chaincode
-        for (let channel of this.networkUtil.getChannels()) {
+        for (const channel of this.networkUtil.getChannels()) {
             this.randomTargetPeerCache.set(channel, new Map());
 
-            for (let chaincode of this.networkUtil.getChaincodesOfChannel(channel)) {
-                let idAndVersion = `${chaincode.id}@${chaincode.version}`;
+            for (const chaincode of this.networkUtil.getChaincodesOfChannel(channel)) {
+                const idAndVersion = `${chaincode.id}@${chaincode.version}`;
                 this.randomTargetPeerCache.get(channel).set(idAndVersion, new Map());
 
-                let targetOrgs = new Set();
-                let targetPeers = this.networkUtil.getTargetPeersOfChaincodeOfChannel(chaincode, channel);
+                const targetOrgs = new Set();
+                const targetPeers = this.networkUtil.getTargetPeersOfChaincodeOfChannel(chaincode, channel);
 
                 // get target orgs
-                for (let peer of targetPeers) {
+                for (const peer of targetPeers) {
                     targetOrgs.add(this.networkUtil.getOrganizationOfPeer(peer));
                 }
 
                 // set target peers in each org
-                for (let org of targetOrgs) {
-                    let peersOfOrg = this.networkUtil.getPeersOfOrganizationAndChannel(org, channel);
+                for (const org of targetOrgs) {
+                    const peersOfOrg = this.networkUtil.getPeersOfOrganizationAndChannel(org, channel);
 
                     // the peers of the org that target the given chaincode of the given channel
                     // one of these peers needs to be a target for every org
@@ -1430,7 +1430,7 @@ class Fabric extends BlockchainInterface {
         }
 
         // assemble random target orderer cache for each channel
-        for (let channel of this.networkUtil.getChannels()) {
+        for (const channel of this.networkUtil.getChannels()) {
             this.randomTargetOrdererCache.set(channel, Array.from(this.networkUtil.getOrderersOfChannel(channel)));
         }
     }
@@ -1450,7 +1450,7 @@ class Fabric extends BlockchainInterface {
         if (!client) {
             CaliperUtils.assertDefined(org);
             // base it on the first client connection profile of the org
-            let clients = this.networkUtil.getClientsOfOrganization(org);
+            const clients = this.networkUtil.getClientsOfOrganization(org);
 
             // NOTE: this assumes at least one client per org, which is reasonable, the clients will interact with the network
             if (clients.size < 1) {
@@ -1463,7 +1463,7 @@ class Fabric extends BlockchainInterface {
         // load the general network data from a clone of the network object
         // NOTE: if we provide a common object instead, the Client class will use it directly,
         // and it will be overwritten when loading the next client
-        let profile = FabricClient.loadFromConfig(this.networkUtil.getNewNetworkObject());
+        const profile = FabricClient.loadFromConfig(this.networkUtil.getNewNetworkObject());
         profile.loadFromConfig({
             version: '1.0',
             client: this.networkUtil.getClientObject(client)
@@ -1484,8 +1484,8 @@ class Fabric extends BlockchainInterface {
      * @private
      */
     _setTlsAdminCertAndKey(org) {
-        let profile = this.adminProfiles.get(org);
-        let crypto = this.networkUtil.getAdminCryptoContentOfOrganization(org);
+        const profile = this.adminProfiles.get(org);
+        const crypto = this.networkUtil.getAdminCryptoContentOfOrganization(org);
         profile.setTlsClientCertAndKey(crypto.signedCertPEM.toString(), crypto.privateKeyPEM.toString());
     }
 
@@ -1519,10 +1519,10 @@ class Fabric extends BlockchainInterface {
      * @return {Promise<TxStatus>} The result and stats of the transaction query.
      */
     async _submitSingleQuery(context, querySettings, timeout) {
-        let startTime = Date.now();
+        const startTime = Date.now();
         this.txIndex++;
 
-        let countAsLoad = querySettings.countAsLoad === undefined ? this.configCountQueryAsLoad : querySettings.countAsLoad;
+        const countAsLoad = querySettings.countAsLoad === undefined ? this.configCountQueryAsLoad : querySettings.countAsLoad;
 
         // retrieve the necessary client/admin profile
         let invoker;
@@ -1543,7 +1543,7 @@ class Fabric extends BlockchainInterface {
         const txIdObject = invoker.newTransactionID(admin);
         const txId = txIdObject.getTransactionID();
 
-        let invokeStatus = new TxStatus(txId);
+        const invokeStatus = new TxStatus(txId);
         invokeStatus.Set('request_type', 'query');
         invokeStatus.SetVerification(true); // querying is a one-step process unlike a normal transaction, so the result is always verified
 
@@ -1551,7 +1551,7 @@ class Fabric extends BlockchainInterface {
         // SEND TRANSACTION PROPOSALS //
         ////////////////////////////////
 
-        let targetPeers = querySettings.targetPeers ||
+        const targetPeers = querySettings.targetPeers ||
             this._assembleRandomTargetPeers(querySettings.channel, querySettings.chaincodeId, querySettings.chaincodeVersion);
 
         /** @link{ChaincodeInvokeRequest} */
@@ -1564,7 +1564,7 @@ class Fabric extends BlockchainInterface {
         };
 
         // the exception should propagate up for an invalid channel name, indicating a user callback module error
-        let channel = invoker.getChannel(querySettings.channel, true);
+        const channel = invoker.getChannel(querySettings.channel, true);
 
         if (countAsLoad && context.engine) {
             context.engine.submitCallback(1);
@@ -1577,12 +1577,12 @@ class Fabric extends BlockchainInterface {
         // no exception should escape, query failures have to be handled gracefully
         try {
             // NOTE: wrap it in a Promise to enforce user-provided timeout
-            let resultPromise = new Promise(async (resolve, reject) => {
-                let timeoutHandle = setTimeout(() => {
+            const resultPromise = new Promise(async (resolve, reject) => {
+                const timeoutHandle = setTimeout(() => {
                     reject(new Error('TIMEOUT'));
                 }, this._getRemainingTimeout(startTime, timeout));
 
-                let result = await channel.queryByChaincode(proposalRequest, admin);
+                const result = await channel.queryByChaincode(proposalRequest, admin);
                 clearTimeout(timeoutHandle);
                 resolve(result);
             });
@@ -1597,7 +1597,7 @@ class Fabric extends BlockchainInterface {
 
             // filter for errors inside, so we have accurate indices for the corresponding peers
             results.forEach((value, index) => {
-                let targetName = targetPeers[index];
+                const targetName = targetPeers[index];
                 if (value instanceof Error) {
                     invokeStatus.Set(`endorsement_result_error_${targetName}`, value.message);
                     errMsg = `\n\t- Endorsement error from ${targetName}: ${value.message}`;
@@ -1662,16 +1662,16 @@ class Fabric extends BlockchainInterface {
         const txId = txIdObject.getTransactionID();
 
         // timestamps are recorded for every phase regardless of success/failure
-        let invokeStatus = new TxStatus(txId);
+        const invokeStatus = new TxStatus(txId);
         invokeStatus.Set('request_type', 'transaction');
 
-        let errors = []; // errors are collected during response validations
+        const errors = []; // errors are collected during response validations
 
         ////////////////////////////////
         // SEND TRANSACTION PROPOSALS //
         ////////////////////////////////
 
-        let targetPeers = invokeSettings.targetPeers ||
+        const targetPeers = invokeSettings.targetPeers ||
             this._assembleRandomTargetPeers(invokeSettings.channel, invokeSettings.chaincodeId, invokeSettings.chaincodeVersion);
 
         /** @link{ChaincodeInvokeRequest} */
@@ -1684,7 +1684,7 @@ class Fabric extends BlockchainInterface {
             targets: targetPeers
         };
 
-        let channel = invoker.getChannel(invokeSettings.channel, true);
+        const channel = invoker.getChannel(invokeSettings.channel, true);
 
         /** @link{ProposalResponseObject} */
         let proposalResponseObject = null;
@@ -1723,7 +1723,7 @@ class Fabric extends BlockchainInterface {
 
             // NOTES: filter inside, so we have accurate indices corresponding to the original target peers
             proposalResponses.forEach((value, index) => {
-                let targetName = targetPeers[index];
+                const targetName = targetPeers[index];
 
                 // Errors from peers/chaincode are returned as an Error object
                 if (value instanceof Error) {
@@ -1736,7 +1736,7 @@ class Fabric extends BlockchainInterface {
                 }
 
                 /** @link{ProposalResponse} */
-                let proposalResponse = value;
+                const proposalResponse = value;
 
                 // save a chaincode results/response
                 // NOTE: the last one will be kept as result
@@ -1756,7 +1756,7 @@ class Fabric extends BlockchainInterface {
                 }
 
                 /** @link{ResponseObject} */
-                let responseObject = proposalResponse.response;
+                const responseObject = proposalResponse.response;
 
                 if (responseObject.status !== 200) {
                     invokeStatus.Set(`endorsement_result_error_${targetName}`, `${responseObject.status} ${responseObject.message}`);
@@ -1788,7 +1788,7 @@ class Fabric extends BlockchainInterface {
             // REGISTERING EVENT LISTENERS //
             /////////////////////////////////
 
-            let eventPromises = []; // to wait for every event response
+            const eventPromises = []; // to wait for every event response
 
             // NOTE: in compatibility mode, the same EventHub can be used for multiple channels
             // if the peer is part of multiple channels
@@ -1801,7 +1801,7 @@ class Fabric extends BlockchainInterface {
             // SUBMITTING TRANSACTION TO THE ORDERER //
             ///////////////////////////////////////////
 
-            let targetOrderer = invokeSettings.orderer || this._getRandomTargetOrderer(invokeSettings.channel);
+            const targetOrderer = invokeSettings.orderer || this._getRandomTargetOrderer(invokeSettings.channel);
             let orderer;
 
             if (typeof(targetOrderer) === 'string' || targetOrderer instanceof String) {
@@ -1823,12 +1823,12 @@ class Fabric extends BlockchainInterface {
             let broadcastResponse;
             try {
                 // wrap it in a Promise to add explicit timeout to the call
-                let responsePromise = new Promise(async (resolve, reject) => {
-                    let timeoutHandle = setTimeout(() => {
+                const responsePromise = new Promise(async (resolve, reject) => {
+                    const timeoutHandle = setTimeout(() => {
                         reject(new Error('TIMEOUT'));
                     }, this._getRemainingTimeout(startTime, timeout));
 
-                    let result = await channel.sendTransaction(transactionRequest);
+                    const result = await channel.sendTransaction(transactionRequest);
                     clearTimeout(timeoutHandle);
                     resolve(result);
                 });
@@ -1860,10 +1860,10 @@ class Fabric extends BlockchainInterface {
             //////////////////////////////
 
             // this shouldn't throw, otherwise the error handling is not robust
-            let eventResults = await Promise.all(eventPromises);
+            const eventResults = await Promise.all(eventPromises);
 
             // NOTE: this is the latency@threshold support described by the PSWG in their first paper
-            let failedNotifications = eventResults.filter(er => !er.successful);
+            const failedNotifications = eventResults.filter(er => !er.successful);
 
             // NOTE: an error from any peer indicates some problem, don't mask it;
             // although one successful transaction should be enough for "eventual" success;
@@ -1872,7 +1872,7 @@ class Fabric extends BlockchainInterface {
                 invokeStatus.SetStatusFail();
 
                 let logMsg = `Transaction[${txId.substring(0, 10)}] commit errors:`;
-                for (let commitErrors of failedNotifications) {
+                for (const commitErrors of failedNotifications) {
                     logMsg += `\n\t- ${commitErrors.message}`;
                 }
 
@@ -1882,7 +1882,7 @@ class Fabric extends BlockchainInterface {
                 eventResults.sort((a, b) => a.time - b.time);
 
                 // transform to (0,length] by *, then to (-1,length-1] by -, then to [0,length-1] by ceil
-                let thresholdIndex = Math.ceil(eventResults.length * this.configLatencyThreshold - 1);
+                const thresholdIndex = Math.ceil(eventResults.length * this.configLatencyThreshold - 1);
 
                 // every commit event contained a VALID code
                 // mark the time corresponding to the set threshold
@@ -1897,7 +1897,7 @@ class Fabric extends BlockchainInterface {
                 logger.error(`Transaction[${txId.substring(0, 10)}] unexpected error: ${err.stack ? err.stack : err}`);
             } else if (err.length > 0) {
                 let logMsg = `Transaction[${txId.substring(0, 10)}] life-cycle errors:`;
-                for (let execError of err) {
+                for (const execError of err) {
                     logMsg += `\n\t- ${execError.message}`;
                 }
 
@@ -1969,7 +1969,7 @@ class Fabric extends BlockchainInterface {
         this.txIndex = -1;
 
         // Configure the adaptor
-        for (let channel of this.networkUtil.getChannels()) {
+        for (const channel of this.networkUtil.getChannels()) {
             // initialize the channels by getting the config from the orderer
             await this._initializeChannel(this.adminProfiles, channel, true);
             await this._initializeChannel(this.clientProfiles, channel, false);
@@ -1979,11 +1979,11 @@ class Fabric extends BlockchainInterface {
             // NOTE: for old event hubs we have a single connection to every peer set as an event source
             const EventHub = require('fabric-client/lib/EventHub.js');
 
-            for (let peer of this.networkUtil.getAllEventSources()) {
-                let org = this.networkUtil.getOrganizationOfPeer(peer);
-                let admin = this.adminProfiles.get(org);
+            for (const peer of this.networkUtil.getAllEventSources()) {
+                const org = this.networkUtil.getOrganizationOfPeer(peer);
+                const admin = this.adminProfiles.get(org);
 
-                let eventHub = new EventHub(admin);
+                const eventHub = new EventHub(admin);
                 eventHub.setPeerAddr(this.networkUtil.getPeerEventUrl(peer),
                     this.networkUtil.getGrpcOptionsOfPeer(peer));
 
@@ -1997,17 +1997,17 @@ class Fabric extends BlockchainInterface {
         } else {
             // NOTE: for channel event hubs we might have multiple connections to a peer,
             // so connect to the defined event sources of every org in every channel
-            for (let channel of this.networkUtil.getChannels()) {
-                for (let org of this.networkUtil.getOrganizationsOfChannel(channel)) {
-                    let admin = this.adminProfiles.get(org);
+            for (const channel of this.networkUtil.getChannels()) {
+                for (const org of this.networkUtil.getOrganizationsOfChannel(channel)) {
+                    const admin = this.adminProfiles.get(org);
 
                     // The API for retrieving channel event hubs changed, from SDK v1.2 it expects the MSP ID of the org
-                    let orgId = this.version.lessThan('1.2.0') ? org : this.networkUtil.getMspIdOfOrganization(org);
+                    const orgId = this.version.lessThan('1.2.0') ? org : this.networkUtil.getMspIdOfOrganization(org);
 
-                    let eventHubs = admin.getChannel(channel, true).getChannelEventHubsForOrg(orgId);
+                    const eventHubs = admin.getChannel(channel, true).getChannelEventHubsForOrg(orgId);
 
                     // the peer (as an event source) is associated with exactly one channel in case of channel-level eventing
-                    for (let eventHub of eventHubs) {
+                    for (const eventHub of eventHubs) {
                         this.eventSources.push({
                             channel: [channel],
                             peer: this.networkUtil.getPeerNameOfEventHub(eventHub),
@@ -2025,18 +2025,18 @@ class Fabric extends BlockchainInterface {
         // rebuild the event source cache
         this.channelEventSourcesCache = new Map();
 
-        for (let es of this.eventSources) {
-            let channels = es.channel;
+        for (const es of this.eventSources) {
+            const channels = es.channel;
 
             // an event source can be used for multiple channels in compatibility mode
-            for (let c of channels) {
+            for (const c of channels) {
                 // initialize the cache for a channel with an empty array at the first time
                 if (!this.channelEventSourcesCache.has(c)) {
                     this.channelEventSourcesCache.set(c, []);
                 }
 
                 // add the event source to the channels collection
-                let eventSources = this.channelEventSourcesCache.get(c);
+                const eventSources = this.channelEventSourcesCache.get(c);
                 eventSources.push(es);
             }
         }
@@ -2053,9 +2053,9 @@ class Fabric extends BlockchainInterface {
      * @async
      */
     async init(workerInit = false) {
-        let tlsInfo = this.networkUtil.isMutualTlsEnabled() ? 'mutual'
+        const tlsInfo = this.networkUtil.isMutualTlsEnabled() ? 'mutual'
             : (this.networkUtil.isTlsEnabled() ? 'server' : 'none');
-        let compMode = this.networkUtil.isInCompatibilityMode() ? '; Fabric v1.0 compatibility mode' : '';
+        const compMode = this.networkUtil.isInCompatibilityMode() ? '; Fabric v1.0 compatibility mode' : '';
         logger.info(`Fabric SDK version: ${this.version.toString()}; TLS: ${tlsInfo}${compMode}`);
 
         await this._initializeRegistrars(workerInit);
@@ -2107,7 +2107,7 @@ class Fabric extends BlockchainInterface {
      */
     async invokeSmartContract(context, contractID, contractVersion, invokeSettings, timeout) {
         timeout = timeout || this.configDefaultTimeout;
-        let promises = [];
+        const promises = [];
         let settingsArray;
 
         if (!Array.isArray(invokeSettings)) {
@@ -2116,8 +2116,8 @@ class Fabric extends BlockchainInterface {
             settingsArray = invokeSettings;
         }
 
-        for (let settings of settingsArray) {
-            let contractDetails = this.networkUtil.getContractDetails(contractID);
+        for (const settings of settingsArray) {
+            const contractDetails = this.networkUtil.getContractDetails(contractID);
             if (!contractDetails) {
                 throw new Error(`Could not find details for contract ID ${contractID}`);
             }
@@ -2148,7 +2148,7 @@ class Fabric extends BlockchainInterface {
      */
     async querySmartContract(context, contractID, contractVersion, querySettings, timeout) {
         timeout = timeout || this.configDefaultTimeout;
-        let promises = [];
+        const promises = [];
         let settingsArray;
 
         if (!Array.isArray(querySettings)) {
@@ -2157,8 +2157,8 @@ class Fabric extends BlockchainInterface {
             settingsArray = querySettings;
         }
 
-        for (let settings of settingsArray) {
-            let contractDetails = this.networkUtil.getContractDetails(contractID);
+        for (const settings of settingsArray) {
+            const contractDetails = this.networkUtil.getContractDetails(contractID);
             if (!contractDetails) {
                 throw new Error(`Could not find details for contract ID ${contractID}`);
             }

--- a/packages/caliper-fabric/lib/adaptor-versions/v2/fabric-gateway-v2.js
+++ b/packages/caliper-fabric/lib/adaptor-versions/v2/fabric-gateway-v2.js
@@ -14,15 +14,14 @@
 
 'use strict';
 
-const FabricClient = require('fabric-client');
-let { DefaultEventHandlerStrategies, DefaultQueryHandlerStrategies, Gateway, Wallets } = require('fabric-network');
-const { google, common } = require('fabric-protos');
+const { DefaultEventHandlerStrategies, DefaultQueryHandlerStrategies, Gateway, Wallets } = require('fabric-network');
 const { BlockchainInterface, CaliperUtils, TxStatus, Version, ConfigUtil } = require('@hyperledger/caliper-core');
 const logger = CaliperUtils.getLogger('adapters/fabric');
 
 const FabricNetwork = require('../../fabricNetwork.js');
 const ConfigValidator = require('../../configValidator.js');
-const fs = require('fs');
+const RegistrarHelper = require('./registrarHelper');
+const uuid = require('uuid/v1');
 
 const EventStrategies = {
     msp_all : DefaultEventHandlerStrategies.MSPID_SCOPE_ALLFORTX,
@@ -95,38 +94,23 @@ const QueryStrategies = {
  * Implements {BlockchainInterface} for a Fabric backend, utilizing the SDK's Common Connection Profile.
  *
  * @property {Version} version Contains the version information about the used Fabric SDK.
- * @property {Map<string, FabricClient>} clientProfiles Contains the initialized and user-specific SDK client profiles
- *           for each defined user. Maps the custom user names to the Client instances.
- * @property {Map<string, FabricClient>} adminProfiles Contains the initialized and admin-specific SDK client profiles
- *           for each defined admin. Maps the custom organization names to the Client instances
- *           (since only one admin per org is supported).
- * @property {Map<string, FabricClient>} registrarProfiles Contains the initialized and registrar-specific SDK client
- *           profiles for each defined registrar. Maps the custom organization names to the Client instances
- *           (since only one registrar per org is supported).
- * @property {EventSource[]} eventSources Collection of potential event sources to listen to for transaction confirmation events.
  * @property {number} clientIndex The index of the client process using the adapter that is set in the constructor
  * @property {number} txIndex A counter for keeping track of the index of the currently submitted transaction.
  * @property {FabricNetwork} networkUtil Utility object containing easy-to-query information about the topology
  *           and settings of the network.
- * @property {Map<string, Map<string, Map<string, string[]>>>} randomTargetPeerCache Contains the target peers of chaincodes
- *           grouped by channels and organizations: Channel -> Chaincode -> Org -> Peers
- * @property {Map<string, EventSource[]>} channelEventSourcesCache Contains the list of event sources for every channel.
- * @property {Map<string, string[]>} randomTargetOrdererCache Contains the list of target orderers of channels.
+ * @property {RegistrarHelper} registrarHelper A RegistrarHelper used to help register and enrol new test clients
  * @property {string} defaultInvoker The name of the client to use if an invoker is not specified.
  * @property {number} configSmallestTimeout The timeout value to use when the user-provided timeout is too small.
- * @property {number} configSleepAfterCreateChannel The sleep duration in milliseconds after creating the channels.
- * @property {number} configSleepAfterJoinChannel The sleep duration in milliseconds after joining the channels.
- * @property {number} configSleepAfterInstantiateChaincode The sleep duration in milliseconds after instantiating the chaincodes.
- * @property {boolean} configVerifyProposalResponse Indicates whether to verify the proposal responses of the endorsers.
- * @property {boolean} configVerifyReadWriteSets Indicates whether to verify the matching of the returned read-write sets.
- * @property {number} configLatencyThreshold The network latency threshold to use for calculating the final commit time of transactions.
- * @property {boolean} configOverwriteGopath Indicates whether GOPATH should be set to the Caliper root directory.
- * @property {number} configChaincodeInstantiateTimeout The timeout in milliseconds for the chaincode instantiation endorsement.
- * @property {number} configChaincodeInstantiateEventTimeout The timeout in milliseconds for receiving the chaincode instantiation event.
  * @property {number} configDefaultTimeout The default timeout in milliseconds to use for invoke/query transactions.
  * @property {boolean} configCountQueryAsLoad Indicates whether queries should be counted as workload.
  * @property {boolean} configLocalHost Indicates whether to use the localhost default within the Fabric Gateway API
  * @property {boolean} configDiscovery Indicates whether to use discovery within the Fabric Gateway API
+ * @property {string} eventStrategy Event strategy to use within the Fabric Gateway
+ * @property {string} queryStrategy Query strategy to use within the Fabric Gateway
+ * @property {Wallet} wallet The wallet containing all identities
+ * @property {Map} userContracts A map of identities to contracts they may submit/evaluate
+ * @property {Map} userGateways A map of identities to the gateway they are connected
+ * @property {Map} peerCache A cache of peer objects
  */
 class Fabric extends BlockchainInterface {
     /**
@@ -139,11 +123,11 @@ class Fabric extends BlockchainInterface {
         super(networkConfig);
         this.bcType = 'fabric';
         this.workspaceRoot = workspace_root;
-        this.version = new Version(require('fabric-client/package').version);
+        this.version = new Version(require('fabric-network/package').version);
 
         this.network = undefined;
         if (typeof networkConfig === 'string') {
-            let configPath = CaliperUtils.resolvePath(networkConfig, workspace_root);
+            const configPath = CaliperUtils.resolvePath(networkConfig, workspace_root);
             this.network = CaliperUtils.parseYaml(configPath);
         } else if (typeof networkConfig === 'object' && networkConfig !== null) {
             // clone the object to prevent modification by other objects
@@ -152,28 +136,22 @@ class Fabric extends BlockchainInterface {
             throw new Error('[FabricNetwork.constructor] Parameter \'networkConfig\' is neither a file path nor an object');
         }
 
-        this.clientProfiles = new Map();
-        this.adminProfiles = new Map();
-        this.registrarProfiles = new Map();
+        // validate the network
+        ConfigValidator.validateNetwork(this.network, CaliperUtils.getFlowOptions(),
+            this.configDiscovery, true);
+
         this.clientIndex = clientIndex;
         this.txIndex = -1;
+        this.networkUtil = new FabricNetwork(this.network, workspace_root);
+        this.defaultInvoker = Array.from(this.networkUtil.getClients())[0];
+
         this.wallet = undefined;
         this.userContracts = new Map();
         this.userGateways = new Map();
         this.peerCache = new Map();
 
-        // this value is hardcoded, if it's used, that means that the provided timeouts are not sufficient
+        // Timeouts
         this.configSmallestTimeout = 1000;
-
-        this.configSleepAfterCreateChannel = ConfigUtil.get(ConfigUtil.keys.Fabric.SleepAfter.CreateChannel, 5000);
-        this.configSleepAfterJoinChannel = ConfigUtil.get(ConfigUtil.keys.Fabric.SleepAfter.JoinChannel, 3000);
-        this.configSleepAfterInstantiateChaincode = ConfigUtil.get(ConfigUtil.keys.Fabric.SleepAfter.InstantiateChaincode, 5000);
-        this.configVerifyProposalResponse = ConfigUtil.get(ConfigUtil.keys.Fabric.Verify.ProposalResponse, true);
-        this.configVerifyReadWriteSets = ConfigUtil.get(ConfigUtil.keys.Fabric.Verify.ReadWriteSets, true);
-        this.configLatencyThreshold = ConfigUtil.get(ConfigUtil.keys.Fabric.LatencyThreshold, 1.0);
-        this.configOverwriteGopath = ConfigUtil.get(ConfigUtil.keys.Fabric.OverwriteGopath, true);
-        this.configChaincodeInstantiateTimeout = ConfigUtil.get(ConfigUtil.keys.Fabric.Timeout.ChaincodeInstantiate, 300000);
-        this.configChaincodeInstantiateEventTimeout = ConfigUtil.get(ConfigUtil.keys.Fabric.Timeout.ChaincodeInstantiateEvent, 300000);
         this.configDefaultTimeout = ConfigUtil.get(ConfigUtil.keys.Fabric.Timeout.InvokeOrQuery, 60000);
         this.configCountQueryAsLoad = ConfigUtil.get(ConfigUtil.keys.Fabric.CountQueryAsLoad, true);
 
@@ -182,18 +160,6 @@ class Fabric extends BlockchainInterface {
         this.configDiscovery = ConfigUtil.get(ConfigUtil.keys.Fabric.Gateway.Discovery, false);
         this.eventStrategy = ConfigUtil.get(ConfigUtil.keys.Fabric.Gateway.EventStrategy, 'msp_all');
         this.queryStrategy = ConfigUtil.get(ConfigUtil.keys.Fabric.Gateway.QueryStrategy, 'msp_single');
-
-        ConfigValidator.validateNetwork(this.network, CaliperUtils.getFlowOptions(),
-            this.configDiscovery, true);
-
-        this.networkUtil = new FabricNetwork(this.network, workspace_root);
-        this.fileWalletPath = this.networkUtil.getFileWalletPath();
-        this.defaultInvoker = Array.from(this.networkUtil.getClients())[0];
-
-        // Network Wallet/Gateway is only available in SDK versions greater than v1.4.0
-        if (this.version.lessThan('1.4.0')) {
-            throw new Error(`Fabric SDK ${this.version.toString()} is not supported when using a Fabric Gateway object, use at least version 1.4.0`);
-        }
     }
 
     ////////////////////////////////
@@ -202,495 +168,58 @@ class Fabric extends BlockchainInterface {
 
     /**
      * Initialize the adaptor
-     * @param {boolean} workerInit Indicates whether the initialization happens in the worker process.
      */
-    async _initAdaptor(workerInit) {
-        let tlsInfo = this.networkUtil.isMutualTlsEnabled() ? 'mutual'
+    async _initAdaptor() {
+        const tlsInfo = this.networkUtil.isMutualTlsEnabled() ? 'mutual'
             : (this.networkUtil.isTlsEnabled() ? 'server' : 'none');
-        let compMode = this.networkUtil.isInCompatibilityMode() ? '; Fabric v1.0 compatibility mode' : '';
-        logger.info(`Fabric SDK version: ${this.version.toString()}; TLS: ${tlsInfo}${compMode}`);
+        logger.info(`Fabric SDK version: ${this.version.toString()}; TLS: ${tlsInfo}`);
 
         await this._prepareWallet();
-        await this._initializeRegistrars(workerInit);
-        await this._initializeAdmins(workerInit);
-        await this._initializeUsers(workerInit);
+        await this._initializeAdmins();
+        // Initialize registrars *after* initialization of admins so that admins are not created
+        this.registrarHelper = await RegistrarHelper.newWithNetwork(this.networkUtil);
+        await this._initializeUsers();
         this.initPhaseCompleted = true;
-    }
-
-    /**
-     * Assembles the event sources based on explicitly given target peers.
-     * @param {string} channel The name of channel containing the target peers. Doesn't matter if peer-level event service is used in compatibility mode.
-     * @param {string[]} targetPeers The list of peers to connect to.
-     * @return {EventSource[]} The list of event sources.
-     * @private
-     */
-    _assembleTargetEventSources(channel, targetPeers) {
-        let eventSources = [];
-        if (this.networkUtil.isInCompatibilityMode()) {
-            // NOTE: for old event hubs we have a single connection to every peer set as an event source
-            const EventHub = require('fabric-client/lib/EventHub.js');
-
-            for (let peer of targetPeers) {
-                let org = this.networkUtil.getOrganizationOfPeer(peer);
-                let admin = this.adminProfiles.get(org);
-
-                let eventHub = new EventHub(admin);
-                eventHub.setPeerAddr(this.networkUtil.getPeerEventUrl(peer),
-                    this.networkUtil.getGrpcOptionsOfPeer(peer));
-
-                eventSources.push({
-                    channel: [channel], // unused during chaincode instantiation
-                    peer: peer,
-                    eventHub: eventHub
-                });
-            }
-        } else {
-            for (let peer of targetPeers) {
-                let org = this.networkUtil.getOrganizationOfPeer(peer);
-                let admin = this.adminProfiles.get(org);
-
-                let eventHub = admin.getChannel(channel, true).newChannelEventHub(peer);
-
-                eventSources.push({
-                    channel: [channel], // unused during chaincode instantiation
-                    peer: peer,
-                    eventHub: eventHub
-                });
-            }
-        }
-
-        return eventSources;
-    }
-
-    /**
-     * Creates the specified channels if necessary.
-     * @return {boolean} True, if at least one channel was created. Otherwise, false.
-     * @private
-     * @async
-     */
-    async _createChannels() {
-        let channels = this.networkUtil.getChannels();
-        let channelCreated = false;
-
-        for (let channel of channels) {
-            let channelObject = this.networkUtil.getNetworkObject().channels[channel];
-
-            if (CaliperUtils.checkProperty(channelObject, 'created') && channelObject.created) {
-                logger.info(`Channel '${channel}' is configured as created, skipping creation`);
-                continue;
-            }
-
-            if (ConfigUtil.get(ConfigUtil.keys.Fabric.SkipCreateChannelPrefix + channel, false)) {
-                logger.info(`Creation of Channel '${channel}' is configured to skip`);
-                continue;
-            }
-
-            channelCreated = true;
-
-            let configUpdate;
-            if (CaliperUtils.checkProperty(channelObject, 'configBinary')) {
-                logger.info(`Channel '${channel}' definiton being retrieved from file`);
-                configUpdate = this._getChannelConfigFromFile(channelObject, channel);
-            }
-            else {
-                logger.info(`Channel '${channel}' definiton being generated from description`);
-                const channelTx = this._createChannelTxEnvelope(channelObject.definition, channel);
-                const payload = common.Payload.decode(channelTx.getPayload().toBuffer());
-                const configtx = common.ConfigUpdateEnvelope.decode(payload.getData().toBuffer());
-                configUpdate =  configtx.getConfigUpdate().toBuffer();
-            }
-
-            // NOTE: without knowing the system channel policies, signing with every org admin is a safe bet
-            let orgs = this.networkUtil.getOrganizationsOfChannel(channel);
-            let admin; // declared here to keep the admin of the last org of the channel
-            let signatures = [];
-            for (let org of orgs) {
-                admin = this.adminProfiles.get(org);
-                try {
-                    signatures.push(admin.signChannelConfig(configUpdate));
-                } catch (err) {
-                    throw new Error(`${org}'s admin couldn't sign the configuration update of Channel '${channel}': ${err.message}`);
-                }
-            }
-
-            let txId = admin.newTransactionID(true);
-            let request = {
-                config: configUpdate,
-                signatures: signatures,
-                name: channel,
-                txId: txId
-            };
-
-            try {
-                /** @link{BroadcastResponse} */
-                let broadcastResponse = await admin.createChannel(request);
-
-                CaliperUtils.assertDefined(broadcastResponse, `The returned broadcast response for creating Channel '${channel}' is undefined`);
-                CaliperUtils.assertProperty(broadcastResponse, 'broadcastResponse', 'status');
-
-                if (broadcastResponse.status !== 'SUCCESS') {
-                    throw new Error(`Orderer response indicated unsuccessful Channel '${channel}' creation: ${broadcastResponse.status}`);
-                }
-            } catch (err) {
-                throw new Error(`Couldn't create Channel '${channel}': ${err.message}`);
-            }
-
-            logger.info(`Channel '${channel}' successfully created`);
-        }
-
-        return channelCreated;
-    }
-
-    /**
-     * Creates and sets a User object as the context based on the provided identity information.
-     * @param {Client} profile The Client object whose user context must be set.
-     * @param {string} org The name of the user's organization.
-     * @param {string} userName The name of the user.
-     * @param {{privateKeyPEM: Buffer, signedCertPEM: Buffer}} cryptoContent The object containing the signing key and cert in PEM format.
-     * @param {string} profileName Optional name of the profile that will appear in error messages.
-     * @returns {FabricClient.User} The User object created
-     * @private
-     * @async
-     */
-    async _createUser(profile, org, userName, cryptoContent, profileName) {
-        // set the user explicitly based on its crypto materials
-        // createUser also sets the user context
-        try {
-            return await profile.createUser({
-                username: userName,
-                mspid: this.networkUtil.getMspIdOfOrganization(org),
-                cryptoContent: cryptoContent,
-                skipPersistence: this.fileWalletPath ? true : false
-            });
-        } catch (err) {
-            throw new Error(`Couldn't create ${profileName || ''} user object: ${err.message}`);
-        }
-    }
-
-    /**
-     * Enrolls the given user through its corresponding CA.
-     * @param {Client} profile The Client object whose user must be enrolled.
-     * @param {string} id The enrollment ID.
-     * @param {string} secret The enrollment secret.
-     * @param {string} profileName Optional name of the profile that will appear in error messages.
-     * @return {Promise<{key: ECDSA_KEY, certificate: string}>} The resulting private key and certificate.
-     * @private
-     * @async
-     */
-    async _enrollUser(profile, id, secret, profileName) {
-        // this call will throw an error if the CA configuration is not found
-        // this error should propagate up
-        let ca = profile.getCertificateAuthority();
-        try {
-            return await ca.enroll({
-                enrollmentID: id,
-                enrollmentSecret: secret
-            });
-        } catch (err) {
-            throw new Error(`Couldn't enroll ${profileName || 'user'}: ${err.message}`);
-        }
-    }
-
-    /**
-     * Populate an envelope with a channel creation transaction
-     * @param {object} channelObject The channel configuration object.
-     * @param {string} channelName The name of the channel.
-     * @return {Buffer} The extracted channel configuration bytes.
-     * @private
-     */
-    _createChannelTxEnvelope(channelObject, channelName) {
-        // Versioning
-        const readVersion = 0;
-        const writeVersion = 0;
-        const appVersion = 1;
-        const policyVersion = 0;
-
-        // Build the readSet
-        const readValues = {};
-        readValues.Consortium = new common.ConfigValue();
-
-        const readAppGroup = {};
-        for (const mspId of channelObject.msps) {
-            readAppGroup[mspId] = new common.ConfigGroup();
-        }
-        const readGroups = {};
-        readGroups.Application = new common.ConfigGroup({ groups: readAppGroup });
-
-        const readSet = new common.ConfigGroup({ version: readVersion, groups: readGroups, values: readValues });
-
-        // Build the writeSet (based on consortium name and passed Capabiliites)
-        const modPolicy = 'Admins';
-        const writeValues = {};
-
-        const consortium = new common.Consortium({ name: channelObject.consortium });
-        writeValues.Consortium = new common.ConfigValue({ version: writeVersion, value: consortium.toBuffer() });
-
-        if (channelObject.capabilities) {
-            const capabilities = this._populateCapabilities(channelObject.capabilities);
-            writeValues.Capabilities = new common.ConfigValue({ version: writeVersion, value: capabilities.toBuffer(), mod_policy: modPolicy });
-        }
-
-        // Write Policy
-        const writePolicies = this._generateWritePolicy(policyVersion, modPolicy);
-
-        // Write Application Groups
-        const writeAppGroup = {};
-        for (const mspId of channelObject.msps) {
-            writeAppGroup[mspId] = new common.ConfigGroup();
-        }
-
-        const writeGroups = {};
-        writeGroups.Application = new common.ConfigGroup({ version: appVersion, groups: writeAppGroup, policies: writePolicies, mod_policy: modPolicy });
-
-        const writeSet = new common.ConfigGroup({ version: writeVersion, groups: writeGroups, values: writeValues });
-
-        // Now create the configUpdate and configUpdateEnv
-        const configUpdate = new common.ConfigUpdate({ channel_id: channelName, read_set: readSet, write_set: writeSet});
-        const configUpdateEnv= new common.ConfigUpdateEnvelope({ config_update: configUpdate.toBuffer(), signatures: [] });
-
-        // Channel header
-        const channelTimestamp = new google.protobuf.Timestamp({ seconds: Date.now()/1000, nanos: 0 }); // Date.now() is millis since 1970 epoch, we need seconds
-        const channelEpoch = 0;
-        const chHeader = new common.ChannelHeader({ type: common.HeaderType.CONFIG_UPDATE, version: channelObject.version, timestamp: channelTimestamp, channel_id: channelName, epoch: channelEpoch });
-
-        // Common header
-        const header = new common.Header({ channel_header: chHeader.toBuffer() });
-
-        // Form the payload header/data
-        const payload = new common.Payload({ header: header, data: configUpdateEnv.toBuffer() });
-
-        // Form and return the envelope
-        const envelope = new common.Envelope({ payload: payload.toBuffer() });
-        return envelope;
-    }
-
-    /**
-     * Populate a Capabilities protobuf
-     * @param {Array<string>} applicationCapabilities the application capability keys
-     * @returns {common.Capabilities} Capabilities in a protobuf
-     */
-    _populateCapabilities(applicationCapabilities) {
-        const capabilities = {};
-        for (const capability of applicationCapabilities) {
-            capabilities[capability] = new common.Capability();
-        }
-        return  new common.Capabilities({ capabilities: capabilities });
-    }
-
-    /**
-     * Form a populated Policy protobuf that contains an ImplicitMetaPolicy
-     * @param {String} subPolicyName the sub policy name
-     * @param {common.Policy.PolicyType} rule the rule type
-     * @returns {common.Policy} the policy protobuf
-     */
-    _makeImplicitMetaPolicy(subPolicyName, rule){
-        const metaPolicy = new common.ImplicitMetaPolicy({ sub_policy: subPolicyName, rule: rule });
-        const policy= new common.Policy({ type: common.Policy.PolicyType.IMPLICIT_META, value: metaPolicy.toBuffer() });
-        return policy;
-    }
-
-    /**
-     * Generate a write policy
-     * @param {number} version the policy version
-     * @param {string} modPolicy the modification policy
-     * @returns {Object} an object of Admin/Reader/Writer keys mapping to populated ConfigPolicy protobufs
-     */
-    _generateWritePolicy(version, modPolicy) {
-        // Write Policy
-        const writePolicies = {};
-        // admins
-        const adminsPolicy = this._makeImplicitMetaPolicy('Admins', common.ImplicitMetaPolicy.Rule.MAJORITY); // majority
-        writePolicies.Admins = new common.ConfigPolicy({ version: version, policy: adminsPolicy, mod_policy: modPolicy });
-        // Readers
-        const readersPolicy = this._makeImplicitMetaPolicy('Readers', common.ImplicitMetaPolicy.Rule.ANY); // Any
-        writePolicies.Readers = new common.ConfigPolicy({ version: version, policy: readersPolicy, mod_policy: modPolicy });
-        // Writers
-        const writersPolicy = this._makeImplicitMetaPolicy('Writers', common.ImplicitMetaPolicy.Rule.ANY); // Any
-        writePolicies.Writers = new common.ConfigPolicy({ version: version, policy: writersPolicy, mod_policy: modPolicy });
-        return writePolicies;
-    }
-
-    /**
-     * Extracts the channel configuration from the configured file.
-     * @param {object} channelObject The channel configuration object.
-     * @param {string} channelName The name of the channel.
-     * @return {Buffer} The extracted channel configuration bytes.
-     * @private
-     */
-    _getChannelConfigFromFile(channelObject, channelName) {
-        // extracting the config from the binary file
-        let binaryPath = CaliperUtils.resolvePath(channelObject.configBinary, this.workspaceRoot);
-        let envelopeBytes;
-
-        try {
-            envelopeBytes = fs.readFileSync(binaryPath);
-        } catch (err) {
-            throw new Error(`Couldn't read configuration binary for ${channelName}: ${err.message}`);
-        }
-
-        try {
-            return new FabricClient().extractChannelConfig(envelopeBytes);
-        } catch (err) {
-            throw new Error(`Couldn't extract configuration object for ${channelName}: ${err.message}`);
-        }
-    }
-
-    /**
-     * Calculates the remaining time to timeout based on the original timeout and a starting time.
-     * @param {number} start The epoch of the start time in ms.
-     * @param {number} original The original timeout in ms.
-     * @returns {number} The remaining time until the timeout in ms.
-     * @private
-     */
-    _getRemainingTimeout(start, original) {
-        let newTimeout = original - (Date.now() - start);
-        if (newTimeout < this.configSmallestTimeout) {
-            logger.warn(`Timeout is too small, default value of ${this.configSmallestTimeout}ms is used instead`);
-            newTimeout = this.configSmallestTimeout;
-        }
-
-        return newTimeout;
-    }
-
-    /**
-     * Checks whether the user materials are already persisted in the local store and sets the user context if found.
-     * @param {Client} profile The Client object to fill with the User instance.
-     * @param {string} userName The name of the user to check and load.
-     * @param {string} profileName Optional name of the profile that will appear in error messages.
-     * @return {Promise<User>} The loaded User object
-     * @private
-     * @async
-     */
-    async _getUserContext(profile, userName, profileName) {
-        // Check whether the materials are already saved
-        // getUserContext automatically sets the user if found
-        try {
-            return await profile.getUserContext(userName, true);
-        } catch (err) {
-            throw new Error(`Couldn't check whether ${profileName || 'the user'}'s materials are available locally: ${err.message}`);
-        }
     }
 
     /**
      * Initializes the admins of the organizations.
      *
-     * @param {boolean} workerInit Indicates whether the initialization happens in the worker process.
      * @private
      * @async
      */
-    async _initializeAdmins(workerInit) {
-        let orgs = this.networkUtil.getOrganizations();
-        for (let org of orgs) {
-            let adminName = `admin.${org}`;
-            // build the common part of the profile
-            let adminProfile = await this._prepareClientProfile(org, undefined, `${org}'s admin`);
+    async _initializeAdmins() {
+        logger.info('Initializing administrators');
+        const orgs = this.networkUtil.getOrganizations();
+        for (const org of orgs) {
+            const adminName = `admin.${org}`;
 
-            // Check if the materials already exist locally in file system key-value stores. Only valid if not using a file wallet
-            if (!this.fileWalletPath){
-                let admin = await this._getUserContext(adminProfile, adminName, `${org}'s admin`);
-                if (admin) {
-                    this.adminProfiles.set(org, adminProfile);
-
-                    if (this.networkUtil.isMutualTlsEnabled()) {
-                        this._setTlsAdminCertAndKey(org);
-                    }
-
-                    if (!workerInit) {
-                        logger.warn(`${org}'s admin's materials found locally in file system key-value stores. Make sure it is the right one!`);
-                    }
-
-                    if (!this.fileWalletPath) {
-                        // Persist in InMemory wallet if not using a file based wallet
-                        await this._addToWallet(org, admin.getIdentity()._certificate, admin.getSigningIdentity()._signer._key.toBytes(), adminName);
-                    }
-                    continue;
-                }
+            // Check if the caliper config file has this identity supplied
+            if (!this.networkUtil.getClients().has(adminName)) {
+                logger.info(`No ${adminName} found in caliper configuration file - unable to perform admin options`);
+                continue;
             }
 
-            // Set the admin explicitly based on its crypto materials either provided in a FileWallet or in the connection profile
-            let cryptoContent;
-            if (this.fileWalletPath) {
+            // Since admin exists, conditionally use it
+            const fileWalletPath = this.networkUtil.getFileWalletPath();
+            if (fileWalletPath) {
                 // If a file wallet is provided, it is expected that *all* required identities are provided
                 // Admin is a super-user identity, and is consequently optional
                 const hasAdmin = await this.wallet.get(adminName);
                 if (!hasAdmin) {
-                    logger.info(`No ${adminName} found in wallet - unable to perform admin options`);
-                    continue;
+                    logger.info(`No ${adminName} found in wallet - unable to perform admin options using client specified in caliper configuration file`);
                 }
-
-                logger.info(`Retrieving credentials for ${adminName} from wallet`);
-                const identity = await this.wallet.get(adminName);
-                // Identity {type: string, mspId: string, version: string, credentials: {privateKeyPEM: string, signedCertPEM: string} }
-                cryptoContent = {
-                    privateKeyPEM: identity.credentials.privateKey,
-                    signedCertPEM: identity.credentials.certificate
-                };
             } else {
-                cryptoContent = this.networkUtil.getAdminCryptoContentOfOrganization(org);
+                // Build up the admin identity based on caliper client items and add to the in-memory wallet
+                const cryptoContent = this.networkUtil.getAdminCryptoContentOfOrganization(org);
+                if (!cryptoContent) {
+                    logger.info(`No ${adminName} cryptoContent found in caliper configuration file - unable to perform admin options`);
+                    continue;
+                } else {
+                    await this._addToWallet(org, cryptoContent.signedCertPEM, cryptoContent.privateKeyPEM, adminName);
+                }
             }
-
-            const adminUser = await this._createUser(adminProfile, org, adminName, cryptoContent,`${org}'s admin`);
-
-            this.adminProfiles.set(org, adminProfile);
-
-            if (this.networkUtil.isMutualTlsEnabled()) {
-                this._setTlsAdminCertAndKey(org);
-            }
-
-            if (!this.fileWalletPath) {
-                // Persist in InMemory wallet if not using a file based wallet
-                await this._addToWallet(org, adminUser.getIdentity()._certificate, adminUser.getSigningIdentity()._signer._key.toBytes(), adminName);
-            }
-
             logger.info(`${org}'s admin's materials are successfully loaded`);
-        }
-    }
-
-    /**
-     * Initializes the registrars of the organizations.
-     *
-     * @param {boolean} workerInit Indicates whether the initialization happens in the worker process.
-     * @private
-     * @async
-     */
-    async _initializeRegistrars(workerInit) {
-        let orgs = this.networkUtil.getOrganizations();
-        for (let org of orgs) {
-
-            // providing registrar information is optional and only needed for user registration and enrollment
-            if (this.fileWalletPath) {
-                logger.info('skipping registrar initialization due to presence of file system wallet');
-                continue;
-            }
-            let registrarInfo = this.networkUtil.getRegistrarOfOrganization(org);
-            if (!registrarInfo) {
-                if (!workerInit) {
-                    logger.warn(`${org}'s registrar information not provided.`);
-                }
-                continue;
-            }
-
-            // build the common part of the profile
-            let registrarProfile = await this._prepareClientProfile(org, undefined, 'registrar');
-            // check if the materials already exist locally in the file system key-value stores
-            let registrar = await this._getUserContext(registrarProfile, registrarInfo.enrollId, `${org}'s registrar`);
-
-            if (registrar) {
-                if (!workerInit) {
-                    logger.warn(`${org}'s registrar's materials found locally in file system key-value stores. Make sure it is the right one!`);
-                }
-                this.registrarProfiles.set(org, registrarProfile);
-                continue;
-            }
-
-            // set the registrar identity as the current user context
-            await this._setUserContextByEnrollment(registrarProfile, registrarInfo.enrollId,
-                registrarInfo.enrollSecret, `${org}'s registrar`);
-
-            this.registrarProfiles.set(org, registrarProfile);
-            if (!workerInit) {
-                logger.info(`${org}'s registrar enrolled successfully`);
-            }
         }
     }
 
@@ -701,170 +230,49 @@ class Fabric extends BlockchainInterface {
      * @private
      * @async
      */
-    async _initializeUsers(workerInit) {
-        let clients = this.networkUtil.getClients();
+    async _initializeUsers() {
+        logger.info('Initializing users');
 
-        // register and enroll each client with its organization's CA
-        for (let client of clients) {
-            let org = this.networkUtil.getOrganizationOfClient(client);
-
-            // create the profile based on the connection profile
-            let clientProfile = await this._prepareClientProfile(org, client, client);
-            this.clientProfiles.set(client, clientProfile);
-
-            // check if the materials already exist locally in the file system key-value stores
-            let user = await this._getUserContext(clientProfile, client, client);
-            if (user) {
-                if (this.networkUtil.isMutualTlsEnabled()) {
-                    // "retrieve" and set the deserialized cert and key
-                    clientProfile.setTlsClientCertAndKey(user.getIdentity()._certificate, user.getSigningIdentity()._signer._key.toBytes());
-                }
-
-                if (!workerInit) {
-                    logger.warn(`${client}'s materials found locally in file system key-value stores. Make sure it is the right one!`);
-                }
-
-                if (!this.fileWalletPath) {
-                    // Add identity to wallet if not using file based wallet
-                    await this._addToWallet(org, user.getIdentity()._certificate, user.getSigningIdentity()._signer._key.toBytes(), client);
-                }
+        // Ensure clients passed by the config are able to be used
+        // - They must be present in a wallet
+        // - Use passed material if present
+        // - Register and enroll each client with its organization's CA as a fall back option
+        for (const clientName of this.networkUtil.getClients()) {
+            const orgName = this.networkUtil.getOrganizationOfClient(clientName);
+            const hasClient = await this.wallet.get(clientName);
+            if (hasClient) {
+                logger.info(`Client ${clientName} present in wallet: skipping client enrollment`);
                 continue;
-            }
-
-            let cryptoContent;
-            if (this.fileWalletPath) {
-                logger.info(`Retrieving credentials for ${client} from wallet`);
-                const identity = await this.wallet.get(client);
-                // Identity {type: string, mspId: string, version: string, credentials: {privateKeyPEM: string, signedCertPEM: string} }
-                cryptoContent = {
-                    privateKeyPEM: identity.credentials.privateKey,
-                    signedCertPEM: identity.credentials.certificate
-                };
             } else {
-                cryptoContent = this.networkUtil.getClientCryptoContent(client);
-            }
-
-            if (cryptoContent) {
-                // the client is already enrolled, just create and persist the User object
-                user = await this._createUser(clientProfile, org, client, cryptoContent, client);
-                if (this.networkUtil.isMutualTlsEnabled()) {
-                    // the materials are included in the configuration file
-                    let crypto = this.networkUtil.getClientCryptoContent(client);
-                    clientProfile.setTlsClientCertAndKey(crypto.signedCertPEM.toString(), crypto.privateKeyPEM.toString());
-                }
-
-                if (!workerInit) {
-                    logger.info(`${client}'s materials are successfully loaded`);
-                }
-
-                if (!this.fileWalletPath) {
-                    // Persist in InMemory wallet if not using file based wallet
-                    await this._addToWallet(org, user.getIdentity()._certificate, user.getSigningIdentity()._signer._key.toBytes(), client);
-                }
-                continue;
-            }
-
-            // The user needs to be enrolled or even registered
-
-            // if the enrollment ID and secret is provided, then enroll the already registered user
-            let enrollmentSecret = this.networkUtil.getClientEnrollmentSecret(client);
-            if (enrollmentSecret) {
-                let enrollment = await this._enrollUser(clientProfile, client, enrollmentSecret, client);
-
-                // create the new user based on the retrieved materials
-                user = await this._createUser(clientProfile, org, client,
-                    {
-                        privateKeyPEM: enrollment.key.toBytes(),
-                        signedCertPEM: Buffer.from(enrollment.certificate)
-                    }, client);
-
-                if (this.networkUtil.isMutualTlsEnabled()) {
-                    // set the received cert and key for mutual TLS
-                    clientProfile.setTlsClientCertAndKey(Buffer.from(enrollment.certificate).toString(), enrollment.key.toString());
-                }
-
-                if (!workerInit) {
-                    logger.info(`${client} successfully enrolled`);
-                }
-
-                // Add identity to wallet
-                await this._addToWallet(org, user.getIdentity()._certificate, user.getSigningIdentity()._signer._key.toBytes(), client);
-
-                continue;
-            }
-
-            // Otherwise, register then enroll the user
-            let secret;
-            try {
-                let registrarProfile = this.registrarProfiles.get(org);
-
-                if (!registrarProfile) {
-                    throw new Error(`Registrar identity is not provided for ${org}`);
-                }
-
-                let registrarInfo = this.networkUtil.getRegistrarOfOrganization(org);
-                let registrar = await registrarProfile.getUserContext(registrarInfo.enrollId, true);
-                // this call will throw an error if the CA configuration is not found
-                // this error should propagate up
-                let ca = clientProfile.getCertificateAuthority();
-                let userAffiliation = this.networkUtil.getAffiliationOfUser(client);
-
-                // if not in compatibility mode (i.e., at least SDK v1.1), check whether the affiliation is already registered or not
-                if (!this.networkUtil.isInCompatibilityMode()) {
-                    let affService = ca.newAffiliationService();
-                    let affiliationExists = false;
+                // Extract required information from the supplied caliper config
+                const cryptoContent = this.networkUtil.getClientCryptoContent(clientName);
+                if (cryptoContent) {
+                    await this._addToWallet(orgName, cryptoContent.signedCertPEM.toString('utf8'), cryptoContent.privateKeyPEM.toString('utf8'), clientName);
+                } else {
                     try {
-                        await affService.getOne(userAffiliation, registrar);
-                        affiliationExists = true;
-                    } catch (err) {
-                        if (!workerInit) {
-                            logger.info(`${userAffiliation} affiliation doesn't exists`);
+                        // Check if there is a valid registrar to use for the org
+                        if (this.registrarHelper.registrarExistsForOrg(orgName)) {
+                            // Do we have an enrollment secret?
+                            const enrollmentSecret = this.networkUtil.getClientEnrollmentSecret(clientName);
+                            if (enrollmentSecret) {
+                                // enrolled, so register with enrollment secret
+                                const enrollment = await this.registrarHelper.enrollUserForOrg(orgName, clientName, enrollmentSecret);
+                                await this._addToWallet(orgName, enrollment.certificate,  enrollment.key.toBytes(), clientName);
+                            } else {
+                                // Register and enrol
+                                const secret = await this.registrarHelper.registerUserForOrg(orgName, clientName);
+                                const enrollment = await this.registrarHelper.enrollUserForOrg(orgName, clientName, secret);
+                                await this._addToWallet(orgName, enrollment.certificate,  enrollment.key.toBytes(), clientName);
+                            }
+                        } else {
+                            logger.warn(`Required registrar for organization ${orgName} does not exist; unable to enroll client with identity ${clientName}.`);
                         }
-                    }
-
-                    if (!affiliationExists) {
-                        await affService.create({name: userAffiliation, force: true}, registrar);
-                        if (!workerInit) {
-                            logger.info(`${userAffiliation} affiliation added`);
-                        }
+                    } catch (error) {
+                        logger.warn(`Failed to enrol client with identity ${clientName}. This client will be unavailable for use, due to error ${error.toString()}`);
+                        continue;
                     }
                 }
-
-                let attributes = this.networkUtil.getAttributesOfUser(client);
-                attributes.push({name: 'hf.Registrar.Roles', value: 'client'});
-
-                secret = await ca.register({
-                    enrollmentID: client,
-                    affiliation: userAffiliation,
-                    role: 'client',
-                    attrs: attributes
-                }, registrar);
-            } catch (err) {
-                throw new Error(`Couldn't register ${client}: ${err.message}`);
             }
-
-            if (!workerInit) {
-                logger.info(`${client} successfully registered`);
-            }
-
-            let enrollment = await this._enrollUser(clientProfile, client, secret, client);
-
-            // create the new user based on the retrieved materials
-            user = await this._createUser(clientProfile, org, client,
-                {privateKeyPEM: enrollment.key.toBytes(), signedCertPEM: Buffer.from(enrollment.certificate)}, client);
-
-            if (this.networkUtil.isMutualTlsEnabled()) {
-                // set the received cert and key for mutual TLS
-                clientProfile.setTlsClientCertAndKey(Buffer.from(enrollment.certificate).toString(), enrollment.key.toString());
-                //this._setTlsClientCertAndKey(client);
-            }
-
-            if (!workerInit) {
-                logger.info(`${client} successfully enrolled`);
-            }
-
-            // Add identity to wallet
-            await this._addToWallet(org, user.getIdentity()._certificate, user.getSigningIdentity()._signer._key.toBytes(), client);
         }
     }
 
@@ -885,7 +293,8 @@ class Fabric extends BlockchainInterface {
             mspId: this.networkUtil.getMspIdOfOrganization(org),
             type: 'X.509',
         };
-        logger.info(`Adding identity for ${identityName} to wallet`);
+
+        logger.info(`Adding identity for identityName ${identityName} to wallet`);
         await this.wallet.put(identityName, identity);
         logger.info(`Identity ${identityName} created and imported to wallet`);
     }
@@ -957,6 +366,7 @@ class Fabric extends BlockchainInterface {
                 strategy: EventStrategies[this.eventStrategy]
             },
             queryHandlerOptions: {
+                requestTimeout: this.configDefaultTimeout,
                 strategy: QueryStrategies[this.queryStrategy]
             }
         };
@@ -969,8 +379,13 @@ class Fabric extends BlockchainInterface {
         // Retrieve gateway using ccp and options
         const gateway = new Gateway();
 
-        logger.info(`Connecting user ${userId} to a Network Gateway`);
-        await gateway.connect(this.networkUtil.getNetworkObject(), opts);
+        try {
+            logger.info(`Connecting user ${userId} to a Network Gateway`);
+            await gateway.connect(this.networkUtil.getNetworkObject(), opts);
+            logger.info(`Successfully connected user ${userId} to a Network Gateway`);
+        } catch (err) {
+            logger.error(`Connecting user ${userId} to a Network Gateway failed with error: ${err}`);
+        }
 
         // return the gateway object
         return gateway;
@@ -991,464 +406,11 @@ class Fabric extends BlockchainInterface {
                 const channel = network.getChannel();
 
                 // Add all peers
-                for (const peerObject of channel.getPeers()) {
-                    this.peerCache.set(peerObject.getName(), peerObject);
+                for (const peerObject of channel.client.getEndorsers()) {
+                    this.peerCache.set(peerObject.name, peerObject);
                 }
             }
         }
-    }
-
-    /**
-     * Install the specified chaincodes to their target peers.
-     * @private
-     * @async
-     */
-    async _installChaincodes() {
-        if (this.configOverwriteGopath) {
-            process.env.GOPATH = CaliperUtils.resolvePath('.', this.workspaceRoot);
-        }
-
-        let errors = [];
-
-        let channels = this.networkUtil.getChannels();
-        for (let channel of channels) {
-            logger.info(`Installing chaincodes for ${channel}...`);
-
-            // proceed cc by cc for the channel
-            let chaincodeInfos = this.networkUtil.getChaincodesOfChannel(channel);
-            for (let chaincodeInfo of chaincodeInfos) {
-                let ccObject = this.networkUtil.getNetworkObject().channels[channel].chaincodes.find(
-                    cc => cc.id === chaincodeInfo.id && cc.version === chaincodeInfo.version);
-
-                let targetPeers = this.networkUtil.getTargetPeersOfChaincodeOfChannel(chaincodeInfo, channel);
-                if (targetPeers.size < 1) {
-                    logger.info(`No target peers are defined for ${chaincodeInfo.id}@${chaincodeInfo.version} on ${channel}, skipping it`);
-                    continue;
-                }
-
-                // find the peers that don't have the cc installed
-                let installTargets = [];
-
-                for (let peer of targetPeers) {
-                    let org = this.networkUtil.getOrganizationOfPeer(peer);
-                    let admin = this.adminProfiles.get(org);
-
-                    try {
-                        /** {@link ChaincodeQueryResponse} */
-                        let resp = await admin.queryInstalledChaincodes(peer, true);
-                        if (resp.chaincodes.some(cc => cc.name === chaincodeInfo.id && cc.version === chaincodeInfo.version)) {
-                            logger.info(`${chaincodeInfo.id}@${chaincodeInfo.version} is already installed on ${peer}`);
-                            continue;
-                        }
-
-                        installTargets.push(peer);
-                    } catch (err) {
-                        errors.push(new Error(`Couldn't query installed chaincodes on ${peer}: ${err.message}`));
-                    }
-                }
-
-                if (errors.length > 0) {
-                    let errorMsg = `Could not query whether ${chaincodeInfo.id}@${chaincodeInfo.version} is installed on some peers of ${channel}:`;
-                    for (let err of errors) {
-                        errorMsg += `\n\t- ${err.message}`;
-                    }
-
-                    logger.error(errorMsg);
-                    throw new Error(`Could not query whether ${chaincodeInfo.id}@${chaincodeInfo.version} is installed on some peers of ${channel}`);
-                }
-
-                // cc is installed on every target peer in the channel
-                if (installTargets.length < 1) {
-                    continue;
-                }
-
-                // install chaincodes org by org
-                let orgs = this.networkUtil.getOrganizationsOfChannel(channel);
-                for (let org of orgs) {
-                    let peersOfOrg = this.networkUtil.getPeersOfOrganization(org);
-                    // selecting the target peers for this org
-                    let orgPeerTargets = installTargets.filter(p => peersOfOrg.has(p));
-
-                    // cc is installed on every target peer of the org in the channel
-                    if (orgPeerTargets.length < 1) {
-                        continue;
-                    }
-
-                    let admin = this.adminProfiles.get(org);
-
-                    let txId = admin.newTransactionID(true);
-                    /** @{ChaincodeInstallRequest} */
-                    let request = {
-                        targets: orgPeerTargets,
-                        chaincodePath: ccObject.language === 'golang' ? ccObject.path : CaliperUtils.resolvePath(ccObject.path, this.workspaceRoot),
-                        chaincodeId: ccObject.id,
-                        chaincodeVersion: ccObject.version,
-                        chaincodeType: ccObject.language,
-                        txId: txId
-                    };
-
-                    // metadata (like CouchDB indices) are only supported since Fabric v1.1
-                    if (CaliperUtils.checkProperty(ccObject, 'metadataPath')) {
-                        if (!this.networkUtil.isInCompatibilityMode()) {
-                            request.metadataPath = CaliperUtils.resolvePath(ccObject.metadataPath, this.workspaceRoot);
-                        } else {
-                            throw new Error(`Installing ${chaincodeInfo.id}@${chaincodeInfo.version} with metadata is not supported in Fabric v1.0`);
-                        }
-                    }
-
-                    // install to necessary peers of org and process the results
-                    try {
-                        /** @link{ProposalResponseObject} */
-                        let propRespObject = await admin.installChaincode(request);
-                        CaliperUtils.assertDefined(propRespObject);
-
-                        /** Array of @link{ProposalResponse} objects */
-                        let proposalResponses = propRespObject[0];
-                        CaliperUtils.assertDefined(proposalResponses);
-
-                        proposalResponses.forEach((propResponse, index) => {
-                            if (propResponse instanceof Error) {
-                                let errMsg = `Install proposal error for ${chaincodeInfo.id}@${chaincodeInfo.version} on ${orgPeerTargets[index]}: ${propResponse.message}`;
-                                errors.push(new Error(errMsg));
-                                return;
-                            }
-
-                            /** @link{ProposalResponse} */
-                            CaliperUtils.assertProperty(propResponse, 'propResponse', 'response');
-
-                            /** @link{ResponseObject} */
-                            let response = propResponse.response;
-                            CaliperUtils.assertProperty(response, 'response', 'status');
-
-                            if (response.status !== 200) {
-                                let errMsg = `Unsuccessful install status for ${chaincodeInfo.id}@${chaincodeInfo.version} on ${orgPeerTargets[index]}: ${propResponse.response.message}`;
-                                errors.push(new Error(errMsg));
-                            }
-                        });
-                    } catch (err) {
-                        throw new Error(`Couldn't install ${chaincodeInfo.id}@${chaincodeInfo.version} on peers ${orgPeerTargets.toString()}: ${err.message}`);
-                    }
-
-                    // there were some install errors, proceed to the other orgs to gather more information
-                    if (errors.length > 0) {
-                        continue;
-                    }
-
-                    logger.info(`${chaincodeInfo.id}@${chaincodeInfo.version} successfully installed on ${org}'s peers: ${orgPeerTargets.toString()}`);
-                }
-
-                if (errors.length > 0) {
-                    let errorMsg = `Could not install ${chaincodeInfo.id}@${chaincodeInfo.version} on some peers of ${channel}:`;
-                    for (let err of errors) {
-                        errorMsg += `\n\t- ${err.message}`;
-                    }
-
-                    logger.error(errorMsg);
-                    throw new Error(`Could not install ${chaincodeInfo.id}@${chaincodeInfo.version} on some peers of ${channel}`);
-                }
-            }
-        }
-    }
-
-    /**
-     * Instantiates the chaincodes on their channels.
-     * @return {boolean} True, if at least one chaincode was instantiated. Otherwise, false.
-     * @private
-     * @async
-     */
-    async _instantiateChaincodes() {
-        let channels = this.networkUtil.getChannels();
-        let chaincodeInstantiated = false;
-
-        // chaincodes needs to be installed channel by channel
-        for (let channel of channels) {
-            let chaincodeInfos = this.networkUtil.getChaincodesOfChannel(channel);
-
-            for (let chaincodeInfo of chaincodeInfos) {
-                logger.info(`Instantiating ${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel}. This might take some time...`);
-
-                let ccObject = this.networkUtil.getNetworkObject().channels[channel].chaincodes.find(
-                    cc => cc.id === chaincodeInfo.id && cc.version === chaincodeInfo.version);
-
-                // check chaincode language
-                // only golang, node and java are supported
-                if (!['golang', 'node', 'java'].includes(ccObject.language)) {
-                    throw new Error(`${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel}: unknown chaincode type ${ccObject.language}`);
-                }
-
-                let targetPeers = Array.from(this.networkUtil.getTargetPeersOfChaincodeOfChannel(chaincodeInfo, channel));
-                if (targetPeers.length < 1) {
-                    logger.info(`No target peers are defined for ${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel}, skipping it`);
-                    continue;
-                }
-
-                // select a target peer for the chaincode to see if it's instantiated
-                // these are the same as the install targets, so if one of the peers has already instantiated the chaincode,
-                // then the other targets also had done the same
-                let org = this.networkUtil.getOrganizationOfPeer(targetPeers[0]);
-                let admin = this.adminProfiles.get(org);
-
-                /** @link{ChaincodeQueryResponse} */
-                let queryResponse;
-                try {
-                    queryResponse = await admin.getChannel(channel, true).queryInstantiatedChaincodes(targetPeers[0], true);
-                } catch (err) {
-                    throw new Error(`Couldn't query whether ${chaincodeInfo.id}@${chaincodeInfo.version} is instantiated on ${targetPeers[0]}: ${err.message}`);
-                }
-
-                CaliperUtils.assertDefined(queryResponse);
-                CaliperUtils.assertProperty(queryResponse, 'queryResponse', 'chaincodes');
-
-                if (queryResponse.chaincodes.some(
-                    cc => cc.name === chaincodeInfo.id && cc.version === chaincodeInfo.version)) {
-                    logger.info(`${chaincodeInfo.id}@${chaincodeInfo.version} is already instantiated in ${channel}`);
-                    continue;
-                }
-
-                chaincodeInstantiated = true;
-
-                let txId = admin.newTransactionID(true);
-                /** @link{ChaincodeInstantiateUpgradeRequest} */
-                let request = {
-                    targets: targetPeers,
-                    chaincodeId: ccObject.id,
-                    chaincodeVersion: ccObject.version,
-                    chaincodeType: ccObject.language,
-                    args: ccObject.init || [],
-                    fcn: ccObject.function || 'init',
-                    'endorsement-policy': ccObject['endorsement-policy'] ||
-                        this.networkUtil.getDefaultEndorsementPolicy(channel, { id: ccObject.id, version: ccObject.version }),
-                    transientMap: this.networkUtil.getTransientMapOfChaincodeOfChannel(chaincodeInfo, channel),
-                    txId: txId
-                };
-
-                // check private collection configuration
-                if (CaliperUtils.checkProperty(ccObject, 'collections-config')) {
-                    request['collections-config'] = ccObject['collections-config'];
-                }
-
-                /** @link{ProposalResponseObject} */
-                let response;
-                try {
-                    response = await admin.getChannel(channel, true).sendInstantiateProposal(request, this.configChaincodeInstantiateTimeout);
-                } catch (err) {
-                    throw new Error(`Couldn't endorse ${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel} on peers [${targetPeers.toString()}]: ${err.message}`);
-                }
-
-                CaliperUtils.assertDefined(response);
-
-                /** @link{Array<ProposalResponse>} */
-                let proposalResponses = response[0];
-                /** @link{Proposal} */
-                let proposal = response[1];
-                CaliperUtils.assertDefined(proposalResponses);
-                CaliperUtils.assertDefined(proposal);
-
-                // check each response
-                proposalResponses.forEach((propResp, index) => {
-                    CaliperUtils.assertDefined(propResp);
-                    // an Error is returned for a rejected proposal
-                    if (propResp instanceof Error) {
-                        throw new Error(`Invalid endorsement for ${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel} from ${targetPeers[index]}: ${propResp.message}`);
-                    } else if (propResp.response.status !== 200) {
-                        throw new Error(`Invalid endorsement for ${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel} from ${targetPeers[index]}: status code ${propResp.response.status}`);
-                    }
-                });
-
-                // connect to every event source of every org in the channel
-                let eventSources = this._assembleTargetEventSources(channel, targetPeers);
-                let eventPromises = [];
-
-                try {
-                    // NOTE: everything is resolved, errors are signaled through an Error object
-                    // this makes error handling and reporting easier
-                    eventSources.forEach((es) => {
-                        let promise = new Promise((resolve) => {
-                            let timeoutHandle = setTimeout(() => {
-                                // unregister manually
-                                es.eventHub.unregisterTxEvent(txId.getTransactionID(), false);
-                                resolve(new Error(`Commit timeout for ${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel} from ${es.peer}`));
-                            }, this.configChaincodeInstantiateEventTimeout);
-
-                            es.eventHub.registerTxEvent(txId.getTransactionID(), (tx, code) => {
-                                clearTimeout(timeoutHandle);
-                                if (code !== 'VALID') {
-                                    resolve(new Error(`Invalid commit code for ${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel} from ${es.peer}: ${code}`));
-                                } else {
-                                    resolve(code);
-                                }
-                            }, /* Error handler */ (err) => {
-                                clearTimeout(timeoutHandle);
-                                resolve(new Error(`Event hub error from ${es.peer} during instantiating ${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel}: ${err.message}`));
-                            });
-
-                            es.eventHub.connect();
-                        });
-
-                        eventPromises.push(promise);
-                    });
-
-                    /** @link{TransactionRequest} */
-                    let ordererRequest = {
-                        txId: txId,
-                        proposalResponses: proposalResponses,
-                        proposal: proposal
-                    };
-
-                    /** @link{BroadcastResponse} */
-                    let broadcastResponse;
-                    try {
-                        broadcastResponse = await admin.getChannel(channel, true).sendTransaction(ordererRequest);
-                    } catch (err) {
-                        throw new Error(`Orderer error for instantiating ${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel}: ${err.message}`);
-                    }
-
-                    CaliperUtils.assertDefined(broadcastResponse);
-                    CaliperUtils.assertProperty(broadcastResponse, 'broadcastResponse', 'status');
-
-                    if (broadcastResponse.status !== 'SUCCESS') {
-                        throw new Error(`Orderer error for instantiating ${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel}: ${broadcastResponse.status}`);
-                    }
-
-                    // since every event promise is resolved, this shouldn't throw an error
-                    let eventResults = await Promise.all(eventPromises);
-
-                    // if we received an error, propagate it
-                    if (eventResults.some(er => er instanceof Error)) {
-                        let errMsg = `The following errors occured while instantiating ${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel}:`;
-                        let err; // keep the last error
-                        for (let eventResult of eventResults) {
-                            if (eventResult instanceof Error) {
-                                err = eventResult;
-                                errMsg += `\n\t- ${eventResult.message}`;
-                            }
-                        }
-
-                        logger.error(errMsg);
-                        throw err;
-                    }
-
-                    logger.info(`Successfully instantiated ${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel}`);
-                } finally {
-                    eventSources.forEach(es => {
-                        if (es.eventHub.isconnected()) {
-                            es.eventHub.disconnect();
-                        }
-                    });
-                }
-            }
-        }
-
-        return chaincodeInstantiated;
-    }
-
-    /**
-     * Joins the peers to the specified channels is necessary.
-     * @return {boolean} True, if at least one peer joined a channel. Otherwise, false.
-     * @private
-     * @async
-     */
-    async _joinChannels() {
-        let channels = this.networkUtil.getChannels();
-        let channelJoined = false;
-        let errors = [];
-
-        for (let channelName of channels) {
-            let genesisBlock = null;
-            let orgs = this.networkUtil.getOrganizationsOfChannel(channelName);
-
-            for (let org of orgs) {
-                let admin = this.adminProfiles.get(org);
-                let channelObject = admin.getChannel(channelName, true);
-
-                let peers = this.networkUtil.getPeersOfOrganizationAndChannel(org, channelName);
-                let peersToJoin = [];
-
-                for (let peer of peers) {
-                    try {
-                        /** {@link ChannelQueryResponse} */
-                        let resp = await admin.queryChannels(peer, true);
-                        if (resp.channels.some(ch => ch.channel_id === channelName)) {
-                            logger.info(`${peer} has already joined ${channelName}`);
-                            continue;
-                        }
-
-                        peersToJoin.push(peer);
-                    } catch (err) {
-                        errors.push(new Error(`Couldn't query ${channelName} information from ${peer}: ${err.message}`));
-                    }
-                }
-
-                if (errors.length > 0) {
-                    let errMsg = `The following errors occurred while querying ${channelName} information from ${org}'s peers:`;
-                    for (let err of errors) {
-                        errMsg += `\n\t- ${err.message}`;
-                    }
-
-                    logger.error(errMsg);
-                    throw new Error(`Couldn't query ${channelName} information from ${org}'s peers`);
-                }
-
-                // all target peers of the org have already joined the channel
-                if (peersToJoin.length < 1) {
-                    continue;
-                }
-
-                channelJoined = true;
-
-                // only retrieve the genesis block once, and "cache" it
-                if (genesisBlock === null) {
-                    try {
-                        let genesisTxId = admin.newTransactionID(true);
-                        /** @link{OrdererRequest} */
-                        let genesisRequest = {
-                            txId: genesisTxId
-                        };
-                        genesisBlock = await channelObject.getGenesisBlock(genesisRequest);
-                    } catch (err) {
-                        throw new Error(`Couldn't retrieve the genesis block for ${channelName}: ${err.message}`);
-                    }
-                }
-
-                let joinTxId = admin.newTransactionID(true);
-                let joinRequest = {
-                    block: genesisBlock,
-                    txId: joinTxId,
-                    targets: peersToJoin
-                };
-
-                try {
-                    /**{@link ProposalResponse} array*/
-                    let joinRespArray = await channelObject.joinChannel(joinRequest);
-                    CaliperUtils.assertDefined(joinRespArray);
-
-                    // Some errors are returned as Error instances, some as error messages
-                    joinRespArray.forEach((propResponse, index) => {
-                        if (propResponse instanceof Error) {
-                            errors.push(new Error(`${peersToJoin[index]} could not join ${channelName}: ${propResponse.message}`));
-                        } else if (propResponse.response.status !== 200) {
-                            errors.push(new Error(`${peersToJoin[index]} could not join ${channelName}: ${propResponse.response.message}`));
-                        }
-                    });
-                } catch (err) {
-                    throw new Error(`Couldn't join peers ${peersToJoin.toString()} to ${channelName}: ${err.message}`);
-                }
-
-                if (errors.length > 0) {
-                    let errMsg = `The following errors occurred while ${org}'s peers tried to join ${channelName}:`;
-                    for (let err of errors) {
-                        errMsg += `\n\t- ${err.message}`;
-                    }
-
-                    logger.error(errMsg);
-                    throw new Error(`${org}'s peers couldn't join ${channelName}`);
-                }
-
-                logger.info(`${org}'s peers successfully joined ${channelName}: ${peersToJoin}`);
-            }
-        }
-
-        return channelJoined;
     }
 
     /**
@@ -1456,89 +418,13 @@ class Fabric extends BlockchainInterface {
      * @private
      */
     async _prepareWallet() {
-        if (this.fileWalletPath) {
-            logger.info(`Using defined file wallet path ${this.fileWalletPath}`);
-            this.wallet = await Wallets.newFileSystemWallet(this.fileWalletPath);
+        const fileWalletPath = this.networkUtil.getFileWalletPath();
+        if (fileWalletPath) {
+            logger.info(`Using defined file wallet path ${fileWalletPath}`);
+            this.wallet = await Wallets.newFileSystemWallet(fileWalletPath);
         } else {
             logger.info('Creating new InMemoryWallet to persist user identities');
             this.wallet = await Wallets.newInMemoryWallet();
-        }
-    }
-
-    /**
-     * Partially assembles a Client object containing general network information.
-     * @param {string} org The name of the organization the client belongs to. Mandatory, if the client name is omitted.
-     * @param {string} clientName The name of the client to base the profile on.
-     *                            If omitted, then the first client of the organization will be used.
-     * @param {string} profileName Optional name of the profile that will appear in error messages.
-     * @return {Promise<Client>} The partially assembled Client object.
-     * @private
-     * @async
-     */
-    async _prepareClientProfile(org, clientName, profileName) {
-        let client = clientName;
-        if (!client) {
-            CaliperUtils.assertDefined(org);
-            // base it on the first client connection profile of the org
-            let clients = this.networkUtil.getClientsOfOrganization(org);
-
-            // NOTE: this assumes at least one client per org, which is reasonable, the clients will interact with the network
-            if (clients.size < 1) {
-                throw new Error(`At least one client specification for ${org} is needed to initialize the ${profileName || 'profile'}`);
-            }
-
-            client = Array.from(clients)[0];
-        }
-
-        // load the general network data from a clone of the network object
-        // NOTE: if we provide a common object instead, the Client class will use it directly,
-        // and it will be overwritten when loading the next client
-        let profile = await FabricClient.loadFromConfig(this.networkUtil.getNewNetworkObject());
-        profile.loadFromConfig({
-            version: '1.0',
-            client: this.networkUtil.getClientObject(client)
-        });
-
-        if (!this.fileWalletPath) {
-            try {
-                await profile.initCredentialStores();
-            } catch (err) {
-                throw new Error(`Couldn't initialize the credential stores for ${org}'s ${profileName || 'profile'}: ${err.message}`);
-            }
-        }
-
-        return profile;
-    }
-
-    /**
-     * Sets the mutual TLS for the admin of the given organization.
-     * @param {string} org The name of the organization.
-     * @private
-     */
-    _setTlsAdminCertAndKey(org) {
-        let profile = this.adminProfiles.get(org);
-        let crypto = this.networkUtil.getAdminCryptoContentOfOrganization(org);
-        profile.setTlsClientCertAndKey(crypto.signedCertPEM.toString(), crypto.privateKeyPEM.toString());
-    }
-
-    /**
-     * Tries to set the given identity as the current user context for the given profile. Enrolls it if needed and can.
-     * @param {Client} profile The Client object whose user context must be set.
-     * @param {string} userName The name of the user.
-     * @param {string} password The password for the user.
-     * @param {string} profileName Optional name of the profile that will appear in error messages.
-     * @private
-     * @async
-     */
-    async _setUserContextByEnrollment(profile, userName, password, profileName) {
-        try {
-            // automatically tries to enroll the given identity with the CA (must be registered)
-            await profile.setUserContext({
-                username: userName,
-                password: password
-            }, false);
-        } catch (err) {
-            throw new Error(`Couldn't enroll ${profileName || 'the user'} or set it as user context: ${err.message}`);
         }
     }
 
@@ -1559,12 +445,7 @@ class Fabric extends BlockchainInterface {
         const transaction = smartContract.createTransaction(invokeSettings.chaincodeFunction);
 
         // Build the Caliper TxStatus, this is a reduced item when compared to the low level API capabilities
-        const txId = transaction.getTransactionID();
-        let invokeStatus = new TxStatus(txId);
-
-        if (context.engine) {
-            context.engine.submitCallback(1);
-        }
+        const invokeStatus = new TxStatus(uuid());
 
         // Add transient data if present
         // - passed as key value pairing such as {"hello":"world"}
@@ -1572,7 +453,7 @@ class Fabric extends BlockchainInterface {
             const transientData = {};
             const keys = Array.from(Object.keys(invokeSettings.transientData));
             keys.forEach((key) => {
-                transientData[key] = Buffer.from(transientData[key]);
+                transientData[key] = Buffer.from(invokeSettings.transientData[key]);
             });
             transaction.setTransient(transientData);
         }
@@ -1592,9 +473,16 @@ class Fabric extends BlockchainInterface {
         try {
             let result;
             if (isSubmit) {
+                if (context.engine) {
+                    context.engine.submitCallback(1);
+                }
                 invokeStatus.Set('request_type', 'transaction');
                 result = await transaction.submit(...invokeSettings.chaincodeArguments);
             } else {
+                const countAsLoad = invokeSettings.countAsLoad === undefined ? this.configCountQueryAsLoad : invokeSettings.countAsLoad;
+                if (context.engine && countAsLoad) {
+                    context.engine.submitCallback(1);
+                }
                 invokeStatus.Set('request_type', 'query');
                 result = await transaction.evaluate(...invokeSettings.chaincodeArguments);
             }
@@ -1649,7 +537,6 @@ class Fabric extends BlockchainInterface {
     // PUBLIC API FUNCTIONS //
     //////////////////////////
 
-
     /**
      * Retrieve the blockchain type the implementation relates to
      * @returns {string} the blockchain type
@@ -1688,28 +575,16 @@ class Fabric extends BlockchainInterface {
 
     /**
      * Initializes the Fabric adapter: sets up clients, admins, registrars, channels and chaincodes.
-     * @param {boolean} workerInit Indicates whether the initialization happens in the worker process.
+     * @param {boolean} workerInit unused
      * @async
      */
-    async init(workerInit = false) {
-        let tlsInfo = this.networkUtil.isMutualTlsEnabled() ? 'mutual'
+    async init() {
+        const tlsInfo = this.networkUtil.isMutualTlsEnabled() ? 'mutual'
             : (this.networkUtil.isTlsEnabled() ? 'server' : 'none');
-        let compMode = this.networkUtil.isInCompatibilityMode() ? '; Fabric v1.0 compatibility mode' : '';
-        logger.info(`Fabric SDK version: ${this.version.toString()}; TLS: ${tlsInfo}${compMode}`);
+        logger.info(`Fabric SDK version: ${this.version.toString()}; TLS: ${tlsInfo}`);
 
-        await this._initAdaptor(workerInit);
-
-        if (!workerInit) {
-            if (await this._createChannels()) {
-                logger.info(`Sleeping ${this.configSleepAfterCreateChannel / 1000.0}s...`);
-                await CaliperUtils.sleep(this.configSleepAfterCreateChannel);
-            }
-
-            if (await this._joinChannels()) {
-                logger.info(`Sleeping ${this.configSleepAfterJoinChannel / 1000.0}s...`);
-                await CaliperUtils.sleep(this.configSleepAfterJoinChannel);
-            }
-        }
+        logger.warn(`Administrative actions are not possible with Fabric SDK version: ${this.version.toString()}`);
+        await this._initAdaptor();
     }
 
     /**
@@ -1717,16 +592,7 @@ class Fabric extends BlockchainInterface {
      * @async
      */
     async installSmartContract() {
-        // With flow conditioning, this phase is conditionally required
-        if (!this.initPhaseCompleted ) {
-            await this._initAdaptor();
-        }
-
-        await this._installChaincodes();
-        if (await this._instantiateChaincodes()) {
-            logger.info(`Sleeping ${this.configSleepAfterInstantiateChaincode / 1000.0}s...`);
-            await CaliperUtils.sleep(this.configSleepAfterInstantiateChaincode);
-        }
+        logger.warn(`Install smart contract not available with Fabric SDK version: ${this.version.toString()}`);
     }
 
     /**
@@ -1736,11 +602,11 @@ class Fabric extends BlockchainInterface {
      * @param {string} contractID The unique contract ID of the target chaincode.
      * @param {string} contractVersion Unused.
      * @param {ChaincodeInvokeSettings|ChaincodeInvokeSettings[]} invokeSettings The settings (collection) associated with the (batch of) transactions to submit.
-     * @param {number} timeout The timeout for the whole transaction life-cycle in seconds.
+     * @param {number} timeout The timeout override for the whole transaction life-cycle in seconds.
      * @return {Promise<TxStatus[]>} The result and stats of the transaction invocation.
      */
     async invokeSmartContract(context, contractID, contractVersion, invokeSettings, timeout) {
-        let promises = [];
+        const promises = [];
         let settingsArray;
 
         if (!Array.isArray(invokeSettings)) {
@@ -1749,8 +615,8 @@ class Fabric extends BlockchainInterface {
             settingsArray = invokeSettings;
         }
 
-        for (let settings of settingsArray) {
-            let contractDetails = this.networkUtil.getContractDetails(contractID);
+        for (const settings of settingsArray) {
+            const contractDetails = this.networkUtil.getContractDetails(contractID);
             if (!contractDetails) {
                 throw new Error(`Could not find details for contract ID ${contractID}`);
             }
@@ -1776,11 +642,11 @@ class Fabric extends BlockchainInterface {
      * @param {string} contractID The unique contract ID of the target chaincode.
      * @param {string} contractVersion Unused.
      * @param {ChaincodeQuerySettings|ChaincodeQuerySettings[]} querySettings The settings (collection) associated with the (batch of) query to submit.
-     * @param {number} timeout The timeout for the call in seconds.
+     * @param {number} timeout Unused - timeouts are set using globally defined values in the gateway construction phase.
      * @return {Promise<TxStatus[]>} The result and stats of the transaction query.
      */
     async querySmartContract(context, contractID, contractVersion, querySettings, timeout) {
-        let promises = [];
+        const promises = [];
         let settingsArray;
 
         if (!Array.isArray(querySettings)) {
@@ -1789,8 +655,8 @@ class Fabric extends BlockchainInterface {
             settingsArray = querySettings;
         }
 
-        for (let settings of settingsArray) {
-            let contractDetails = this.networkUtil.getContractDetails(contractID);
+        for (const settings of settingsArray) {
+            const contractDetails = this.networkUtil.getContractDetails(contractID);
             if (!contractDetails) {
                 throw new Error(`Could not find details for contract ID ${contractID}`);
             }

--- a/packages/caliper-fabric/lib/adaptor-versions/v2/fabric-v2.js
+++ b/packages/caliper-fabric/lib/adaptor-versions/v2/fabric-v2.js
@@ -138,7 +138,7 @@ class Fabric extends BlockchainInterface {
 
         this.network = undefined;
         if (typeof networkConfig === 'string') {
-            let configPath = CaliperUtils.resolvePath(networkConfig, workspace_root);
+            const configPath = CaliperUtils.resolvePath(networkConfig, workspace_root);
             this.network = CaliperUtils.parseYaml(configPath);
         } else if (typeof networkConfig === 'object' && networkConfig !== null) {
             // clone the object to prevent modification by other objects
@@ -205,16 +205,16 @@ class Fabric extends BlockchainInterface {
      * @private
      */
     _assembleTargetEventSources(channel, targetPeers) {
-        let eventSources = [];
+        const eventSources = [];
         if (this.networkUtil.isInCompatibilityMode()) {
             // NOTE: for old event hubs we have a single connection to every peer set as an event source
             const EventHub = require('fabric-client/lib/EventHub.js');
 
-            for (let peer of targetPeers) {
-                let org = this.networkUtil.getOrganizationOfPeer(peer);
-                let admin = this.adminProfiles.get(org);
+            for (const peer of targetPeers) {
+                const org = this.networkUtil.getOrganizationOfPeer(peer);
+                const admin = this.adminProfiles.get(org);
 
-                let eventHub = new EventHub(admin);
+                const eventHub = new EventHub(admin);
                 eventHub.setPeerAddr(this.networkUtil.getPeerEventUrl(peer),
                     this.networkUtil.getGrpcOptionsOfPeer(peer));
 
@@ -225,11 +225,11 @@ class Fabric extends BlockchainInterface {
                 });
             }
         } else {
-            for (let peer of targetPeers) {
-                let org = this.networkUtil.getOrganizationOfPeer(peer);
-                let admin = this.adminProfiles.get(org);
+            for (const peer of targetPeers) {
+                const org = this.networkUtil.getOrganizationOfPeer(peer);
+                const admin = this.adminProfiles.get(org);
 
-                let eventHub = admin.getChannel(channel, true).newChannelEventHub(peer);
+                const eventHub = admin.getChannel(channel, true).newChannelEventHub(peer);
 
                 eventSources.push({
                     channel: [channel], // unused during chaincode instantiation
@@ -251,14 +251,14 @@ class Fabric extends BlockchainInterface {
      * @private
      */
     _assembleRandomTargetPeers(channel, chaincodeId, chaincodeVersion) {
-        let targets = [];
-        let chaincodeOrgs = this.randomTargetPeerCache.get(channel).get(`${chaincodeId}@${chaincodeVersion}`);
+        const targets = [];
+        const chaincodeOrgs = this.randomTargetPeerCache.get(channel).get(`${chaincodeId}@${chaincodeVersion}`);
 
-        for (let entries of chaincodeOrgs.entries()) {
-            let peers = entries[1];
+        for (const entries of chaincodeOrgs.entries()) {
+            const peers = entries[1];
 
             // represents the load balancing mechanism
-            let loadBalancingCounter = this.configClientBasedLoadBalancing ? this.clientIndex : this.txIndex;
+            const loadBalancingCounter = this.configClientBasedLoadBalancing ? this.clientIndex : this.txIndex;
             targets.push(peers[loadBalancingCounter % peers.length]);
         }
 
@@ -272,11 +272,11 @@ class Fabric extends BlockchainInterface {
      * @async
      */
     async _createChannels() {
-        let channels = this.networkUtil.getChannels();
+        const channels = this.networkUtil.getChannels();
         let channelCreated = false;
 
-        for (let channel of channels) {
-            let channelObject = this.networkUtil.getNetworkObject().channels[channel];
+        for (const channel of channels) {
+            const channelObject = this.networkUtil.getNetworkObject().channels[channel];
 
             if (CaliperUtils.checkProperty(channelObject, 'created') && channelObject.created) {
                 logger.info(`Channel '${channel}' is configured as created, skipping creation`);
@@ -304,10 +304,10 @@ class Fabric extends BlockchainInterface {
             }
 
             // NOTE: without knowing the system channel policies, signing with every org admin is a safe bet
-            let orgs = this.networkUtil.getOrganizationsOfChannel(channel);
+            const orgs = this.networkUtil.getOrganizationsOfChannel(channel);
             let admin; // declared here to keep the admin of the last org of the channel
-            let signatures = [];
-            for (let org of orgs) {
+            const signatures = [];
+            for (const org of orgs) {
                 admin = this.adminProfiles.get(org);
                 try {
                     signatures.push(admin.signChannelConfig(configUpdate));
@@ -316,8 +316,8 @@ class Fabric extends BlockchainInterface {
                 }
             }
 
-            let txId = admin.newTransactionID(true);
-            let request = {
+            const txId = admin.newTransactionID(true);
+            const request = {
                 config: configUpdate,
                 signatures: signatures,
                 name: channel,
@@ -326,7 +326,7 @@ class Fabric extends BlockchainInterface {
 
             try {
                 /** @link{BroadcastResponse} */
-                let broadcastResponse = await admin.createChannel(request);
+                const broadcastResponse = await admin.createChannel(request);
 
                 CaliperUtils.assertDefined(broadcastResponse, `The returned broadcast response for creating Channel '${channel}' is undefined`);
                 CaliperUtils.assertProperty(broadcastResponse, 'broadcastResponse', 'status');
@@ -356,13 +356,13 @@ class Fabric extends BlockchainInterface {
      */
     _createEventRegistrationPromise(eventSource, txId, invokeStatus, startTime, timeout) {
         return new Promise(resolve => {
-            let handle = setTimeout(() => {
+            const handle = setTimeout(() => {
                 // give the other event hub connections a chance
                 // to verify the Tx status, so resolve the promise
 
                 eventSource.eventHub.unregisterTxEvent(txId);
 
-                let time = Date.now();
+                const time = Date.now();
                 invokeStatus.Set(`commit_timeout_${eventSource.peer}`, 'TIMEOUT');
 
                 // resolve the failed transaction with the current time and error message
@@ -375,7 +375,7 @@ class Fabric extends BlockchainInterface {
 
             eventSource.eventHub.registerTxEvent(txId, (tx, code) => {
                 clearTimeout(handle);
-                let time = Date.now();
+                const time = Date.now();
                 eventSource.eventHub.unregisterTxEvent(txId);
 
                 // either explicit invalid event or valid event, verified in both cases by at least one peer
@@ -401,7 +401,7 @@ class Fabric extends BlockchainInterface {
             }, (err) => {
                 clearTimeout(handle);
                 eventSource.eventHub.unregisterTxEvent(txId);
-                let time = Date.now();
+                const time = Date.now();
 
                 // we don't know what happened, but give the other event hub connections a chance
                 // to verify the Tx status, so resolve this promise
@@ -455,7 +455,7 @@ class Fabric extends BlockchainInterface {
     async _enrollUser(profile, id, secret, profileName) {
         // this call will throw an error if the CA configuration is not found
         // this error should propagate up
-        let ca = profile.getCertificateAuthority();
+        const ca = profile.getCertificateAuthority();
         try {
             return await ca.enroll({
                 enrollmentID: id,
@@ -594,7 +594,7 @@ class Fabric extends BlockchainInterface {
      */
     _getChannelConfigFromFile(channelObject, channelName) {
         // extracting the config from the binary file
-        let binaryPath = CaliperUtils.resolvePath(channelObject.configBinary, this.workspaceRoot);
+        const binaryPath = CaliperUtils.resolvePath(channelObject.configBinary, this.workspaceRoot);
         let envelopeBytes;
 
         try {
@@ -617,10 +617,10 @@ class Fabric extends BlockchainInterface {
      * @private
      */
     _getRandomTargetOrderer(channel) {
-        let orderers = this.randomTargetOrdererCache.get(channel);
+        const orderers = this.randomTargetOrdererCache.get(channel);
 
         // represents the load balancing mechanism
-        let loadBalancingCounter = this.configClientBasedLoadBalancing ? this.clientIndex : this.txIndex;
+        const loadBalancingCounter = this.configClientBasedLoadBalancing ? this.clientIndex : this.txIndex;
 
         return orderers[loadBalancingCounter % orderers.length];
     }
@@ -669,14 +669,14 @@ class Fabric extends BlockchainInterface {
      * @async
      */
     async _initializeAdmins(workerInit) {
-        let orgs = this.networkUtil.getOrganizations();
-        for (let org of orgs) {
-            let adminName = `admin.${org}`;
+        const orgs = this.networkUtil.getOrganizations();
+        for (const org of orgs) {
+            const adminName = `admin.${org}`;
             // build the common part of the profile
-            let adminProfile = await this._prepareClientProfile(org, undefined, `${org}'s admin`);
+            const adminProfile = await this._prepareClientProfile(org, undefined, `${org}'s admin`);
 
             // Check if the materials already exist locally in file system key-value stores.
-            let admin = await this._getUserContext(adminProfile, adminName, `${org}'s admin`);
+            const admin = await this._getUserContext(adminProfile, adminName, `${org}'s admin`);
             if (admin) {
                 this.adminProfiles.set(org, adminProfile);
 
@@ -716,16 +716,16 @@ class Fabric extends BlockchainInterface {
      */
     async _initializeChannel(profiles, channel, admin) {
         // initialize the channel for every client profile from the local config
-        for (let profile of profiles.entries()) {
-            let profileOrg = admin ? profile[0] : this.networkUtil.getOrganizationOfClient(profile[0]);
-            let channelOrgs = this.networkUtil.getOrganizationsOfChannel(channel);
+        for (const profile of profiles.entries()) {
+            const profileOrg = admin ? profile[0] : this.networkUtil.getOrganizationOfClient(profile[0]);
+            const channelOrgs = this.networkUtil.getOrganizationsOfChannel(channel);
 
             // skip init for profiles whose org is a not a member of the channel
             if (!channelOrgs.has(profileOrg)) {
                 continue;
             }
 
-            let ch = profile[1].getChannel(channel, false);
+            const ch = profile[1].getChannel(channel, false);
             if (ch) {
                 try {
                     await ch.initialize();
@@ -745,10 +745,10 @@ class Fabric extends BlockchainInterface {
      * @async
      */
     async _initializeRegistrars(workerInit) {
-        let orgs = this.networkUtil.getOrganizations();
-        for (let org of orgs) {
+        const orgs = this.networkUtil.getOrganizations();
+        for (const org of orgs) {
 
-            let registrarInfo = this.networkUtil.getRegistrarOfOrganization(org);
+            const registrarInfo = this.networkUtil.getRegistrarOfOrganization(org);
             if (!registrarInfo) {
                 if (!workerInit) {
                     logger.warn(`${org}'s registrar information not provided.`);
@@ -757,9 +757,9 @@ class Fabric extends BlockchainInterface {
             }
 
             // build the common part of the profile
-            let registrarProfile = await this._prepareClientProfile(org, undefined, 'registrar');
+            const registrarProfile = await this._prepareClientProfile(org, undefined, 'registrar');
             // check if the materials already exist locally in th efile system key-value stores
-            let registrar = await this._getUserContext(registrarProfile, registrarInfo.enrollId, `${org}'s registrar`);
+            const registrar = await this._getUserContext(registrarProfile, registrarInfo.enrollId, `${org}'s registrar`);
 
             if (registrar) {
                 if (!workerInit) {
@@ -788,18 +788,18 @@ class Fabric extends BlockchainInterface {
      * @async
      */
     async _initializeUsers(workerInit) {
-        let clients = this.networkUtil.getClients();
+        const clients = this.networkUtil.getClients();
 
         // register and enroll each client with its organization's CA
-        for (let client of clients) {
-            let org = this.networkUtil.getOrganizationOfClient(client);
+        for (const client of clients) {
+            const org = this.networkUtil.getOrganizationOfClient(client);
 
             // create the profile based on the connection profile
-            let clientProfile = await this._prepareClientProfile(org, client, client);
+            const clientProfile = await this._prepareClientProfile(org, client, client);
             this.clientProfiles.set(client, clientProfile);
 
             // check if the materials already exist locally in the file system key-value stores
-            let user = await this._getUserContext(clientProfile, client, client);
+            const user = await this._getUserContext(clientProfile, client, client);
             if (user) {
                 if (this.networkUtil.isMutualTlsEnabled()) {
                     // "retrieve" and set the deserialized cert and key
@@ -820,7 +820,7 @@ class Fabric extends BlockchainInterface {
                 await this._createUser(clientProfile, org, client, cryptoContent, client);
                 if (this.networkUtil.isMutualTlsEnabled()) {
                     // the materials are included in the configuration file
-                    let crypto = this.networkUtil.getClientCryptoContent(client);
+                    const crypto = this.networkUtil.getClientCryptoContent(client);
                     clientProfile.setTlsClientCertAndKey(crypto.signedCertPEM.toString(), crypto.privateKeyPEM.toString());
                 }
 
@@ -834,9 +834,9 @@ class Fabric extends BlockchainInterface {
             // The user needs to be enrolled or even registered
 
             // if the enrollment ID and secret is provided, then enroll the already registered user
-            let enrollmentSecret = this.networkUtil.getClientEnrollmentSecret(client);
+            const enrollmentSecret = this.networkUtil.getClientEnrollmentSecret(client);
             if (enrollmentSecret) {
-                let enrollment = await this._enrollUser(clientProfile, client, enrollmentSecret, client);
+                const enrollment = await this._enrollUser(clientProfile, client, enrollmentSecret, client);
 
                 // create the new user based on the retrieved materials
                 await this._createUser(clientProfile, org, client,
@@ -860,22 +860,22 @@ class Fabric extends BlockchainInterface {
             // Otherwise, register then enroll the user
             let secret;
             try {
-                let registrarProfile = this.registrarProfiles.get(org);
+                const registrarProfile = this.registrarProfiles.get(org);
 
                 if (!registrarProfile) {
                     throw new Error(`Registrar identity is not provided for ${org}`);
                 }
 
-                let registrarInfo = this.networkUtil.getRegistrarOfOrganization(org);
-                let registrar = await registrarProfile.getUserContext(registrarInfo.enrollId, true);
+                const registrarInfo = this.networkUtil.getRegistrarOfOrganization(org);
+                const registrar = await registrarProfile.getUserContext(registrarInfo.enrollId, true);
                 // this call will throw an error if the CA configuration is not found
                 // this error should propagate up
-                let ca = clientProfile.getCertificateAuthority();
-                let userAffiliation = this.networkUtil.getAffiliationOfUser(client);
+                const ca = clientProfile.getCertificateAuthority();
+                const userAffiliation = this.networkUtil.getAffiliationOfUser(client);
 
                 // if not in compatibility mode (i.e., at least SDK v1.1), check whether the affiliation is already registered or not
                 if (!this.networkUtil.isInCompatibilityMode()) {
-                    let affService = ca.newAffiliationService();
+                    const affService = ca.newAffiliationService();
                     let affiliationExists = false;
                     try {
                         await affService.getOne(userAffiliation, registrar);
@@ -894,7 +894,7 @@ class Fabric extends BlockchainInterface {
                     }
                 }
 
-                let attributes = this.networkUtil.getAttributesOfUser(client);
+                const attributes = this.networkUtil.getAttributesOfUser(client);
                 attributes.push({name: 'hf.Registrar.Roles', value: 'client'});
 
                 secret = await ca.register({
@@ -911,7 +911,7 @@ class Fabric extends BlockchainInterface {
                 logger.info(`${client} successfully registered`);
             }
 
-            let enrollment = await this._enrollUser(clientProfile, client, secret, client);
+            const enrollment = await this._enrollUser(clientProfile, client, secret, client);
 
             // create the new user based on the retrieved materials
             await this._createUser(clientProfile, org, client,
@@ -939,34 +939,34 @@ class Fabric extends BlockchainInterface {
             process.env.GOPATH = CaliperUtils.resolvePath('.', this.workspaceRoot);
         }
 
-        let errors = [];
+        const errors = [];
 
-        let channels = this.networkUtil.getChannels();
-        for (let channel of channels) {
+        const channels = this.networkUtil.getChannels();
+        for (const channel of channels) {
             logger.info(`Installing chaincodes for ${channel}...`);
 
             // proceed cc by cc for the channel
-            let chaincodeInfos = this.networkUtil.getChaincodesOfChannel(channel);
-            for (let chaincodeInfo of chaincodeInfos) {
-                let ccObject = this.networkUtil.getNetworkObject().channels[channel].chaincodes.find(
+            const chaincodeInfos = this.networkUtil.getChaincodesOfChannel(channel);
+            for (const chaincodeInfo of chaincodeInfos) {
+                const ccObject = this.networkUtil.getNetworkObject().channels[channel].chaincodes.find(
                     cc => cc.id === chaincodeInfo.id && cc.version === chaincodeInfo.version);
 
-                let targetPeers = this.networkUtil.getTargetPeersOfChaincodeOfChannel(chaincodeInfo, channel);
+                const targetPeers = this.networkUtil.getTargetPeersOfChaincodeOfChannel(chaincodeInfo, channel);
                 if (targetPeers.size < 1) {
                     logger.info(`No target peers are defined for ${chaincodeInfo.id}@${chaincodeInfo.version} on ${channel}, skipping it`);
                     continue;
                 }
 
                 // find the peers that don't have the cc installed
-                let installTargets = [];
+                const installTargets = [];
 
-                for (let peer of targetPeers) {
-                    let org = this.networkUtil.getOrganizationOfPeer(peer);
-                    let admin = this.adminProfiles.get(org);
+                for (const peer of targetPeers) {
+                    const org = this.networkUtil.getOrganizationOfPeer(peer);
+                    const admin = this.adminProfiles.get(org);
 
                     try {
                         /** {@link ChaincodeQueryResponse} */
-                        let resp = await admin.queryInstalledChaincodes(peer, true);
+                        const resp = await admin.queryInstalledChaincodes(peer, true);
                         if (resp.chaincodes.some(cc => cc.name === chaincodeInfo.id && cc.version === chaincodeInfo.version)) {
                             logger.info(`${chaincodeInfo.id}@${chaincodeInfo.version} is already installed on ${peer}`);
                             continue;
@@ -980,7 +980,7 @@ class Fabric extends BlockchainInterface {
 
                 if (errors.length > 0) {
                     let errorMsg = `Could not query whether ${chaincodeInfo.id}@${chaincodeInfo.version} is installed on some peers of ${channel}:`;
-                    for (let err of errors) {
+                    for (const err of errors) {
                         errorMsg += `\n\t- ${err.message}`;
                     }
 
@@ -994,22 +994,22 @@ class Fabric extends BlockchainInterface {
                 }
 
                 // install chaincodes org by org
-                let orgs = this.networkUtil.getOrganizationsOfChannel(channel);
-                for (let org of orgs) {
-                    let peersOfOrg = this.networkUtil.getPeersOfOrganization(org);
+                const orgs = this.networkUtil.getOrganizationsOfChannel(channel);
+                for (const org of orgs) {
+                    const peersOfOrg = this.networkUtil.getPeersOfOrganization(org);
                     // selecting the target peers for this org
-                    let orgPeerTargets = installTargets.filter(p => peersOfOrg.has(p));
+                    const orgPeerTargets = installTargets.filter(p => peersOfOrg.has(p));
 
                     // cc is installed on every target peer of the org in the channel
                     if (orgPeerTargets.length < 1) {
                         continue;
                     }
 
-                    let admin = this.adminProfiles.get(org);
+                    const admin = this.adminProfiles.get(org);
 
-                    let txId = admin.newTransactionID(true);
+                    const txId = admin.newTransactionID(true);
                     /** @{ChaincodeInstallRequest} */
-                    let request = {
+                    const request = {
                         targets: orgPeerTargets,
                         chaincodePath: ccObject.language === 'golang' ? ccObject.path : CaliperUtils.resolvePath(ccObject.path, this.workspaceRoot),
                         chaincodeId: ccObject.id,
@@ -1030,16 +1030,16 @@ class Fabric extends BlockchainInterface {
                     // install to necessary peers of org and process the results
                     try {
                         /** @link{ProposalResponseObject} */
-                        let propRespObject = await admin.installChaincode(request);
+                        const propRespObject = await admin.installChaincode(request);
                         CaliperUtils.assertDefined(propRespObject);
 
                         /** Array of @link{ProposalResponse} objects */
-                        let proposalResponses = propRespObject[0];
+                        const proposalResponses = propRespObject[0];
                         CaliperUtils.assertDefined(proposalResponses);
 
                         proposalResponses.forEach((propResponse, index) => {
                             if (propResponse instanceof Error) {
-                                let errMsg = `Install proposal error for ${chaincodeInfo.id}@${chaincodeInfo.version} on ${orgPeerTargets[index]}: ${propResponse.message}`;
+                                const errMsg = `Install proposal error for ${chaincodeInfo.id}@${chaincodeInfo.version} on ${orgPeerTargets[index]}: ${propResponse.message}`;
                                 errors.push(new Error(errMsg));
                                 return;
                             }
@@ -1048,11 +1048,11 @@ class Fabric extends BlockchainInterface {
                             CaliperUtils.assertProperty(propResponse, 'propResponse', 'response');
 
                             /** @link{ResponseObject} */
-                            let response = propResponse.response;
+                            const response = propResponse.response;
                             CaliperUtils.assertProperty(response, 'response', 'status');
 
                             if (response.status !== 200) {
-                                let errMsg = `Unsuccessful install status for ${chaincodeInfo.id}@${chaincodeInfo.version} on ${orgPeerTargets[index]}: ${propResponse.response.message}`;
+                                const errMsg = `Unsuccessful install status for ${chaincodeInfo.id}@${chaincodeInfo.version} on ${orgPeerTargets[index]}: ${propResponse.response.message}`;
                                 errors.push(new Error(errMsg));
                             }
                         });
@@ -1070,7 +1070,7 @@ class Fabric extends BlockchainInterface {
 
                 if (errors.length > 0) {
                     let errorMsg = `Could not install ${chaincodeInfo.id}@${chaincodeInfo.version} on some peers of ${channel}:`;
-                    for (let err of errors) {
+                    for (const err of errors) {
                         errorMsg += `\n\t- ${err.message}`;
                     }
 
@@ -1088,20 +1088,20 @@ class Fabric extends BlockchainInterface {
      * @async
      */
     async _instantiateChaincodes() {
-        let channels = this.networkUtil.getChannels();
+        const channels = this.networkUtil.getChannels();
         let chaincodeInstantiated = false;
 
         // chaincodes needs to be installed channel by channel
-        for (let channel of channels) {
-            let chaincodeInfos = this.networkUtil.getChaincodesOfChannel(channel);
+        for (const channel of channels) {
+            const chaincodeInfos = this.networkUtil.getChaincodesOfChannel(channel);
 
-            for (let chaincodeInfo of chaincodeInfos) {
+            for (const chaincodeInfo of chaincodeInfos) {
                 logger.info(`Instantiating ${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel}. This might take some time...`);
 
-                let ccObject = this.networkUtil.getNetworkObject().channels[channel].chaincodes.find(
+                const ccObject = this.networkUtil.getNetworkObject().channels[channel].chaincodes.find(
                     cc => cc.id === chaincodeInfo.id && cc.version === chaincodeInfo.version);
 
-                let targetPeers = Array.from(this.networkUtil.getTargetPeersOfChaincodeOfChannel(chaincodeInfo, channel));
+                const targetPeers = Array.from(this.networkUtil.getTargetPeersOfChaincodeOfChannel(chaincodeInfo, channel));
                 if (targetPeers.length < 1) {
                     logger.info(`No target peers are defined for ${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel}, skipping it`);
                     continue;
@@ -1110,8 +1110,8 @@ class Fabric extends BlockchainInterface {
                 // select a target peer for the chaincode to see if it's instantiated
                 // these are the same as the install targets, so if one of the peers has already instantiated the chaincode,
                 // then the other targets also had done the same
-                let org = this.networkUtil.getOrganizationOfPeer(targetPeers[0]);
-                let admin = this.adminProfiles.get(org);
+                const org = this.networkUtil.getOrganizationOfPeer(targetPeers[0]);
+                const admin = this.adminProfiles.get(org);
 
                 /** @link{ChaincodeQueryResponse} */
                 let queryResponse;
@@ -1132,9 +1132,9 @@ class Fabric extends BlockchainInterface {
 
                 chaincodeInstantiated = true;
 
-                let txId = admin.newTransactionID(true);
+                const txId = admin.newTransactionID(true);
                 /** @link{ChaincodeInstantiateUpgradeRequest} */
-                let request = {
+                const request = {
                     targets: targetPeers,
                     chaincodeId: ccObject.id,
                     chaincodeVersion: ccObject.version,
@@ -1183,9 +1183,9 @@ class Fabric extends BlockchainInterface {
                 CaliperUtils.assertDefined(response);
 
                 /** @link{Array<ProposalResponse>} */
-                let proposalResponses = response[0];
+                const proposalResponses = response[0];
                 /** @link{Proposal} */
-                let proposal = response[1];
+                const proposal = response[1];
                 CaliperUtils.assertDefined(proposalResponses);
                 CaliperUtils.assertDefined(proposal);
 
@@ -1201,15 +1201,15 @@ class Fabric extends BlockchainInterface {
                 });
 
                 // connect to every event source of every org in the channel
-                let eventSources = this._assembleTargetEventSources(channel, targetPeers);
-                let eventPromises = [];
+                const eventSources = this._assembleTargetEventSources(channel, targetPeers);
+                const eventPromises = [];
 
                 try {
                     // NOTE: everything is resolved, errors are signaled through an Error object
                     // this makes error handling and reporting easier
                     eventSources.forEach((es) => {
-                        let promise = new Promise((resolve) => {
-                            let timeoutHandle = setTimeout(() => {
+                        const promise = new Promise((resolve) => {
+                            const timeoutHandle = setTimeout(() => {
                                 // unregister manually
                                 es.eventHub.unregisterTxEvent(txId.getTransactionID(), false);
                                 resolve(new Error(`Commit timeout for ${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel} from ${es.peer}`));
@@ -1234,7 +1234,7 @@ class Fabric extends BlockchainInterface {
                     });
 
                     /** @link{TransactionRequest} */
-                    let ordererRequest = {
+                    const ordererRequest = {
                         txId: txId,
                         proposalResponses: proposalResponses,
                         proposal: proposal
@@ -1256,13 +1256,13 @@ class Fabric extends BlockchainInterface {
                     }
 
                     // since every event promise is resolved, this shouldn't throw an error
-                    let eventResults = await Promise.all(eventPromises);
+                    const eventResults = await Promise.all(eventPromises);
 
                     // if we received an error, propagate it
                     if (eventResults.some(er => er instanceof Error)) {
                         let errMsg = `The following errors occured while instantiating ${chaincodeInfo.id}@${chaincodeInfo.version} in ${channel}:`;
                         let err; // keep the last error
-                        for (let eventResult of eventResults) {
+                        for (const eventResult of eventResults) {
                             if (eventResult instanceof Error) {
                                 err = eventResult;
                                 errMsg += `\n\t- ${eventResult.message}`;
@@ -1294,25 +1294,25 @@ class Fabric extends BlockchainInterface {
      * @async
      */
     async _joinChannels() {
-        let channels = this.networkUtil.getChannels();
+        const channels = this.networkUtil.getChannels();
         let channelJoined = false;
-        let errors = [];
+        const errors = [];
 
-        for (let channelName of channels) {
+        for (const channelName of channels) {
             let genesisBlock = null;
-            let orgs = this.networkUtil.getOrganizationsOfChannel(channelName);
+            const orgs = this.networkUtil.getOrganizationsOfChannel(channelName);
 
-            for (let org of orgs) {
-                let admin = this.adminProfiles.get(org);
-                let channelObject = admin.getChannel(channelName, true);
+            for (const org of orgs) {
+                const admin = this.adminProfiles.get(org);
+                const channelObject = admin.getChannel(channelName, true);
 
-                let peers = this.networkUtil.getPeersOfOrganizationAndChannel(org, channelName);
-                let peersToJoin = [];
+                const peers = this.networkUtil.getPeersOfOrganizationAndChannel(org, channelName);
+                const peersToJoin = [];
 
-                for (let peer of peers) {
+                for (const peer of peers) {
                     try {
                         /** {@link ChannelQueryResponse} */
-                        let resp = await admin.queryChannels(peer, true);
+                        const resp = await admin.queryChannels(peer, true);
                         if (resp.channels.some(ch => ch.channel_id === channelName)) {
                             logger.info(`${peer} has already joined ${channelName}`);
                             continue;
@@ -1326,7 +1326,7 @@ class Fabric extends BlockchainInterface {
 
                 if (errors.length > 0) {
                     let errMsg = `The following errors occurred while querying ${channelName} information from ${org}'s peers:`;
-                    for (let err of errors) {
+                    for (const err of errors) {
                         errMsg += `\n\t- ${err.message}`;
                     }
 
@@ -1344,9 +1344,9 @@ class Fabric extends BlockchainInterface {
                 // only retrieve the genesis block once, and "cache" it
                 if (genesisBlock === null) {
                     try {
-                        let genesisTxId = admin.newTransactionID(true);
+                        const genesisTxId = admin.newTransactionID(true);
                         /** @link{OrdererRequest} */
-                        let genesisRequest = {
+                        const genesisRequest = {
                             txId: genesisTxId
                         };
                         genesisBlock = await channelObject.getGenesisBlock(genesisRequest);
@@ -1355,8 +1355,8 @@ class Fabric extends BlockchainInterface {
                     }
                 }
 
-                let joinTxId = admin.newTransactionID(true);
-                let joinRequest = {
+                const joinTxId = admin.newTransactionID(true);
+                const joinRequest = {
                     block: genesisBlock,
                     txId: joinTxId,
                     targets: peersToJoin
@@ -1364,7 +1364,7 @@ class Fabric extends BlockchainInterface {
 
                 try {
                     /**{@link ProposalResponse} array*/
-                    let joinRespArray = await channelObject.joinChannel(joinRequest);
+                    const joinRespArray = await channelObject.joinChannel(joinRequest);
                     CaliperUtils.assertDefined(joinRespArray);
 
                     // Some errors are returned as Error instances, some as error messages
@@ -1381,7 +1381,7 @@ class Fabric extends BlockchainInterface {
 
                 if (errors.length > 0) {
                     let errMsg = `The following errors occurred while ${org}'s peers tried to join ${channelName}:`;
-                    for (let err of errors) {
+                    for (const err of errors) {
                         errMsg += `\n\t- ${err.message}`;
                     }
 
@@ -1402,24 +1402,24 @@ class Fabric extends BlockchainInterface {
      */
     _prepareCaches() {
         // assemble random target peer cache for each channel's each chaincode
-        for (let channel of this.networkUtil.getChannels()) {
+        for (const channel of this.networkUtil.getChannels()) {
             this.randomTargetPeerCache.set(channel, new Map());
 
-            for (let chaincode of this.networkUtil.getChaincodesOfChannel(channel)) {
-                let idAndVersion = `${chaincode.id}@${chaincode.version}`;
+            for (const chaincode of this.networkUtil.getChaincodesOfChannel(channel)) {
+                const idAndVersion = `${chaincode.id}@${chaincode.version}`;
                 this.randomTargetPeerCache.get(channel).set(idAndVersion, new Map());
 
-                let targetOrgs = new Set();
-                let targetPeers = this.networkUtil.getTargetPeersOfChaincodeOfChannel(chaincode, channel);
+                const targetOrgs = new Set();
+                const targetPeers = this.networkUtil.getTargetPeersOfChaincodeOfChannel(chaincode, channel);
 
                 // get target orgs
-                for (let peer of targetPeers) {
+                for (const peer of targetPeers) {
                     targetOrgs.add(this.networkUtil.getOrganizationOfPeer(peer));
                 }
 
                 // set target peers in each org
-                for (let org of targetOrgs) {
-                    let peersOfOrg = this.networkUtil.getPeersOfOrganizationAndChannel(org, channel);
+                for (const org of targetOrgs) {
+                    const peersOfOrg = this.networkUtil.getPeersOfOrganizationAndChannel(org, channel);
 
                     // the peers of the org that target the given chaincode of the given channel
                     // one of these peers needs to be a target for every org
@@ -1430,7 +1430,7 @@ class Fabric extends BlockchainInterface {
         }
 
         // assemble random target orderer cache for each channel
-        for (let channel of this.networkUtil.getChannels()) {
+        for (const channel of this.networkUtil.getChannels()) {
             this.randomTargetOrdererCache.set(channel, Array.from(this.networkUtil.getOrderersOfChannel(channel)));
         }
     }
@@ -1450,7 +1450,7 @@ class Fabric extends BlockchainInterface {
         if (!client) {
             CaliperUtils.assertDefined(org);
             // base it on the first client connection profile of the org
-            let clients = this.networkUtil.getClientsOfOrganization(org);
+            const clients = this.networkUtil.getClientsOfOrganization(org);
 
             // NOTE: this assumes at least one client per org, which is reasonable, the clients will interact with the network
             if (clients.size < 1) {
@@ -1484,8 +1484,8 @@ class Fabric extends BlockchainInterface {
      * @private
      */
     _setTlsAdminCertAndKey(org) {
-        let profile = this.adminProfiles.get(org);
-        let crypto = this.networkUtil.getAdminCryptoContentOfOrganization(org);
+        const profile = this.adminProfiles.get(org);
+        const crypto = this.networkUtil.getAdminCryptoContentOfOrganization(org);
         profile.setTlsClientCertAndKey(crypto.signedCertPEM.toString(), crypto.privateKeyPEM.toString());
     }
 
@@ -1519,10 +1519,10 @@ class Fabric extends BlockchainInterface {
      * @return {Promise<TxStatus>} The result and stats of the transaction query.
      */
     async _submitSingleQuery(context, querySettings, timeout) {
-        let startTime = Date.now();
+        const startTime = Date.now();
         this.txIndex++;
 
-        let countAsLoad = querySettings.countAsLoad === undefined ? this.configCountQueryAsLoad : querySettings.countAsLoad;
+        const countAsLoad = querySettings.countAsLoad === undefined ? this.configCountQueryAsLoad : querySettings.countAsLoad;
 
         // retrieve the necessary client/admin profile
         let invoker;
@@ -1543,7 +1543,7 @@ class Fabric extends BlockchainInterface {
         const txIdObject = invoker.newTransactionID(admin);
         const txId = txIdObject.getTransactionID();
 
-        let invokeStatus = new TxStatus(txId);
+        const invokeStatus = new TxStatus(txId);
         invokeStatus.Set('request_type', 'query');
         invokeStatus.SetVerification(true); // querying is a one-step process unlike a normal transaction, so the result is always verified
 
@@ -1551,7 +1551,7 @@ class Fabric extends BlockchainInterface {
         // SEND TRANSACTION PROPOSALS //
         ////////////////////////////////
 
-        let targetPeers = querySettings.targetPeers ||
+        const targetPeers = querySettings.targetPeers ||
             this._assembleRandomTargetPeers(querySettings.channel, querySettings.chaincodeId, querySettings.chaincodeVersion);
 
         /** @link{ChaincodeInvokeRequest} */
@@ -1564,7 +1564,7 @@ class Fabric extends BlockchainInterface {
         };
 
         // the exception should propagate up for an invalid channel name, indicating a user callback module error
-        let channel = invoker.getChannel(querySettings.channel, true);
+        const channel = invoker.getChannel(querySettings.channel, true);
 
         if (countAsLoad && context.engine) {
             context.engine.submitCallback(1);
@@ -1577,12 +1577,12 @@ class Fabric extends BlockchainInterface {
         // no exception should escape, query failures have to be handled gracefully
         try {
             // NOTE: wrap it in a Promise to enforce user-provided timeout
-            let resultPromise = new Promise(async (resolve, reject) => {
-                let timeoutHandle = setTimeout(() => {
+            const resultPromise = new Promise(async (resolve, reject) => {
+                const timeoutHandle = setTimeout(() => {
                     reject(new Error('TIMEOUT'));
                 }, this._getRemainingTimeout(startTime, timeout));
 
-                let result = await channel.queryByChaincode(proposalRequest, admin);
+                const result = await channel.queryByChaincode(proposalRequest, admin);
                 clearTimeout(timeoutHandle);
                 resolve(result);
             });
@@ -1597,7 +1597,7 @@ class Fabric extends BlockchainInterface {
 
             // filter for errors inside, so we have accurate indices for the corresponding peers
             results.forEach((value, index) => {
-                let targetName = targetPeers[index];
+                const targetName = targetPeers[index];
                 if (value instanceof Error) {
                     invokeStatus.Set(`endorsement_result_error_${targetName}`, value.message);
                     errMsg = `\n\t- Endorsement error from ${targetName}: ${value.message}`;
@@ -1662,16 +1662,16 @@ class Fabric extends BlockchainInterface {
         const txId = txIdObject.getTransactionID();
 
         // timestamps are recorded for every phase regardless of success/failure
-        let invokeStatus = new TxStatus(txId);
+        const invokeStatus = new TxStatus(txId);
         invokeStatus.Set('request_type', 'transaction');
 
-        let errors = []; // errors are collected during response validations
+        const errors = []; // errors are collected during response validations
 
         ////////////////////////////////
         // SEND TRANSACTION PROPOSALS //
         ////////////////////////////////
 
-        let targetPeers = invokeSettings.targetPeers ||
+        const targetPeers = invokeSettings.targetPeers ||
             this._assembleRandomTargetPeers(invokeSettings.channel, invokeSettings.chaincodeId, invokeSettings.chaincodeVersion);
 
         /** @link{ChaincodeInvokeRequest} */
@@ -1684,7 +1684,7 @@ class Fabric extends BlockchainInterface {
             targets: targetPeers
         };
 
-        let channel = invoker.getChannel(invokeSettings.channel, true);
+        const channel = invoker.getChannel(invokeSettings.channel, true);
 
         /** @link{ProposalResponseObject} */
         let proposalResponseObject = null;
@@ -1723,7 +1723,7 @@ class Fabric extends BlockchainInterface {
 
             // NOTES: filter inside, so we have accurate indices corresponding to the original target peers
             proposalResponses.forEach((value, index) => {
-                let targetName = targetPeers[index];
+                const targetName = targetPeers[index];
 
                 // Errors from peers/chaincode are returned as an Error object
                 if (value instanceof Error) {
@@ -1736,7 +1736,7 @@ class Fabric extends BlockchainInterface {
                 }
 
                 /** @link{ProposalResponse} */
-                let proposalResponse = value;
+                const proposalResponse = value;
 
                 // save a chaincode results/response
                 // NOTE: the last one will be kept as result
@@ -1756,7 +1756,7 @@ class Fabric extends BlockchainInterface {
                 }
 
                 /** @link{ResponseObject} */
-                let responseObject = proposalResponse.response;
+                const responseObject = proposalResponse.response;
 
                 if (responseObject.status !== 200) {
                     invokeStatus.Set(`endorsement_result_error_${targetName}`, `${responseObject.status} ${responseObject.message}`);
@@ -1788,7 +1788,7 @@ class Fabric extends BlockchainInterface {
             // REGISTERING EVENT LISTENERS //
             /////////////////////////////////
 
-            let eventPromises = []; // to wait for every event response
+            const eventPromises = []; // to wait for every event response
 
             // NOTE: in compatibility mode, the same EventHub can be used for multiple channels
             // if the peer is part of multiple channels
@@ -1801,7 +1801,7 @@ class Fabric extends BlockchainInterface {
             // SUBMITTING TRANSACTION TO THE ORDERER //
             ///////////////////////////////////////////
 
-            let targetOrderer = invokeSettings.orderer || this._getRandomTargetOrderer(invokeSettings.channel);
+            const targetOrderer = invokeSettings.orderer || this._getRandomTargetOrderer(invokeSettings.channel);
             let orderer;
 
             if (typeof(targetOrderer) === 'string' || targetOrderer instanceof String) {
@@ -1823,12 +1823,12 @@ class Fabric extends BlockchainInterface {
             let broadcastResponse;
             try {
                 // wrap it in a Promise to add explicit timeout to the call
-                let responsePromise = new Promise(async (resolve, reject) => {
-                    let timeoutHandle = setTimeout(() => {
+                const responsePromise = new Promise(async (resolve, reject) => {
+                    const timeoutHandle = setTimeout(() => {
                         reject(new Error('TIMEOUT'));
                     }, this._getRemainingTimeout(startTime, timeout));
 
-                    let result = await channel.sendTransaction(transactionRequest);
+                    const result = await channel.sendTransaction(transactionRequest);
                     clearTimeout(timeoutHandle);
                     resolve(result);
                 });
@@ -1860,10 +1860,10 @@ class Fabric extends BlockchainInterface {
             //////////////////////////////
 
             // this shouldn't throw, otherwise the error handling is not robust
-            let eventResults = await Promise.all(eventPromises);
+            const eventResults = await Promise.all(eventPromises);
 
             // NOTE: this is the latency@threshold support described by the PSWG in their first paper
-            let failedNotifications = eventResults.filter(er => !er.successful);
+            const failedNotifications = eventResults.filter(er => !er.successful);
 
             // NOTE: an error from any peer indicates some problem, don't mask it;
             // although one successful transaction should be enough for "eventual" success;
@@ -1872,7 +1872,7 @@ class Fabric extends BlockchainInterface {
                 invokeStatus.SetStatusFail();
 
                 let logMsg = `Transaction[${txId.substring(0, 10)}] commit errors:`;
-                for (let commitErrors of failedNotifications) {
+                for (const commitErrors of failedNotifications) {
                     logMsg += `\n\t- ${commitErrors.message}`;
                 }
 
@@ -1882,7 +1882,7 @@ class Fabric extends BlockchainInterface {
                 eventResults.sort((a, b) => a.time - b.time);
 
                 // transform to (0,length] by *, then to (-1,length-1] by -, then to [0,length-1] by ceil
-                let thresholdIndex = Math.ceil(eventResults.length * this.configLatencyThreshold - 1);
+                const thresholdIndex = Math.ceil(eventResults.length * this.configLatencyThreshold - 1);
 
                 // every commit event contained a VALID code
                 // mark the time corresponding to the set threshold
@@ -1897,7 +1897,7 @@ class Fabric extends BlockchainInterface {
                 logger.error(`Transaction[${txId.substring(0, 10)}] unexpected error: ${err.stack ? err.stack : err}`);
             } else if (err.length > 0) {
                 let logMsg = `Transaction[${txId.substring(0, 10)}] life-cycle errors:`;
-                for (let execError of err) {
+                for (const execError of err) {
                     logMsg += `\n\t- ${execError.message}`;
                 }
 
@@ -1969,7 +1969,7 @@ class Fabric extends BlockchainInterface {
         this.txIndex = -1;
 
         // Configure the adaptor
-        for (let channel of this.networkUtil.getChannels()) {
+        for (const channel of this.networkUtil.getChannels()) {
             // initialize the channels by getting the config from the orderer
             await this._initializeChannel(this.adminProfiles, channel, true);
             await this._initializeChannel(this.clientProfiles, channel, false);
@@ -1979,11 +1979,11 @@ class Fabric extends BlockchainInterface {
             // NOTE: for old event hubs we have a single connection to every peer set as an event source
             const EventHub = require('fabric-client/lib/EventHub.js');
 
-            for (let peer of this.networkUtil.getAllEventSources()) {
-                let org = this.networkUtil.getOrganizationOfPeer(peer);
-                let admin = this.adminProfiles.get(org);
+            for (const peer of this.networkUtil.getAllEventSources()) {
+                const org = this.networkUtil.getOrganizationOfPeer(peer);
+                const admin = this.adminProfiles.get(org);
 
-                let eventHub = new EventHub(admin);
+                const eventHub = new EventHub(admin);
                 eventHub.setPeerAddr(this.networkUtil.getPeerEventUrl(peer),
                     this.networkUtil.getGrpcOptionsOfPeer(peer));
 
@@ -1997,17 +1997,17 @@ class Fabric extends BlockchainInterface {
         } else {
             // NOTE: for channel event hubs we might have multiple connections to a peer,
             // so connect to the defined event sources of every org in every channel
-            for (let channel of this.networkUtil.getChannels()) {
-                for (let org of this.networkUtil.getOrganizationsOfChannel(channel)) {
-                    let admin = this.adminProfiles.get(org);
+            for (const channel of this.networkUtil.getChannels()) {
+                for (const org of this.networkUtil.getOrganizationsOfChannel(channel)) {
+                    const admin = this.adminProfiles.get(org);
 
                     // The API for retrieving channel event hubs changed, from SDK v1.2 it expects the MSP ID of the org
-                    let orgId = this.version.lessThan('1.2.0') ? org : this.networkUtil.getMspIdOfOrganization(org);
+                    const orgId = this.version.lessThan('1.2.0') ? org : this.networkUtil.getMspIdOfOrganization(org);
 
-                    let eventHubs = admin.getChannel(channel, true).getChannelEventHubsForOrg(orgId);
+                    const eventHubs = admin.getChannel(channel, true).getChannelEventHubsForOrg(orgId);
 
                     // the peer (as an event source) is associated with exactly one channel in case of channel-level eventing
-                    for (let eventHub of eventHubs) {
+                    for (const eventHub of eventHubs) {
                         this.eventSources.push({
                             channel: [channel],
                             peer: this.networkUtil.getPeerNameOfEventHub(eventHub),
@@ -2025,18 +2025,18 @@ class Fabric extends BlockchainInterface {
         // rebuild the event source cache
         this.channelEventSourcesCache = new Map();
 
-        for (let es of this.eventSources) {
-            let channels = es.channel;
+        for (const es of this.eventSources) {
+            const channels = es.channel;
 
             // an event source can be used for multiple channels in compatibility mode
-            for (let c of channels) {
+            for (const c of channels) {
                 // initialize the cache for a channel with an empty array at the first time
                 if (!this.channelEventSourcesCache.has(c)) {
                     this.channelEventSourcesCache.set(c, []);
                 }
 
                 // add the event source to the channels collection
-                let eventSources = this.channelEventSourcesCache.get(c);
+                const eventSources = this.channelEventSourcesCache.get(c);
                 eventSources.push(es);
             }
         }
@@ -2053,9 +2053,9 @@ class Fabric extends BlockchainInterface {
      * @async
      */
     async init(workerInit = false) {
-        let tlsInfo = this.networkUtil.isMutualTlsEnabled() ? 'mutual'
+        const tlsInfo = this.networkUtil.isMutualTlsEnabled() ? 'mutual'
             : (this.networkUtil.isTlsEnabled() ? 'server' : 'none');
-        let compMode = this.networkUtil.isInCompatibilityMode() ? '; Fabric v1.0 compatibility mode' : '';
+        const compMode = this.networkUtil.isInCompatibilityMode() ? '; Fabric v1.0 compatibility mode' : '';
         logger.info(`Fabric SDK version: ${this.version.toString()}; TLS: ${tlsInfo}${compMode}`);
 
         await this._initializeRegistrars(workerInit);
@@ -2107,7 +2107,7 @@ class Fabric extends BlockchainInterface {
      */
     async invokeSmartContract(context, contractID, contractVersion, invokeSettings, timeout) {
         timeout = timeout || this.configDefaultTimeout;
-        let promises = [];
+        const promises = [];
         let settingsArray;
 
         if (!Array.isArray(invokeSettings)) {
@@ -2116,8 +2116,8 @@ class Fabric extends BlockchainInterface {
             settingsArray = invokeSettings;
         }
 
-        for (let settings of settingsArray) {
-            let contractDetails = this.networkUtil.getContractDetails(contractID);
+        for (const settings of settingsArray) {
+            const contractDetails = this.networkUtil.getContractDetails(contractID);
             if (!contractDetails) {
                 throw new Error(`Could not find details for contract ID ${contractID}`);
             }
@@ -2148,7 +2148,7 @@ class Fabric extends BlockchainInterface {
      */
     async querySmartContract(context, contractID, contractVersion, querySettings, timeout) {
         timeout = timeout || this.configDefaultTimeout;
-        let promises = [];
+        const promises = [];
         let settingsArray;
 
         if (!Array.isArray(querySettings)) {
@@ -2157,8 +2157,8 @@ class Fabric extends BlockchainInterface {
             settingsArray = querySettings;
         }
 
-        for (let settings of settingsArray) {
-            let contractDetails = this.networkUtil.getContractDetails(contractID);
+        for (const settings of settingsArray) {
+            const contractDetails = this.networkUtil.getContractDetails(contractID);
             if (!contractDetails) {
                 throw new Error(`Could not find details for contract ID ${contractID}`);
             }

--- a/packages/caliper-fabric/lib/adaptor-versions/v2/registrarHelper.js
+++ b/packages/caliper-fabric/lib/adaptor-versions/v2/registrarHelper.js
@@ -1,0 +1,218 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+const { Wallets } = require('fabric-network');
+const { CaliperUtils } = require('@hyperledger/caliper-core');
+const logger = CaliperUtils.getLogger('identityHelper');
+const FabricCAServices = require('fabric-ca-client');
+
+/**
+ * Helper for registering and enrolling with a Certificate Authority
+ */
+class RegistrarHelper {
+
+    /**
+     * Retrieve an initialized RegistrarHelper
+     * @param {FabricNetwork} networkUtil the network
+     */
+    static async newWithNetwork(networkUtil) {
+        const identityHelper = new RegistrarHelper(networkUtil);
+        await identityHelper.initialize();
+        return identityHelper;
+    }
+
+    /**
+     * Constructor
+     * @param {FabricNetwork} networkUtil the network
+     */
+    constructor(networkUtil) {
+        this.networkUtil = networkUtil;
+        this.registrarInfo = new Map();
+    }
+
+    /**
+     * Initialize the helper
+     */
+    async initialize() {
+        // Use a wallet for convenience
+        this.wallet = await Wallets.newInMemoryWallet();
+
+        // Loop over all known orgs to configure accessible CAs
+        for (const orgName of this.networkUtil.getOrganizations()) {
+            const caName = this.networkUtil.getCertificateAuthorityOfOrganization(orgName);
+            const caObject = this.networkUtil.getCertificateAuthority(caName);
+            if (caObject) {
+                const tlsOptions = {
+                    trustedRoots: [],
+                    verify: caObject.verify || false
+                };
+                const orgCA = new FabricCAServices(caObject.url, tlsOptions, caName);
+
+                const registrarInfo = this.networkUtil.getRegistrarOfOrganization(orgName);
+                if (registrarInfo) {
+                    const registrarName = this.getRegistrarNameForOrg(orgName);
+                    const registrarEnrollment = await this.enrollUser(orgCA, registrarInfo.enrollId, registrarInfo.enrollSecret);
+                    const registrarIdentity = {
+                        credentials: {
+                            certificate: registrarEnrollment.certificate,
+                            privateKey: registrarEnrollment.key.toBytes(),
+                        },
+                        mspId: this.networkUtil.getMspIdOfOrganization(orgName),
+                        type: 'X.509',
+                    };
+                    await this.wallet.put(registrarName, registrarIdentity);
+                    this.registrarInfo.set(orgName, {orgCA, registrarName});
+                } else {
+                    logger.warn(`No registrar information for org ${orgName}; unable to enrol users`);
+                }
+            } else {
+                logger.warn(`No CA provided for org ${orgName}; unable to enrol users`);
+                continue;
+            }
+        }
+    }
+
+    /**
+     * Retrieve the registrar name for the passed org
+     * @param {string} orgName the org name
+     * @returns {string} the registrar name
+     */
+    getRegistrarNameForOrg(orgName) {
+        return `registrar.${orgName}`;
+    }
+
+    /**
+     * Check if a registrar exists for a passed org name
+     * @param {string} orgName the organization name
+     * @returns {boolean} boolean true if registrar exists; otherwise false
+     */
+    registrarExistsForOrg(orgName) {
+        return this.registrarInfo.has(orgName);
+    }
+
+    /**
+     * Register a user and return an enrollment secret
+     * @param {string} orgName the organization to register under
+     * @param {string} clientName the client name to register
+     */
+    async registerUserForOrg(orgName, clientName) {
+        const registrarInfo = this.registrarInfo.get(orgName);
+        const affiliation = this.networkUtil.getAffiliationOfUser(clientName);
+        return await this.registerUser(registrarInfo, clientName, { affiliation });
+    }
+
+    /**
+     * Register a userID through a CA using an admin identity
+     * @param {object} registrarInfo {orgCA, registrarName} Registrar information used to perform the registration action
+     * @param {string} userID The user identity name to be registered
+     * @param {object} options options to be used during registration
+     */
+    async registerUser(registrarInfo, userID, options = {}) {
+        const identity = await this.wallet.get(registrarInfo.registrarName);
+        const provider = this.wallet.getProviderRegistry().getProvider(identity.type);
+        const user = await provider.getUserContext(identity, registrarInfo.registrarName);
+
+        const userSecret = `${userID}_secret`;
+        const registerRequest = {
+            enrollmentID: userID,
+            enrollmentSecret: userSecret,
+            affiliation: options.affiliation || 'org1',  // or eg. org1.department1
+            attrs: [],
+            maxEnrollments: options.maxEnrollments || -1,  // infinite enrollment by default
+            role: options.role || 'client'
+        };
+
+        if (options.issuer) {
+            // Everyone caliper creates can register clients.
+            registerRequest.attrs.push({
+                name: 'hf.Registrar.Roles',
+                value: 'client'
+            });
+
+            // Everyone caliper creates can register clients that can register clients.
+            registerRequest.attrs.push({
+                name: 'hf.Registrar.Attributes',
+                value: 'hf.Registrar.Roles, hf.Registrar.Attributes'
+            });
+        }
+
+        let idAttributes = options.attributes;
+        if (typeof idAttributes === 'string') {
+            try {
+                idAttributes = JSON.parse(idAttributes);
+            } catch (error) {
+                throw new Error('attributes provided are not valid JSON. ' + error);
+            }
+        }
+
+        for (const attribute in idAttributes) {
+            registerRequest.attrs.push({
+                name: attribute,
+                value: idAttributes[attribute]
+            });
+        }
+
+        try {
+            await registrarInfo.orgCA.register(registerRequest, user);
+        } catch (error) {
+            // Might fail if previously registered, in which case pass back the known secret
+            if (error.toString().includes(`Identity '${userID}' is already registered`)) {
+                logger.warn(`Identity ${userID} is already registered`);
+                return userSecret;
+            } else {
+                throw error;
+            }
+        }
+
+        return userSecret;
+    }
+
+    /**
+     * Enroll a user for the organization using the enrollment secret
+     * @param {string} orgName the organization to enrol under
+     * @param {string} clientName the client name to enrol
+     * @param {string} enrollmentSecret the enrollment secret
+     * @return {Promise<{key: ECDSA_KEY, certificate: string}>} The resulting private key and certificate.
+     */
+    async enrollUserForOrg(orgName, clientName, enrollmentSecret) {
+        const caDetails = this.registrarInfo.get(orgName);
+        return await this.enrollUser(caDetails.orgCA, clientName, enrollmentSecret);
+    }
+
+    /**
+     * Enrolls the given user through its corresponding CA.
+     * @param {CertificateAuthority} ca The certificate authority object whose user must be enrolled.
+     * @param {string} id The enrollment ID.
+     * @param {string} secret The enrollment secret.
+     * @return {Promise<{key: ECDSA_KEY, certificate: string}>} The resulting private key and certificate.
+     * @private
+     * @async
+     */
+    async enrollUser(ca, id, secret) {
+        // this call will throw an error if the CA configuration is not found
+        // this error should propagate up
+        try {
+            return await ca.enroll({
+                enrollmentID: id,
+                enrollmentSecret: secret
+            });
+        } catch (err) {
+            throw new Error(`Couldn't enroll 'user' ${id}: ${err.message}`);
+        }
+    }
+
+}
+
+module.exports = RegistrarHelper;

--- a/packages/caliper-fabric/lib/configValidator.js
+++ b/packages/caliper-fabric/lib/configValidator.js
@@ -57,7 +57,7 @@ class ConfigValidator {
         let cas = [];
         if (config.certificateAuthorities) {
             cas = Object.keys(config.certificateAuthorities);
-            for (let ca of cas) {
+            for (const ca of cas) {
                 try {
                     ConfigValidator.validateCertificateAuthority(config.certificateAuthorities[ca], tls, requireRegistrar);
                     tls = (tls || false) || config.certificateAuthorities[ca].url.startsWith('https://');
@@ -71,7 +71,7 @@ class ConfigValidator {
         let orderers = [];
         if (config.orderers) {
             orderers = Object.keys(config.orderers);
-            for (let orderer of orderers) {
+            for (const orderer of orderers) {
                 try {
                     ConfigValidator.validateOrderer(config.orderers[orderer], tls);
                     tls = (tls || false) || config.orderers[orderer].url.startsWith('grpcs://');
@@ -86,7 +86,7 @@ class ConfigValidator {
         if (config.peers) {
             let eventUrl;
             peers = Object.keys(config.peers);
-            for (let peer of peers) {
+            for (const peer of peers) {
                 try {
                     ConfigValidator.validatePeer(config.peers[peer], tls, eventUrl);
                     tls = (tls || false) || config.peers[peer].url.startsWith('grpcs://');
@@ -99,10 +99,10 @@ class ConfigValidator {
 
         // validate organization section
         let orgs = [];
-        let mspIds = [];
+        const mspIds = [];
         if (config.organizations) {
             orgs = Object.keys(config.organizations);
-            for (let org of orgs) {
+            for (const org of orgs) {
                 try {
                     ConfigValidator.validateOrganization(config.organizations[org], peers, cas);
                     mspIds.push(config.organizations[org].mspid);
@@ -114,8 +114,8 @@ class ConfigValidator {
 
         // validate client section
         if (config.clients) {
-            let clients = Object.keys(config.clients);
-            for (let client of clients) {
+            const clients = Object.keys(config.clients);
+            for (const client of clients) {
                 try {
                     ConfigValidator.validateClient(config.clients[client], orgs, config.wallet !== undefined);
                 } catch (err) {
@@ -126,9 +126,9 @@ class ConfigValidator {
 
         // validate channels section
         if (config.channels) {
-            let channels = Object.keys(config.channels);
-            let takenContractIds = [];
-            for (let channel of channels) {
+            const channels = Object.keys(config.channels);
+            const takenContractIds = [];
+            for (const channel of channels) {
                 try {
                     ConfigValidator.validateChannel(config.channels[channel], orderers, peers, mspIds, takenContractIds, flowOptions, discovery);
                     takenContractIds.push(config.channels[channel].chaincodes.map(cc => cc.contractID || cc.id));
@@ -160,7 +160,7 @@ class ConfigValidator {
         const ordererModif = (onlyScript || discovery) ? 'optional' : 'required';
 
         // if server TLS is explicitly disabled, can't enable mutual TLS
-        let mutualTlsValid = tls === undefined ? [ true, false ] : (tls ? [ true, false ] : [ false ]);
+        const mutualTlsValid = tls === undefined ? [ true, false ] : (tls ? [ true, false ] : [ false ]);
 
         const schema = j.object().keys({
             // simple attributes
@@ -186,11 +186,11 @@ class ConfigValidator {
             certificateAuthorities: j.object().optional()
         });
 
-        let options = {
+        const options = {
             abortEarly: false,
             allowUnknown: false
         };
-        let result = j.validate(config, schema, options);
+        const result = j.validate(config, schema, options);
         if (result.error) {
             throw result.error;
         }
@@ -239,9 +239,9 @@ class ConfigValidator {
             needOptionalXor = true;
         }
 
-        let createPeersSchema = () => {
-            let peersSchema = {};
-            for (let peer of validPeers) {
+        const createPeersSchema = () => {
+            const peersSchema = {};
+            for (const peer of validPeers) {
                 peersSchema[peer] = j.object().keys({
                     endorsingPeer: j.boolean().optional(),
                     chaincodeQuery: j.boolean().optional(),
@@ -253,10 +253,10 @@ class ConfigValidator {
             return peersSchema;
         };
 
-        let createEndorsementPolicySchema = () => {
+        const createEndorsementPolicySchema = () => {
             // recursive schema of "X-of" objects
             // array element objects either have a "signed-by" key, or a recursive "X-of"
-            let policySchema = j.array().sparse(false).min(1).items(j.object().min(1)
+            const policySchema = j.array().sparse(false).min(1).items(j.object().min(1)
                 .pattern(/^signed-by$/, j.number().integer().min(0))
                 .pattern(/^[1-9]\d*-of$/,
                     j.lazy(() => policySchema).description('Policy schema'))
@@ -276,7 +276,7 @@ class ConfigValidator {
             });
         };
 
-        let contractIdComparator = (a, b) => {
+        const contractIdComparator = (a, b) => {
             if (a.contractID) {
                 if (b.contractID) {
                     return a.contractID === b.contractID;
@@ -351,11 +351,11 @@ class ConfigValidator {
             schema = schema.oxor('configBinary', 'definition');
         }
 
-        let options = {
+        const options = {
             abortEarly: false,
             allowUnknown: false
         };
-        let result = j.validate(config, schema, options);
+        const result = j.validate(config, schema, options);
         if (result.error) {
             throw result.error;
         }
@@ -368,7 +368,7 @@ class ConfigValidator {
      * @param {string} requireRegistrar Indicates whether a registrar is optional or required.
      */
     static validateCertificateAuthority(config, tls, requireRegistrar) {
-        let urlRegex = tls === undefined ? /^(https|http):\/\// : (tls ? /^https:\/\// : /^http:\/\//);
+        const urlRegex = tls === undefined ? /^(https|http):\/\// : (tls ? /^https:\/\// : /^http:\/\//);
 
         const schema = j.object().keys({
             caName: j.string().optional(),
@@ -392,11 +392,11 @@ class ConfigValidator {
             })).min(1).sparse(false).unique('enrollId')[requireRegistrar]()
         });
 
-        let options = {
+        const options = {
             abortEarly: false,
             allowUnknown: false
         };
-        let result = j.validate(config, schema, options);
+        const result = j.validate(config, schema, options);
         if (result.error) {
             throw result.error;
         }
@@ -409,8 +409,8 @@ class ConfigValidator {
      * @param {boolean} eventUrl Indicates whether other peers specified event URLs or not.
      */
     static validatePeer(config, tls, eventUrl) {
-        let urlRegex = tls === undefined ? /^(grpcs|grpc):\/\// : (tls ? /^grpcs:\/\// : /^grpc:\/\//);
-        let eventModif = eventUrl === undefined ? 'optional' : (eventUrl ? 'required' : 'forbidden');
+        const urlRegex = tls === undefined ? /^(grpcs|grpc):\/\// : (tls ? /^grpcs:\/\// : /^grpc:\/\//);
+        const eventModif = eventUrl === undefined ? 'optional' : (eventUrl ? 'required' : 'forbidden');
 
         const schema = j.object().keys({
             url: j.string().uri().regex(urlRegex).required(),
@@ -434,11 +434,11 @@ class ConfigValidator {
             })
         });
 
-        let options = {
+        const options = {
             abortEarly: false,
             allowUnknown: false
         };
-        let result = j.validate(config, schema, options);
+        const result = j.validate(config, schema, options);
         if (result.error) {
             throw result.error;
         }
@@ -450,7 +450,7 @@ class ConfigValidator {
      * @param {boolean} tls Indicates whether TLS is enabled or known at this point.
      */
     static validateOrderer(config, tls) {
-        let urlRegex = tls === undefined ? /^(grpcs|grpc):\/\// : (tls ? /^grpcs:\/\// : /^grpc:\/\//);
+        const urlRegex = tls === undefined ? /^(grpcs|grpc):\/\// : (tls ? /^grpcs:\/\// : /^grpc:\/\//);
 
         const schema = j.object().keys({
             url: j.string().uri().regex(urlRegex).required(),
@@ -467,11 +467,11 @@ class ConfigValidator {
             })
         });
 
-        let options = {
+        const options = {
             abortEarly: false,
             allowUnknown: false
         };
-        let result = j.validate(config, schema, options);
+        const result = j.validate(config, schema, options);
         if (result.error) {
             throw result.error;
         }
@@ -505,11 +505,11 @@ class ConfigValidator {
             }).xor('pem', 'path').optional(),
         }).and('adminPrivateKey', 'signedCert');
 
-        let options = {
+        const options = {
             abortEarly: false,
             allowUnknown: false
         };
-        let result = j.validate(config, schema, options);
+        const result = j.validate(config, schema, options);
         if (result.error) {
             throw result.error;
         }
@@ -582,11 +582,11 @@ class ConfigValidator {
             client: clientSchema.required()
         });
 
-        let options = {
+        const options = {
             abortEarly: false,
             allowUnknown: false
         };
-        let result = j.validate(config, schema, options);
+        const result = j.validate(config, schema, options);
         if (result.error) {
             throw result.error;
         }

--- a/packages/caliper-fabric/lib/fabric.js
+++ b/packages/caliper-fabric/lib/fabric.js
@@ -56,7 +56,7 @@ const Fabric = class extends BlockchainInterface {
             }
         } else if (semver.satisfies(version, '=2.x')) {
             if (!useGateway) {
-                modulePath = './adaptor-versions/v2/fabric-v2.js';
+                throw new Error(`Caliper currently only supports gateway based operation using the ${version} Fabric-SDK. Please retry with the gateway flag`);
             } else {
                 modulePath = './adaptor-versions/v2/fabric-gateway-v2.js';
             }
@@ -64,10 +64,10 @@ const Fabric = class extends BlockchainInterface {
             throw new Error(`Installed SDK version ${version} did not match any compatible Fabric adaptors`);
         }
 
-        let networkConfig = CaliperUtils.resolvePath(ConfigUtil.get(ConfigUtil.keys.NetworkConfig));
-        let workspaceRoot = path.resolve(ConfigUtil.get(ConfigUtil.keys.Workspace));
+        const networkConfig = CaliperUtils.resolvePath(ConfigUtil.get(ConfigUtil.keys.NetworkConfig));
+        const workspaceRoot = path.resolve(ConfigUtil.get(ConfigUtil.keys.Workspace));
 
-        let Fabric = require(modulePath);
+        const Fabric = require(modulePath);
         this.fabric = new Fabric(networkConfig, workspaceRoot, workerIndex);
     }
 

--- a/packages/caliper-fabric/lib/fabricNetwork.js
+++ b/packages/caliper-fabric/lib/fabricNetwork.js
@@ -40,7 +40,7 @@ class FabricNetwork {
 
         this.network = undefined;
         if (typeof networkConfig === 'string') {
-            let configPath = CaliperUtils.resolvePath(networkConfig, workspace_root);
+            const configPath = CaliperUtils.resolvePath(networkConfig, workspace_root);
             this.network = CaliperUtils.parseYaml(configPath);
         } else if (typeof networkConfig === 'object' && networkConfig !== null) {
             // clone the object to prevent modification by other objects
@@ -72,11 +72,11 @@ class FabricNetwork {
         }
 
         if (this.network.clients) {
-            let clients = this.getClients();
-            for (let client of clients) {
+            const clients = this.getClients();
+            for (const client of clients) {
                 this.clientConfigs[client] = this.network.clients[client];
 
-                let cObj = this.network.clients[client].client;
+                const cObj = this.network.clients[client].client;
                 // normalize paths
                 if (cObj.credentialStore) {
                     cObj.credentialStore.path = CaliperUtils.resolvePath(cObj.credentialStore.path, workspaceRoot);
@@ -94,11 +94,11 @@ class FabricNetwork {
         }
 
         if (this.network.channels) {
-            let channels = this.getChannels();
-            for (let channel of channels) {
-                let cObj = this.network.channels[channel];
+            const channels = this.getChannels();
+            for (const channel of channels) {
+                const cObj = this.network.channels[channel];
 
-                for (let cc of cObj.chaincodes) {
+                for (const cc of cObj.chaincodes) {
                     if (!cc.contractID) {
                         cc.contractID = cc.id;
                     }
@@ -112,9 +112,9 @@ class FabricNetwork {
         }
 
         if (this.network.organizations) {
-            let orgs = this.getOrganizations();
-            for (let org of orgs) {
-                let oObj = this.network.organizations[org];
+            const orgs = this.getOrganizations();
+            for (const org of orgs) {
+                const oObj = this.network.organizations[org];
 
                 if (oObj.adminPrivateKey && oObj.adminPrivateKey.path) {
                     oObj.adminPrivateKey.path = CaliperUtils.resolvePath(oObj.adminPrivateKey.path, workspaceRoot);
@@ -127,9 +127,9 @@ class FabricNetwork {
         }
 
         if (this.network.orderers) {
-            let orderers = this.getOrderers();
-            for (let orderer of orderers) {
-                let oObj = this.network.orderers[orderer];
+            const orderers = this.getOrderers();
+            for (const orderer of orderers) {
+                const oObj = this.network.orderers[orderer];
 
                 this.tls |= oObj.url.startsWith('grpcs://');
 
@@ -140,9 +140,9 @@ class FabricNetwork {
         }
 
         if (this.network.peers) {
-            let peers = this.getPeers();
-            for (let peer of peers) {
-                let pObj = this.network.peers[peer];
+            const peers = this.getPeers();
+            for (const peer of peers) {
+                const pObj = this.network.peers[peer];
 
                 this.tls |= pObj.url.startsWith('grpcs://');
 
@@ -157,9 +157,9 @@ class FabricNetwork {
         }
 
         if (this.network.certificateAuthorities) {
-            let cas = this.getCertificateAuthorities();
-            for (let ca of cas) {
-                let caObj = this.network.certificateAuthorities[ca];
+            const cas = this.getCertificateAuthorities();
+            for (const ca of cas) {
+                const caObj = this.network.certificateAuthorities[ca];
 
                 this.tls |= caObj.url.startsWith('https://');
 
@@ -188,15 +188,15 @@ class FabricNetwork {
      * @returns {{privateKeyPEM: Buffer, signedCertPEM: Buffer}} The object containing the signing key and cert in PEM format.
      */
     getAdminCryptoContentOfOrganization(org) {
-        let orgObject = this.network.organizations[org];
+        const orgObject = this.network.organizations[org];
 
         // if either is missing, the result is undefined
         if (!CaliperUtils.checkAllProperties(orgObject, 'adminPrivateKey', 'signedCert')) {
             return undefined;
         }
 
-        let privateKey = orgObject.adminPrivateKey;
-        let signedCert = orgObject.signedCert;
+        const privateKey = orgObject.adminPrivateKey;
+        const signedCert = orgObject.signedCert;
 
         let privateKeyPEM;
         let signedCertPEM;
@@ -242,10 +242,10 @@ class FabricNetwork {
      * @return {Set<string>} The set of peer names functioning as an event source.
      */
     getAllEventSources() {
-        let result = new Set();
-        for (let channel of this.getChannels()) {
-            for (let peer of this.getPeersOfChannel(channel)) {
-                let peerObject = this.network.channels[channel].peers[peer];
+        const result = new Set();
+        for (const channel of this.getChannels()) {
+            for (const peer of this.getPeersOfChannel(channel)) {
+                const peerObject = this.network.channels[channel].peers[peer];
                 // defaults to true, or explicitly set
                 if (!CaliperUtils.checkProperty(peerObject, 'eventSource') || peerObject.eventSource) {
                     result.add(peer);
@@ -279,9 +279,9 @@ class FabricNetwork {
      * @returns {Set<string>} The set of CA names.
      */
     getCertificateAuthorities() {
-        let result = new Set();
-        let cas = this.network.certificateAuthorities;
-        for (let key in cas) {
+        const result = new Set();
+        const cas = this.network.certificateAuthorities;
+        for (const key in cas) {
             if (!cas.hasOwnProperty(key)) {
                 continue;
             }
@@ -308,6 +308,20 @@ class FabricNetwork {
     }
 
     /**
+     * Gets the CA object corresponding to the passed name.
+     * @param {string} caName The CA name.
+     * @returns {object} The CA object.
+     */
+    getCertificateAuthority(caName) {
+        if (!CaliperUtils.checkProperty(this.network, 'certificateAuthorities') ||
+            !CaliperUtils.checkProperty(this.network.certificateAuthorities, caName) ) {
+            return undefined;
+        }
+
+        return this.network.certificateAuthorities[caName];
+    }
+
+    /**
      * Gets the chaincode names and versions belonging to the given channel.
      * @param {string} channel The channel name.
      * @returns {Set<{id: string, version: string}>} The set of chaincode names.
@@ -326,10 +340,10 @@ class FabricNetwork {
      * @returns {Set<string>} The set of channel names.
      */
     getChannels() {
-        let result = new Set();
-        let channels = this.network.channels;
+        const result = new Set();
+        const channels = this.network.channels;
 
-        for (let key in channels) {
+        for (const key in channels) {
             if (!channels.hasOwnProperty(key)) {
                 continue;
             }
@@ -346,7 +360,7 @@ class FabricNetwork {
      * @return {string[]} The array of channel names the peer belongs to.
      */
     getChannelsOfPeer(peer) {
-        let result = [...this.getChannels()].filter(c => this.getPeersOfChannel(c).has(peer));
+        const result = [...this.getChannels()].filter(c => this.getPeersOfChannel(c).has(peer));
 
         if (result.length === 0) {
             throw new Error(`${peer} does not belong to any channel`);
@@ -361,14 +375,14 @@ class FabricNetwork {
      * @returns {{privateKeyPEM: Buffer, signedCertPEM: Buffer}} The object containing the signing key and cert.
      */
     getClientCryptoContent(client) {
-        let clientObject = this.network.clients[client].client;
+        const clientObject = this.network.clients[client].client;
 
         if (!CaliperUtils.checkAllProperties(clientObject, 'clientPrivateKey', 'clientSignedCert')) {
             return undefined;
         }
 
-        let privateKey = clientObject.clientPrivateKey;
-        let signedCert = clientObject.clientSignedCert;
+        const privateKey = clientObject.clientPrivateKey;
+        const signedCert = clientObject.clientSignedCert;
         let privateKeyPEM;
         let signedCertPEM;
 
@@ -419,10 +433,10 @@ class FabricNetwork {
      * @returns {Set<string>} The set of client names.
      */
     getClients() {
-        let result = new Set();
-        let clients = this.network.clients;
+        const result = new Set();
+        const clients = this.network.clients;
 
-        for (let key in clients) {
+        for (const key in clients) {
             if (!clients.hasOwnProperty(key)) {
                 continue;
             }
@@ -439,10 +453,10 @@ class FabricNetwork {
      * @returns {Set<string>} The set of client names.
      */
     getClientsOfOrganization(org) {
-        let clients = this.getClients();
-        let result = new Set();
+        const clients = this.getClients();
+        const result = new Set();
 
-        for (let client of clients) {
+        for (const client of clients) {
             if (this.network.clients[client].client.organization === org) {
                 result.add(client);
             }
@@ -468,16 +482,16 @@ class FabricNetwork {
      * @private
      */
     getDefaultEndorsementPolicy(channel, chaincodeInfo) {
-        let targetPeers = this.getTargetPeersOfChaincodeOfChannel(chaincodeInfo, channel);
-        let targetOrgs = new Set();
+        const targetPeers = this.getTargetPeersOfChaincodeOfChannel(chaincodeInfo, channel);
+        const targetOrgs = new Set();
 
-        for (let peer of targetPeers) {
+        for (const peer of targetPeers) {
             targetOrgs.add(this.getOrganizationOfPeer(peer));
         }
 
-        let orgArray = Array.from(targetOrgs).sort();
+        const orgArray = Array.from(targetOrgs).sort();
 
-        let policy = {
+        const policy = {
             identities: [],
             policy: {}
         };
@@ -506,8 +520,8 @@ class FabricNetwork {
      * @return {object} An object containing the GRPC options of the peer.
      */
     getGrpcOptionsOfPeer(peer) {
-        let peerObj = this.network.peers[peer];
-        let grpcObj = peerObj.grpcOptions;
+        const peerObj = this.network.peers[peer];
+        const grpcObj = peerObj.grpcOptions;
 
         if (CaliperUtils.checkProperty(peerObj, 'tlsCACerts')) {
             grpcObj.pem = this.getTlsCaCertificateOfPeer(peer);
@@ -548,10 +562,10 @@ class FabricNetwork {
      * @returns {Set<string>} The set of orderer names.
      */
     getOrderers() {
-        let result = new Set();
-        let orderers = this.network.orderers;
+        const result = new Set();
+        const orderers = this.network.orderers;
 
-        for (let key in orderers) {
+        for (const key in orderers) {
             if (!orderers.hasOwnProperty(key)) {
                 continue;
             }
@@ -586,8 +600,8 @@ class FabricNetwork {
      * @return {string} The name of the organization.
      */
     getOrganizationOfCertificateAuthority(ca) {
-        let orgs = this.getOrganizations();
-        for (let org of orgs) {
+        const orgs = this.getOrganizations();
+        for (const org of orgs) {
             if (this.network.organizations[org].certificateAuthorities.includes(ca)) {
                 return org;
             }
@@ -611,9 +625,9 @@ class FabricNetwork {
      * @returns {string} The organization name.
      */
     getOrganizationOfPeer(peer) {
-        let orgs = this.getOrganizations();
-        for (let org of orgs) {
-            let peers = this.getPeersOfOrganization(org);
+        const orgs = this.getOrganizations();
+        for (const org of orgs) {
+            const peers = this.getPeersOfOrganization(org);
             if (peers.has(peer)) {
                 return org;
             }
@@ -627,10 +641,10 @@ class FabricNetwork {
      * @returns {Set<string>} The set of organization names.
      */
     getOrganizations() {
-        let result = new Set();
-        let orgs = this.network.organizations;
+        const result = new Set();
+        const orgs = this.network.organizations;
 
-        for (let key in orgs) {
+        for (const key in orgs) {
             if (!orgs.hasOwnProperty(key)) {
                 continue;
             }
@@ -647,10 +661,10 @@ class FabricNetwork {
      * @returns {Set<string>} The set of organization names.
      */
     getOrganizationsOfChannel(channel) {
-        let peers = this.getPeersOfChannel(channel);
-        let result = new Set();
+        const peers = this.getPeersOfChannel(channel);
+        const result = new Set();
 
-        for (let peer of peers) {
+        for (const peer of peers) {
             result.add(this.getOrganizationOfPeer(peer));
         }
 
@@ -672,14 +686,14 @@ class FabricNetwork {
      * @return {string} The name of the peer.
      */
     getPeerNameForAddress(address) {
-        let peers = this.network.peers;
-        for (let peer in peers) {
+        const peers = this.network.peers;
+        for (const peer in peers) {
             if (!peers.hasOwnProperty(peer)) {
                 continue;
             }
 
             // remove protocol from address in the config
-            let url = peers[peer].url.replace(/(^\w+:|^)\/\//, '');
+            const url = peers[peer].url.replace(/(^\w+:|^)\/\//, '');
             if (url === address) {
                 return peer.toString();
             }
@@ -694,7 +708,7 @@ class FabricNetwork {
      * @return {string} The name of the peer.
      */
     getPeerNameOfEventHub(eventHub) {
-        let peerAddress = eventHub.getPeerAddr();
+        const peerAddress = eventHub.getPeerAddr();
         return this.getPeerNameForAddress(peerAddress);
     }
 
@@ -704,10 +718,10 @@ class FabricNetwork {
      * @returns {Set<string>} The set of peer names.
      */
     getPeers() {
-        let result = new Set();
-        let peers = this.network.peers;
+        const result = new Set();
+        const peers = this.network.peers;
 
-        for (let peerKey in peers) {
+        for (const peerKey in peers) {
             if (!peers.hasOwnProperty(peerKey)) {
                 continue;
             }
@@ -724,10 +738,10 @@ class FabricNetwork {
      * @returns {Set<string>} The set of peer names.
      */
     getPeersOfChannel(channel) {
-        let peers = this.network.channels[channel].peers;
-        let result = new Set();
+        const peers = this.network.channels[channel].peers;
+        const result = new Set();
 
-        for (let key in peers) {
+        for (const key in peers) {
             if (!peers.hasOwnProperty(key)) {
                 continue;
             }
@@ -754,8 +768,8 @@ class FabricNetwork {
      * @returns {Set<string>} The set of peer names.
      */
     getPeersOfOrganizationAndChannel(org, channel) {
-        let peersInOrg = this.getPeersOfOrganization(org);
-        let peersInChannel = this.getPeersOfChannel(channel);
+        const peersInOrg = this.getPeersOfOrganization(org);
+        const peersInChannel = this.getPeersOfChannel(channel);
 
         // return the intersection of the two sets
         return new Set([...peersInOrg].filter(p => peersInChannel.has(p)));
@@ -767,7 +781,7 @@ class FabricNetwork {
      * @returns {{enrollId: string, enrollSecret: string}} The enrollment ID and secret of the registrar.
      */
     getRegistrarOfOrganization(org) {
-        let ca = this.getCertificateAuthorityOfOrganization(org);
+        const ca = this.getCertificateAuthorityOfOrganization(org);
 
         if (!ca || !CaliperUtils.checkProperty(this.network.certificateAuthorities[ca], 'registrar')) {
             return undefined;
@@ -784,7 +798,7 @@ class FabricNetwork {
      * @returns {Set<string>} The set of peer names.
      */
     getTargetPeersOfChaincodeOfChannel(chaincodeInfo, channel) {
-        let cc = this.network.channels[channel].chaincodes.find(
+        const cc = this.network.channels[channel].chaincodes.find(
             cc => cc.id === chaincodeInfo.id && cc.version === chaincodeInfo.version);
 
         CaliperUtils.assertDefined(cc, `Could not find the following chaincode in the configuration: ${chaincodeInfo.id}@${chaincodeInfo.version}`);
@@ -795,14 +809,14 @@ class FabricNetwork {
 
         // we need to gather the target peers from the channel's peer section
         // based on their provided functionality (endorsing and cc query)
-        let results = new Set();
-        let peers = this.network.channels[channel].peers;
-        for (let key in peers) {
+        const results = new Set();
+        const peers = this.network.channels[channel].peers;
+        for (const key in peers) {
             if (!peers.hasOwnProperty(key)) {
                 continue;
             }
 
-            let peer = peers[key];
+            const peer = peers[key];
             // if only the peer name is present in the config, then it is a target based on the default values
             if (!CaliperUtils.checkDefined(peer)) {
                 results.add(key.toString());
@@ -831,13 +845,13 @@ class FabricNetwork {
      * @return {string} The PEM encoded CA certificate.
      */
     getTlsCaCertificateOfPeer(peer) {
-        let peerObject = this.network.peers[peer];
+        const peerObject = this.network.peers[peer];
 
         if (!CaliperUtils.checkProperty(peerObject, 'tlsCACerts')) {
             return undefined;
         }
 
-        let tlsCACert = peerObject.tlsCACerts;
+        const tlsCACert = peerObject.tlsCACerts;
         let tlsPEM;
 
         if (CaliperUtils.checkProperty(tlsCACert, 'path')) {
@@ -857,20 +871,20 @@ class FabricNetwork {
      * @return {Map<string, Buffer>} The map of attribute names to byte arrays.
      */
     getTransientMapOfChaincodeOfChannel(chaincode, channel) {
-        let map = {};
-        let cc = this.network.channels[channel].chaincodes.find(
+        const map = {};
+        const cc = this.network.channels[channel].chaincodes.find(
             cc => cc.id === chaincode.id && cc.version === chaincode.version);
 
         if (!CaliperUtils.checkProperty(cc, 'initTransientMap')) {
             return map;
         }
 
-        for (let key in cc.initTransientMap) {
+        for (const key in cc.initTransientMap) {
             if (!cc.initTransientMap.hasOwnProperty(key)) {
                 continue;
             }
 
-            let value = cc.initTransientMap[key];
+            const value = cc.initTransientMap[key];
             map[key.toString()] = Buffer.from(value.toString());
         }
 

--- a/packages/caliper-fabric/package.json
+++ b/packages/caliper-fabric/package.json
@@ -27,7 +27,6 @@
         "semver":"7.1.1"
     },
     "devDependencies": {
-        "grpc": "1.14.2",
         "fabric-ca-client": "^1.4.7",
         "fabric-client": "^1.4.7",
         "fabric-network": "^1.4.7",

--- a/packages/caliper-fabric/test/configValidator.js
+++ b/packages/caliper-fabric/test/configValidator.js
@@ -199,7 +199,7 @@ describe('Class: ConfigValidator', () => {
                 }
             }
         };
-        let configString = JSON.stringify(config);
+        const configString = JSON.stringify(config);
 
         beforeEach(() => {
             config = JSON.parse(configString);
@@ -452,7 +452,7 @@ describe('Class: ConfigValidator', () => {
             peers: { peer1: {} },
             certificateAuthorities: { ca1: {} }
         };
-        let configString = JSON.stringify(config);
+        const configString = JSON.stringify(config);
 
         beforeEach(() => {
             config = JSON.parse(configString);
@@ -823,7 +823,7 @@ describe('Class: ConfigValidator', () => {
                 { enrollId: 'admin2', enrollSecret: 'secret2' }
             ]
         };
-        let configString = JSON.stringify(config);
+        const configString = JSON.stringify(config);
 
         let configNoRegistrar = {
             url: 'https://localhost:7054',
@@ -834,7 +834,7 @@ describe('Class: ConfigValidator', () => {
                 path: 'my/path/tocert'
             }
         };
-        let configStringNoRegistrar = JSON.stringify(configNoRegistrar);
+        const configStringNoRegistrar = JSON.stringify(configNoRegistrar);
 
         // reset the local config before every test
         beforeEach(() => {
@@ -1098,7 +1098,7 @@ describe('Class: ConfigValidator', () => {
         };
 
         let eventUrl = true;
-        let configString = JSON.stringify(config);
+        const configString = JSON.stringify(config);
 
         beforeEach(() => {
             config = JSON.parse(configString);
@@ -1318,7 +1318,7 @@ describe('Class: ConfigValidator', () => {
                 path: 'my/path/tocert'
             }
         };
-        let configString = JSON.stringify(config);
+        const configString = JSON.stringify(config);
 
         beforeEach(() => {
             config = JSON.parse(configString);
@@ -1507,7 +1507,7 @@ describe('Class: ConfigValidator', () => {
                 path: 'path'
             }
         };
-        let configString = JSON.stringify(config);
+        const configString = JSON.stringify(config);
 
         beforeEach(() => {
             config = JSON.parse(configString);
@@ -1801,7 +1801,7 @@ describe('Class: ConfigValidator', () => {
                 // other properties are added during the tests
             }
         };
-        let configString = JSON.stringify(config);
+        const configString = JSON.stringify(config);
 
         let wallet = false;
 
@@ -2519,7 +2519,7 @@ describe('Class: ConfigValidator', () => {
 
             // additional properties added by the tests
         };
-        let configString = JSON.stringify(config);
+        const configString = JSON.stringify(config);
 
         beforeEach(() => {
             config = JSON.parse(configString);

--- a/packages/caliper-fisco-bcos/.eslintrc.yml
+++ b/packages/caliper-fisco-bcos/.eslintrc.yml
@@ -5,8 +5,7 @@ env:
 extends: 'eslint:recommended'
 parserOptions:
     ecmaVersion: 8
-    sourceType:
-        - script
+    sourceType: script
 rules:
     indent:
         - error


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

A few changes here:
- Bindings
  - Added a bind point with a current V2 snapshots
- ESLint
  - Added `prefer const` to the eslint rule for fabric
- Fabric V2
  - Will throw if not using `gateway` mode (can work on non-gateway in background and enable it)
  - Updated fabric gateway adaptor to be compatible with latest working snaphot
    - No admin actions (warn if used)
    - Account for breaking changes in APIs
  - Added a registrar helper to perform any enrol actions for users to with no credentials
  - Enabled `countQueryAsLoad`
- Fabric V1 Gateway
  - Updated the adaptor to mirror the V2 adaptor and accept transient data
  - Enabled `countQueryAsLoad`
