### PR TITLE
Update Besu Support

### DIFF
--- a/packages/caliper-cli/lib/lib/config.yaml
+++ b/packages/caliper-cli/lib/lib/config.yaml
@@ -96,8 +96,10 @@ sut:
         latest: *ethereum-latest
 
     besu:
-        1.3.2: &besu-latest
+        1.3.2:
             packages: ['web3@1.2.0']
-        1.3: *besu-latest
-        1.4: *besu-latest
+        1.3: 
+            packages: ['web3@1.2.0']
+        1.4: &besu-latest
+            packages: ['web3@1.2.0']
         latest: *besu-latest

--- a/packages/caliper-cli/lib/lib/config.yaml
+++ b/packages/caliper-cli/lib/lib/config.yaml
@@ -98,4 +98,6 @@ sut:
     besu:
         1.3.2: &besu-latest
             packages: ['web3@1.2.0']
+        1.3: *besu-latest
+        1.4: *besu-latest
         latest: *besu-latest


### PR DESCRIPTION
Update besu to support 1.3 and 1.4 via semver.  Keep 1.3.2 in place to
support legacy configurations.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

