### PR TITLE
add npmignore file to packages

### DIFF
--- a/packages/caliper-burrow/.gitignore
+++ b/packages/caliper-burrow/.gitignore
@@ -10,9 +10,6 @@ architecture.pptx
 output.log
 lerna-debug.log
 
-# Ignore zookeeper files
-zookeeper.out
-
 # We prefer to not use lock files
 **/package-lock.json
 

--- a/packages/caliper-burrow/.npmignore
+++ b/packages/caliper-burrow/.npmignore
@@ -1,0 +1,21 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# hidden config files
+.editorconfig
+.eslintignore
+.eslintrc.yml
+
+# test directory
+test

--- a/packages/caliper-cli/.npmignore
+++ b/packages/caliper-cli/.npmignore
@@ -1,0 +1,21 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# hidden config files
+.editorconfig
+.eslintignore
+.eslintrc.yml
+
+# test directory
+test

--- a/packages/caliper-core/.npmignore
+++ b/packages/caliper-core/.npmignore
@@ -1,0 +1,21 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# hidden config files
+.editorconfig
+.eslintignore
+.eslintrc.yml
+
+# test directory
+test

--- a/packages/caliper-ethereum/.npmignore
+++ b/packages/caliper-ethereum/.npmignore
@@ -1,0 +1,21 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# hidden config files
+.editorconfig
+.eslintignore
+.eslintrc.yml
+
+# test directory
+test

--- a/packages/caliper-fabric/.npmignore
+++ b/packages/caliper-fabric/.npmignore
@@ -1,0 +1,21 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# hidden config files
+.editorconfig
+.eslintignore
+.eslintrc.yml
+
+# test directory
+test

--- a/packages/caliper-fisco-bcos/.npmignore
+++ b/packages/caliper-fisco-bcos/.npmignore
@@ -1,0 +1,21 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# hidden config files
+.editorconfig
+.eslintignore
+.eslintrc.yml
+
+# test directory
+test

--- a/packages/caliper-generator/generator-caliper/.npmignore
+++ b/packages/caliper-generator/generator-caliper/.npmignore
@@ -1,0 +1,21 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# hidden config files
+.editorconfig
+.eslintignore
+.eslintrc.yml
+
+# test directory
+test

--- a/packages/caliper-iroha/.npmignore
+++ b/packages/caliper-iroha/.npmignore
@@ -1,0 +1,21 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# hidden config files
+.editorconfig
+.eslintignore
+.eslintrc.yml
+
+# test directory
+test

--- a/packages/caliper-sawtooth/.gitignore
+++ b/packages/caliper-sawtooth/.gitignore
@@ -10,9 +10,6 @@ architecture.pptx
 output.log
 lerna-debug.log
 
-# Ignore zookeeper files
-zookeeper.out
-
 # We prefer to not use lock files
 **/package-lock.json
 

--- a/packages/caliper-sawtooth/.npmignore
+++ b/packages/caliper-sawtooth/.npmignore
@@ -1,0 +1,21 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# hidden config files
+.editorconfig
+.eslintignore
+.eslintrc.yml
+
+# test directory
+test


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

Currently during the Caliper publish phase, we are also publishing unrequired content such as:
- tests
- config files

This PR (should) stop that through the introduction of an npm ignore file