### PR TITLE
Update the binding for v2

### DIFF
--- a/packages/caliper-cli/lib/lib/config.yaml
+++ b/packages/caliper-cli/lib/lib/config.yaml
@@ -61,7 +61,7 @@ sut:
         1.4.7: &fabric-latest
             packages: ['fabric-client@1.4.7', 'fabric-protos@2.0.0-snapshot.1', 'fabric-network@1.4.7']
         2.0.0:
-            packages: ['fabric-common@2.0.0-snapshot.388', 'fabric-protos@2.0.0-snapshot.246', 'fabric-network@2.0.0-snapshot.352']
+            packages: ['fabric-common@2.0.0-snapshot.388', 'fabric-protos@2.0.0-snapshot.246', 'fabric-network@2.0.0-snapshot.352', fabric-ca-client@2.0.0-snapshot.396']
         latest: *fabric-latest
 
     sawtooth:
@@ -100,7 +100,7 @@ sut:
     besu:
         1.3.2:
             packages: ['web3@1.2.0']
-        1.3: 
+        1.3:
             packages: ['web3@1.2.0']
         1.4: &besu-latest
             packages: ['web3@1.2.0']


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

The registrarHelper.js present in the fabric v2 adaptor has a direct requirement on fabric-ca-client. This PR adds the required item to the bindings