### PR TITLE
Add binding to CI tests

### DIFF
--- a/.travis/benchmark-integration-test-direct.sh
+++ b/.travis/benchmark-integration-test-direct.sh
@@ -23,6 +23,8 @@ npm i && npm run repoclean -- --yes && npm run bootstrap
 # Call CLI directly
 # The CWD will be in one of the caliper-tests-integration/*_tests directories
 export CALL_METHOD="node ../../caliper-cli/caliper.js"
+# Use explicit binding for
+export BIND_IN_PACKAGE_DIR=true
 export GENERATOR_METHOD="yo ../../../caliper-generator/generator-caliper/generators/benchmark/index.js"
 
 echo "---- Running Integration test for adaptor ${BENCHMARK}"

--- a/packages/caliper-tests-integration/besu_tests/run.sh
+++ b/packages/caliper-tests-integration/besu_tests/run.sh
@@ -20,6 +20,12 @@ set -v
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "${DIR}"
 
+# bind during CI tests, using the package dir as CWD
+# Note: do not use env variables for binding settings, as subsequent launch calls will pick them up and bind again
+if [[ "${BIND_IN_PACKAGE_DIR}" = "true" ]]; then
+    ${CALL_METHOD} bind --caliper-bind-sut besu:latest --caliper-bind-cwd ./../../caliper-ethereum/ --caliper-bind-args="--no-save"
+fi
+
 # change default settings (add config paths too)
 export CALIPER_PROJECTCONFIG=../caliper.yaml
 

--- a/packages/caliper-tests-integration/ethereum_tests/run.sh
+++ b/packages/caliper-tests-integration/ethereum_tests/run.sh
@@ -20,6 +20,12 @@ set -v
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "${DIR}"
 
+# bind during CI tests, using the package dir as CWD
+# Note: do not use env variables for binding settings, as subsequent launch calls will pick them up and bind again
+if [[ "${BIND_IN_PACKAGE_DIR}" = "true" ]]; then
+    ${CALL_METHOD} bind --caliper-bind-sut ethereum:latest --caliper-bind-cwd ./../../caliper-ethereum/ --caliper-bind-args="--no-save"
+fi
+
 # change default settings (add config paths too)
 export CALIPER_PROJECTCONFIG=caliper.yaml
 

--- a/packages/caliper-tests-integration/fabric_tests/run.sh
+++ b/packages/caliper-tests-integration/fabric_tests/run.sh
@@ -27,6 +27,12 @@ cd ./config
 # back to this dir
 cd ${DIR}
 
+# bind during CI tests, using the package dir as CWD
+# Note: do not use env variables for binding settings, as subsequent launch calls will pick them up and bind again
+if [[ "${BIND_IN_PACKAGE_DIR}" = "true" ]]; then
+    ${CALL_METHOD} bind --caliper-bind-sut fabric:1.4.7 --caliper-bind-cwd ./../../caliper-fabric/ --caliper-bind-args="--no-save"
+fi
+
 # change default settings (add config paths too)
 export CALIPER_PROJECTCONFIG=../caliper.yaml
 

--- a/packages/caliper-tests-integration/fisco-bcos_tests/run.sh
+++ b/packages/caliper-tests-integration/fisco-bcos_tests/run.sh
@@ -20,6 +20,12 @@ set -v
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "${DIR}"
 
+# bind during CI tests, using the package dir as CWD
+# Note: do not use env variables for binding settings, as subsequent launch calls will pick them up and bind again
+if [[ "${BIND_IN_PACKAGE_DIR}" = "true" ]]; then
+    ${CALL_METHOD} bind --caliper-bind-sut fisco-bcos:latest --caliper-bind-cwd ./../../caliper-fisco-bcos/ --caliper-bind-args="--no-save"
+fi
+
 # change default settings (add config paths too)
 export CALIPER_PROJECTCONFIG=caliper.yaml
 

--- a/packages/caliper-tests-integration/sawtooth_tests/run.sh
+++ b/packages/caliper-tests-integration/sawtooth_tests/run.sh
@@ -20,6 +20,12 @@ set -v
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "${DIR}"
 
+# bind during CI tests, using the package dir as CWD
+# Note: do not use env variables for binding settings, as subsequent launch calls will pick them up and bind again
+if [[ "${BIND_IN_PACKAGE_DIR}" = "true" ]]; then
+    ${CALL_METHOD} bind --caliper-bind-sut sawtooth:latest --caliper-bind-cwd ./../../caliper-sawtooth/ --caliper-bind-args="--no-save"
+fi
+
 # change default settings (add config paths too)
 export CALIPER_PROJECTCONFIG=caliper.yaml
 


### PR DESCRIPTION
Signed-off-by: Attila Klenik <a.klenik@gmail.com>

An explicit binding step is added to the Fabric CI test instead of using the latest dev deps.
* This opens up the possibility for a fabric-v2 CI test.
* The other CI adapter tests can introduce the same approach if needed to deviate from the latest dev deps.