### PR TITLE
Add package version check to internal CLI and CI test

### DIFF
--- a/.travis/checks-and-unit-tests.sh
+++ b/.travis/checks-and-unit-tests.sh
@@ -23,5 +23,9 @@ set -o pipefail
 # Bootstrap the project again
 npm i && npm run repoclean -- --yes && npm run bootstrap
 
+pushd ./packages/caliper-publish/
+./publish.js version check
+popd
+
 # Run linting, license check and unit tests
 npm test

--- a/lerna.json
+++ b/lerna.json
@@ -14,7 +14,8 @@
         "packages/caliper-sawtooth",
         "packages/caliper-cli",
         "packages/caliper-publish",
-        "packages/caliper-tests-integration"
+        "packages/caliper-tests-integration",
+        "packages/caliper-generator/generator-caliper"
 	],
 	"version": "0.3.1-unstable",
 	"hoist": true

--- a/packages/caliper-generator/generator-caliper/.eslintignore
+++ b/packages/caliper-generator/generator-caliper/.eslintignore
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
@@ -13,3 +13,4 @@
 #
 
 node_modules
+generators/benchmark/templates/callback.js

--- a/packages/caliper-generator/generator-caliper/.eslintrc.yml
+++ b/packages/caliper-generator/generator-caliper/.eslintrc.yml
@@ -1,0 +1,49 @@
+env:
+    es6: true
+    node: true
+    mocha: true
+extends: 'eslint:recommended'
+parserOptions:
+    ecmaFeatures:
+        experimentalObjectRestSpread: true
+    ecmaVersion: 8
+    sourceType: script
+rules:
+    indent:
+        - error
+        - 4
+    linebreak-style:
+        - error
+        - unix
+    quotes:
+        - error
+        - single
+    semi:
+        - error
+        - always
+    no-unused-vars:
+        - error
+        - args: none
+    no-console: off
+    curly: error
+    eqeqeq: error
+    no-throw-literal: error
+    strict: error
+    no-var: error
+    dot-notation: error
+    no-tabs: error
+    no-trailing-spaces: error
+    no-use-before-define: error
+    no-useless-call: error
+    no-with: error
+    operator-linebreak: error
+    require-jsdoc:
+        - error
+        - require:
+            ClassDeclaration: true
+            MethodDefinition: true
+            FunctionDeclaration: true
+    valid-jsdoc:
+        - error
+        - requireReturn: false
+    yoda: error

--- a/packages/caliper-generator/generator-caliper/generators/app/index.js
+++ b/packages/caliper-generator/generator-caliper/generators/app/index.js
@@ -2,9 +2,9 @@
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
-* 
+*
 * http://www.apache.org/licenses/LICENSE-2.0
-* 
+*
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,11 +12,17 @@
 * limitations under the License.
 */
 
-var Generator = require('yeoman-generator');
+'use strict';
+
+let Generator = require('yeoman-generator');
 
 module.exports = class extends Generator {
-    async prompting() { 
-        this.log("Welcome to the Hyperledger Caliper generator!");
+    /**
+     * Prompts the user the question about the generator to use.
+     * @async
+     */
+    async prompting() {
+        this.log('Welcome to the Hyperledger Caliper generator!');
         const question = [{
             type: 'list',
             name: 'subgenerator',
@@ -29,11 +35,14 @@ module.exports = class extends Generator {
         }];
         const answers = await this.prompt(question);
         Object.assign(this.options, answers);
-    };
+    }
 
+    /**
+     * Sets/configures the selected sub-generator.
+     */
     async configuring() {
         const { subgenerator } = this.options;
         this.log(`You can also run the ${subgenerator} generator using: yo caliper:${subgenerator}\n`);
         this.composeWith(require.resolve(`../${subgenerator}`));
-    };
-}
+    }
+};

--- a/packages/caliper-generator/generator-caliper/generators/benchmark/index.js
+++ b/packages/caliper-generator/generator-caliper/generators/benchmark/index.js
@@ -12,16 +12,22 @@
 * limitations under the License.
 */
 
-var Generator = require('yeoman-generator');
+'use strict';
+
+let Generator = require('yeoman-generator');
 
 const defaultTxValue = 50;
 const defaultClientValue = 5;
 const answersObject = {};
 
-let promptAnswers, workspaceAnswers, callbackAnswers, inititalAnswers, clientAnswer, roundAnswers, txValueAnswer
+let promptAnswers, workspaceAnswers, callbackAnswers, inititalAnswers, clientAnswer, roundAnswers, txValueAnswer;
 module.exports = class extends Generator {
+    /**
+     * Prompts questions about the benchmark generator settings.
+     * @async
+     */
     async prompting () {
-        this.log("Welcome to the Hyperledger Caliper benchmark generator!\nLet's start off by creating a workspace folder!");
+        this.log('Welcome to the Hyperledger Caliper benchmark generator!\nLet\'s start off by creating a workspace folder!');
 
         const workspaceQuestions = [{
             type: 'input',
@@ -31,7 +37,7 @@ module.exports = class extends Generator {
         }];
         workspaceAnswers = await this.prompt(workspaceQuestions);
 
-        this.log("Now for the callback file...");
+        this.log('Now for the callback file...');
         const callbackQuestions = [{
             type: 'input',
             name: 'chaincodeId',
@@ -59,11 +65,11 @@ module.exports = class extends Generator {
             try {
                 JSON.parse(callbackAnswers.chaincodeArguments);
             } catch (error) {
-                this.log(`Error: Incorrect array format. Using empty array for arguments. Defaulting to '[]' for arguments`);
+                this.log('Error: Incorrect array format. Using empty array for arguments. Defaulting to \'[]\' for arguments');
             }
         }
 
-        this.log("Now for the benchmark configuration file...");
+        this.log('Now for the benchmark configuration file...');
         const configQuestions = {
             initialQuestions: [{
                 type: 'input',
@@ -93,10 +99,10 @@ module.exports = class extends Generator {
                 name: 'rateController',
                 message: 'Which rate controller would you like to use?',
                 choices: [
-                {name: 'Fixed Rate', value: 'fixed-rate'},
-                {name: 'Fixed Backlog', value: 'fixed-backlog'},
-                {name: 'Linear Rate', value: 'linear-rate'},
-                {name: 'Fixed Feedback Rate', value: 'fixed-feedback-rate'}
+                    {name: 'Fixed Rate', value: 'fixed-rate'},
+                    {name: 'Fixed Backlog', value: 'fixed-backlog'},
+                    {name: 'Linear Rate', value: 'linear-rate'},
+                    {name: 'Fixed Feedback Rate', value: 'fixed-feedback-rate'}
                 ],
                 when: () => !this.options.rateController
             }, {
@@ -104,8 +110,8 @@ module.exports = class extends Generator {
                 name: 'txType',
                 message: 'How would you like to measure the length of the round?',
                 choices: [
-                {name: 'Transaction Duration', value:'txDuration'},
-                {name: 'Transaction Number', value: 'txNumber'}
+                    {name: 'Transaction Duration', value:'txDuration'},
+                    {name: 'Transaction Number', value: 'txNumber'}
                 ],
                 when: () => !this.options.txType
             }],
@@ -123,36 +129,36 @@ module.exports = class extends Generator {
                 default: defaultTxValue,
                 when: () => !this.options.txNumber
             }]
-        }
+        };
 
         inititalAnswers = await this.prompt(configQuestions.initialQuestions);
 
         clientAnswer = await this.prompt(configQuestions.clientQuestions);
         if (isNaN(parseFloat(this.options.workers)) && isNaN(parseFloat(clientAnswer.workers))) {
-            this.log(`Error: Not a valid input. Using default client value of ${defaultClientValue}.`)
+            this.log(`Error: Not a valid input. Using default client value of ${defaultClientValue}.`);
         }
         if (this.options.workers < 0 || clientAnswer.workers < 0) {
-            this.log(`Error: Negative values not accepted. Defaulting to ${Math.abs(clientAnswer.workers)}.`)
+            this.log(`Error: Negative values not accepted. Defaulting to ${Math.abs(clientAnswer.workers)}.`);
         }
 
         roundAnswers = await this.prompt(configQuestions.roundQuestions);
 
-        if (roundAnswers.txType === "txDuration") {
+        if (roundAnswers.txType === 'txDuration') {
             txValueAnswer = await this.prompt(configQuestions.txDurationQuestion);
             if (isNaN(parseFloat(txValueAnswer.txDuration))) {
-              this.log(`Error: Not a valid input. Using default txDuration value of ${defaultTxValue}.`)
+                this.log(`Error: Not a valid input. Using default txDuration value of ${defaultTxValue}.`);
             }
             if (txValueAnswer.txDuration < 0) {
-                this.log(`Error: Negative values not accepted. Defaulting to ${Math.abs(txValueAnswer.txDuration)}.`)
+                this.log(`Error: Negative values not accepted. Defaulting to ${Math.abs(txValueAnswer.txDuration)}.`);
             }
         }
-        if (roundAnswers.txType === "txNumber") {
+        if (roundAnswers.txType === 'txNumber') {
             txValueAnswer = await this.prompt(configQuestions.txNumberQuestion);
             if (isNaN(parseFloat(txValueAnswer.txNumber))) {
-              this.log(`Error: Not a valid input. Using default txNumber value of ${defaultTxValue}.`)
+                this.log(`Error: Not a valid input. Using default txNumber value of ${defaultTxValue}.`);
             }
             if (txValueAnswer.txNumber < 0) {
-                this.log(`Error: Negative values not accepted. Defaulting to ${Math.abs(txValueAnswer.txNumber)}.`)
+                this.log(`Error: Negative values not accepted. Defaulting to ${Math.abs(txValueAnswer.txNumber)}.`);
             }
         }
 
@@ -160,6 +166,10 @@ module.exports = class extends Generator {
         promptAnswers = this.options;
     }
 
+    /**
+     * Creates the workload module file/callback.
+     * @private
+     */
     _callbackWrite() {
         answersObject.chaincodeId = promptAnswers.chaincodeId;
         answersObject.version = promptAnswers.version;
@@ -183,13 +193,17 @@ module.exports = class extends Generator {
         this.fs.copyTpl(
             this.templatePath('callback.js'),
             this.destinationPath(`${ promptAnswers.workspace }/benchmarks/callbacks/${ answersObject.callback }`), answersObject
-            )
+        );
     }
 
+    /**
+     * Creates the benchmark configuration file.
+     * @private
+     */
     _configWrite() {
         answersObject.benchmarkName = promptAnswers.benchmarkName;
         answersObject.benchmarkDescription = promptAnswers.benchmarkDescription;
-        answersObject.workers = promptAnswers.workers
+        answersObject.workers = promptAnswers.workers;
         answersObject.label = promptAnswers.label;
         answersObject.txType = promptAnswers.txType;
         answersObject.chaincodeId = promptAnswers.chaincodeId;
@@ -205,58 +219,64 @@ module.exports = class extends Generator {
 
         if (promptAnswers.txType === 'txDuration') {
             if (isNaN(promptAnswers.txDuration)) {
-              answersObject.txValue = defaultTxValue;
+                answersObject.txValue = defaultTxValue;
             } else if (promptAnswers.txDuration < 0) {
                 answersObject.txValue = Math.abs(promptAnswers.txDuration);
             } else {
                 answersObject.txValue = promptAnswers.txDuration;
             }
-        };
+        }
 
 
         if (promptAnswers.txType === 'txNumber') {
             if (isNaN(promptAnswers.txNumber)) {
-              answersObject.txValue = defaultTxValue;
+                answersObject.txValue = defaultTxValue;
             } else if (promptAnswers.txNumber < 0) {
                 answersObject.txValue = Math.abs(promptAnswers.txNumber);
             }
             else {
                 answersObject.txValue = promptAnswers.txNumber;
             }
-        };
+        }
 
         this.fs.copyTpl(
             this.templatePath('config.yaml'),
             this.destinationPath(`${ promptAnswers.workspace }/benchmarks/config.yaml`), answersObject
-          );
+        );
     }
 
+    /**
+     * Creates the benchmark artifacts.
+     */
     async writing () {
         console.log('Generating benchmark files...');
         this._callbackWrite();
         answersObject.rateController = promptAnswers.rateController;
 
         switch(promptAnswers.rateController) {
-            case 'fixed-rate':
-            answersObject.opts = `tps: 10`;
+        case 'fixed-rate':
+            answersObject.opts = 'tps: 10';
             this._configWrite();
             break;
         case 'fixed-backlog':
-            answersObject.opts = `unfinished_per_client: 5`;
+            answersObject.opts = 'unfinished_per_client: 5';
             this._configWrite();
             break;
         case 'linear-rate':
-            answersObject.opts = `startingTps: 25, finishingTps: 75`;
+            answersObject.opts = 'startingTps: 25, finishingTps: 75';
             this._configWrite();
             break;
         case 'fixed-feedback-rate':
-            answersObject.opts = `tps: 100, unfinished_per_client: 100`;
+            answersObject.opts = 'tps: 100, unfinished_per_client: 100';
             this._configWrite();
             break;
         }
     }
 
+    /**
+     * Called at the end of the benchmark generation.
+     */
     end(){
         console.log('Finished generating benchmark files');
-    };
-}
+    }
+};

--- a/packages/caliper-generator/generator-caliper/package.json
+++ b/packages/caliper-generator/generator-caliper/package.json
@@ -34,17 +34,17 @@
     "yosay": "^2.0.1"
   },
   "devDependencies": {
-    "js-yaml": "^3.13.1",
+    "js-yaml": "^3.12.0",
     "fs-extra": "8.1.0",
     "yeoman-assert": "^3.1.1",
     "yeoman-test": "^1.7.0",
-    "mocha": "6.2.1",
-    "sinon": "7.5.0",
-    "chai": "^4.0.0",
+    "mocha": "3.4.2",
+    "sinon": "^7.3.2",
+    "chai": "^3.5.0",
     "sinon-chai": "^3.3.0",
-    "eslint": "^4.19.1",
+    "eslint": "^5.16.0",
     "rewire": "^4.0.0",
-    "nyc": "14.1.1",
+    "nyc": "11.1.0",
     "license-check-and-add": "2.3.6"
   },
   "license": "Apache-2.0",

--- a/packages/caliper-generator/generator-caliper/test/benchmark/callback.js
+++ b/packages/caliper-generator/generator-caliper/test/benchmark/callback.js
@@ -12,20 +12,20 @@
 * limitations under the License.
 */
 
+'use strict';
+
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');
-const fs = require('fs');
 const chai = require('chai');
 chai.should();
 
 const path = require('path');
 
 describe('', () => {
-    let dir, tmpCallbackPath;
     let options = {
         subgenerator: 'benchmark',
         chaincodeFunction: 'callback',
-        chaincodeArguments: `["args1", "args2", "args3"]`,
+        chaincodeArguments: '["args1", "args2", "args3"]',
         name: 'x contract benchmark',
         description: 'benchmark for contract x',
         workers: 5,
@@ -42,11 +42,8 @@ describe('', () => {
 
     const runGenerator = async () => {
         await helpers.run(path.join(__dirname, '../../generators/app'))
-            .inTmpDir((dir_) => {
-                dir = dir_;
-            })
+            .inTmpDir((dir_) => {})
             .withPrompts(options);
-        tmpCallbackPath = path.join(dir, callbackFile);
     };
 
     it('should create a callbacks folder', async () => {
@@ -61,48 +58,48 @@ describe('', () => {
 
     it('should populate the file based on answers to user prompts', async () => {
         await runGenerator();
-        let callbackFileContent = `/*\n` +
-        `* Licensed under the Apache License, Version 2.0 (the "License");\n` +
-        `* you may not use this file except in compliance with the License.\n` +
-        `* You may obtain a copy of the License at\n` +
-        `* \n` +
-        `* http://www.apache.org/licenses/LICENSE-2.0\n` +
-        `* \n` +
-        `* Unless required by applicable law or agreed to in writing, software\n` +
-        `* distributed under the License is distributed on an "AS IS" BASIS,\n` +
-        `* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n` +
-        `* See the License for the specific language governing permissions and\n` +
-        `* limitations under the License.\n` +
-        `*/\n` +
-        `\n` +
-        `'use strict';\n` +
-        `\n` +
+        let callbackFileContent = '/*\n' +
+        '* Licensed under the Apache License, Version 2.0 (the "License");\n' +
+        '* you may not use this file except in compliance with the License.\n' +
+        '* You may obtain a copy of the License at\n' +
+        '* \n' +
+        '* http://www.apache.org/licenses/LICENSE-2.0\n' +
+        '* \n' +
+        '* Unless required by applicable law or agreed to in writing, software\n' +
+        '* distributed under the License is distributed on an "AS IS" BASIS,\n' +
+        '* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n' +
+        '* See the License for the specific language governing permissions and\n' +
+        '* limitations under the License.\n' +
+        '*/\n' +
+        '\n' +
+        '\'use strict\';\n' +
+        '\n' +
         `const contractId = '${options.chaincodeId}';\n` +
         `const version = '${options.version}';\n` +
-        `\n` +
-        `let bc, ctx, clientArgs, clientIdx;\n` +
-        `\n` +
-        `module.exports.init = async function(blockchain, context, args) {\n` +
-        `    bc = blockchain;\n` +
-        `    ctx = context;\n` +
-        `    clientArgs = args;\n` +
-        `    clientIdx = context.clientIdx.toString();\n` +
-        `\n` +
-        `    return Promise.resolve();\n` +
-        `};\n` +
-        `\n` +
-        `module.exports.run = function() {\n` +
-        `    let myArgs = {\n` +
+        '\n' +
+        'let bc, ctx, clientArgs, clientIdx;\n' +
+        '\n' +
+        'module.exports.init = async function(blockchain, context, args) {\n' +
+        '    bc = blockchain;\n' +
+        '    ctx = context;\n' +
+        '    clientArgs = args;\n' +
+        '    clientIdx = context.clientIdx.toString();\n' +
+        '\n' +
+        '    return Promise.resolve();\n' +
+        '};\n' +
+        '\n' +
+        'module.exports.run = function() {\n' +
+        '    let myArgs = {\n' +
         `        chaincodeFunction: '${options.chaincodeFunction}',\n` +
         `        chaincodeArguments: ${options.chaincodeArguments}\n` +
-        `    };\n` +
-        `\n` +
-        `    return bc.invokeSmartContract(ctx, contractId, version, myArgs, 60);\n` +
-        `};\n` +
-        `\n` +
-        `module.exports.end = async function() {\n` +
-        `    return Promise.resolve();\n` +
-        `};\n`
+        '    };\n' +
+        '\n' +
+        '    return bc.invokeSmartContract(ctx, contractId, version, myArgs, 60);\n' +
+        '};\n' +
+        '\n' +
+        'module.exports.end = async function() {\n' +
+        '    return Promise.resolve();\n' +
+        '};\n';
 
         assert.fileContent(callbackFile, callbackFileContent);
     });
@@ -111,27 +108,27 @@ describe('', () => {
         options.chaincodeArguments = '';
         await runGenerator();
 
-        assert.fileContent(`${options.workspace}/benchmarks/callbacks/${options.chaincodeFunction}.js`, "chaincodeArguments: []");
+        assert.fileContent(`${options.workspace}/benchmarks/callbacks/${options.chaincodeFunction}.js`, 'chaincodeArguments: []');
     });
 
     it('should default to an empty array if user input for chaincode argument does not start with [', async () => {
-        options.chaincodeArguments = `"args1", "args2", "args3"]`;
+        options.chaincodeArguments = '"args1", "args2", "args3"]';
         await runGenerator();
 
-        assert.fileContent(`${options.workspace}/benchmarks/callbacks/${options.chaincodeFunction}.js`, "chaincodeArguments: []");
+        assert.fileContent(`${options.workspace}/benchmarks/callbacks/${options.chaincodeFunction}.js`, 'chaincodeArguments: []');
     });
 
     it('should default to an empty array if user input for chaincode argument does not end with ]', async () => {
-        options.chaincodeArguments = `["args1", "args2", "args3"`;
+        options.chaincodeArguments = '["args1", "args2", "args3"';
         await runGenerator();
 
-        assert.fileContent(`${options.workspace}/benchmarks/callbacks/${options.chaincodeFunction}.js`, "chaincodeArguments: []");
+        assert.fileContent(`${options.workspace}/benchmarks/callbacks/${options.chaincodeFunction}.js`, 'chaincodeArguments: []');
     });
 
     it('should default to an empty array if user input is not the correct format', async () => {
-        options.chaincodeArguments = `[args1, "args2" "args3"]`;
+        options.chaincodeArguments = '[args1, "args2" "args3"]';
         await runGenerator();
 
-        assert.fileContent(`${options.workspace}/benchmarks/callbacks/${options.chaincodeFunction}.js`, "chaincodeArguments: []");
+        assert.fileContent(`${options.workspace}/benchmarks/callbacks/${options.chaincodeFunction}.js`, 'chaincodeArguments: []');
     });
 });

--- a/packages/caliper-generator/generator-caliper/test/benchmark/config.js
+++ b/packages/caliper-generator/generator-caliper/test/benchmark/config.js
@@ -175,7 +175,7 @@ describe ('benchmark configuration generator', () => {
     });
 
     it('should provide a default client value if user answered prompt with a string for workers', async () => {
-        options.workers = "penguin";
+        options.workers = 'penguin';
         await runGenerator();
 
         const config = yaml.safeLoad(fs.readFileSync(tmpConfigPath),'utf8');
@@ -222,7 +222,7 @@ describe ('benchmark configuration generator', () => {
 
     it('should provide a default txDuration if user answered prompt with a string for txDuration', async () => {
         options.txType = 'txDuration';
-        options.txDuration = "penguin";
+        options.txDuration = 'penguin';
         await runGenerator();
 
         const config = yaml.safeLoad(fs.readFileSync(tmpConfigPath),'utf8');
@@ -234,7 +234,7 @@ describe ('benchmark configuration generator', () => {
 
     it('should provide a default txNumber if user answered prompt with a string for txNumber', async () => {
         options.txType = 'txNumber';
-        options.txNumber = "penguin";
+        options.txNumber = 'penguin';
         await runGenerator();
 
         const config = yaml.safeLoad(fs.readFileSync(tmpConfigPath),'utf8');

--- a/packages/caliper-publish/lib/version.js
+++ b/packages/caliper-publish/lib/version.js
@@ -1,0 +1,25 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+exports.command = 'version <subcommand>';
+exports.desc = 'Commands for checking and fixing package versions across the mono-repository';
+exports.builder = yargs => {
+    // apply commands in subdirectories
+    return yargs
+        .demandCommand(1, 'Incorrect command. Please see "./publish.js version --help"')
+        .commandDir('version');
+};
+exports.handler = argv => {};

--- a/packages/caliper-publish/lib/version/checkCommand.js
+++ b/packages/caliper-publish/lib/version/checkCommand.js
@@ -1,0 +1,29 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const Check = require('./impl/check');
+
+module.exports.command = 'check';
+module.exports.describe = 'Check whether the Caliper package versions match the root version';
+module.exports.builder = yargs => {
+    yargs.help();
+    yargs.usage('Example usage:\n./publish.js version check');
+    return yargs;
+};
+
+module.exports.handler = argv => {
+    argv.thePromise = Check.handler();
+};

--- a/packages/caliper-publish/lib/version/fixCommand.js
+++ b/packages/caliper-publish/lib/version/fixCommand.js
@@ -1,0 +1,29 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const Fix = require('./impl/fix');
+
+module.exports.command = 'fix';
+module.exports.describe = 'Restore the Caliper package versions to the root version';
+module.exports.builder = yargs => {
+    yargs.help();
+    yargs.usage('Example usage:\n./publish.js version fix');
+    return yargs;
+};
+
+module.exports.handler = argv => {
+    argv.thePromise = Fix.handler();
+};

--- a/packages/caliper-publish/lib/version/impl/check.js
+++ b/packages/caliper-publish/lib/version/impl/check.js
@@ -1,0 +1,66 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const path = require('path');
+
+// impl => version => lib => caliper-publish => packages => root
+const repoRoot = path.join(__dirname, '..', '..', '..', '..', '..');
+
+/**
+ * Implements the version check command logic.
+ */
+class Check {
+    /**
+     * Handler for the version check invocation.
+     * @async
+     */
+    static async handler() {
+        const lernaJsonPath = path.join(repoRoot, 'lerna.json');
+        const lernaObject = require(lernaJsonPath);
+        const lernaVersion = lernaObject.version;
+        const packages = Array.from(lernaObject.packages);
+        // add the root "package"
+        packages.push('./');
+
+        let mismatch = false;
+        console.log('Checking package versions...');
+
+        for (const pkg of packages) {
+            const packageJsonPath = path.join(repoRoot, pkg, 'package.json');
+            const packageObject = require(packageJsonPath);
+
+            if (packageObject.version !== lernaVersion) {
+                mismatch = true;
+                console.log(`ERROR: package "${pkg}" version "${packageObject.version}" does not match lerna version "${lernaVersion}"`);
+            }
+
+            for (const dep of Object.keys(packageObject.dependencies)) {
+                if (dep.startsWith('@hyperledger/caliper-') && packageObject.dependencies[dep] !== lernaVersion) {
+                    mismatch = true;
+                    console.log(`ERROR: package "${pkg}" dependency "${dep}" does not match lerna version "${lernaVersion}"`);
+                }
+            }
+        }
+
+        if (mismatch) {
+            throw new Error(`Some package versions do not match the lerna version "${lernaVersion}"`);
+        }
+
+        console.log('Package versions are correct');
+    }
+}
+
+module.exports = Check;

--- a/packages/caliper-publish/lib/version/impl/fix.js
+++ b/packages/caliper-publish/lib/version/impl/fix.js
@@ -1,0 +1,73 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+
+// impl => version => lib => caliper-publish => packages => root
+const repoRoot = path.join(__dirname, '..', '..', '..', '..', '..');
+
+/**
+ * Utility function for overwriting the common Caliper version in the package.json files.
+ * @param {string} packageJsonPath The path of the package.json file.
+ * @param {string} customVersion The new version to use.
+ */
+function injectCustomVersion(packageJsonPath, customVersion) {
+    const packageObject = require(packageJsonPath);
+
+    if (packageObject.version !== customVersion) {
+        console.log(`Setting package version in "${packageJsonPath}" to "${customVersion}"`);
+        // overwrite the current version
+        packageObject.version = customVersion;
+
+        // overwrite every dependency to other Caliper packages if any (to keep unstable builds in sync)
+        for (const dep of Object.keys(packageObject.dependencies)) {
+            if (dep.startsWith('@hyperledger/caliper-')) {
+                console.log(`\tSetting dependency version for "${dep}" to "${customVersion}"`);
+                packageObject.dependencies[dep] = customVersion;
+            }
+        }
+
+        // serialize new content
+        fs.writeFileSync(packageJsonPath, JSON.stringify(packageObject, null, 4));
+    }
+}
+
+/**
+ * Implements the version fix command logic.
+ */
+class Fix {
+    /**
+     * Handler for the version fix invocation.
+     * @async
+     */
+    static async handler() {
+        const lernaJsonPath = path.join(repoRoot, 'lerna.json');
+        const lernaObject = require(lernaJsonPath);
+        const lernaVersion = lernaObject.version;
+        const packages = Array.from(lernaObject.packages);
+        // add the root "package"
+        packages.push('./');
+
+        console.log('Fixing package versions...');
+
+        for (const pkg of packages) {
+            injectCustomVersion(path.join(repoRoot, pkg, 'package.json'), lernaVersion);
+        }
+    }
+}
+
+module.exports = Fix;


### PR DESCRIPTION
Signed-off-by: Attila Klenik <a.klenik@gmail.com>

The PR adds package version check and fix functionality to the internal CLI. This check is also added to the CI test.

Covers and extends #758 

## Validate check
Bump the root json version, and run `./publish.js version check` from the `./packages/caliper-publish` directory. Note, that misaligned version in the packages themselves are picked up during lerna bootstrap.

## Validate fix
Run `./publish.js version fix` from the `./packages/caliper-publish` directory after the previous bump. It should bump all package versions and cross-package dependencies to the root version.