### PR TITLE
Update binding to official fabric-sdk-node

### DIFF
--- a/packages/caliper-cli/lib/lib/config.yaml
+++ b/packages/caliper-cli/lib/lib/config.yaml
@@ -60,9 +60,10 @@ sut:
             packages: ['fabric-client@1.4.6', 'fabric-protos@2.0.0-snapshot.1', 'fabric-network@1.4.6']
         1.4.7: &fabric-latest
             packages: ['fabric-client@1.4.7', 'fabric-protos@2.0.0-snapshot.1', 'fabric-network@1.4.7']
-        2.0.0:
-            packages: ['fabric-common@2.0.0-snapshot.388', 'fabric-protos@2.0.0-snapshot.246', 'fabric-network@2.0.0-snapshot.352', fabric-ca-client@2.0.0-snapshot.396']
+        2.1.0: &fabric-latest-v2
+            packages: ['fabric-common@2.1.0', 'fabric-protos@2.1.0', 'fabric-network@2.1.0', fabric-ca-client@2.1.0']
         latest: *fabric-latest
+        latest-v2: *fabric-latest-v2
 
     sawtooth:
         1.0.0:


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

Turns out there was an official fabric-sdk-node release (who knew!) so we can now use that as an official binding.

Added new link for `latest-v2`

Would appear that there is no 2.0.0 version and just a 2.1.0 version, so we will have to skip the 2.0.0 entry