### PR TITLE
update v2 gateway

### DIFF
--- a/packages/caliper-cli/lib/lib/config.yaml
+++ b/packages/caliper-cli/lib/lib/config.yaml
@@ -61,7 +61,7 @@ sut:
         1.4.7: &fabric-latest
             packages: ['fabric-client@1.4.7', 'fabric-protos@2.0.0-snapshot.1', 'fabric-network@1.4.7']
         2.0.0:
-            packages: ['fabric-common@2.0.0-snapshot.387', 'fabric-protos@2.0.0-snapshot.245', 'fabric-network@2.0.0-snapshot.351']
+            packages: ['fabric-common@2.0.0-snapshot.388', 'fabric-protos@2.0.0-snapshot.246', 'fabric-network@2.0.0-snapshot.352']
         latest: *fabric-latest
 
     sawtooth:


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

Make use of the most recent ability to gain direct access to the txID from the transaction object.
- updated v2 binding
- removed uuid require
- txID is populated on the TxStatus object after the txn has been completed
- cried when I noticed that the TxStatus object uses capitalised method names 😢 