### PR TITLE
ethereum: add contractDeployerAddress to context

### DIFF
--- a/packages/caliper-ethereum/lib/ethereum.js
+++ b/packages/caliper-ethereum/lib/ethereum.js
@@ -124,9 +124,16 @@ class Ethereum extends BlockchainInterface {
                 estimateGas: args.contracts[key].estimateGas
             };
         }
+
         if (this.ethereumConfig.fromAddress) {
             context.fromAddress = this.ethereumConfig.fromAddress;
         }
+
+        if (this.ethereumConfig.contractDeployerAddress) {
+            context.contractDeployerAddress = this.ethereumConfig.contractDeployerAddress;
+            context.contractDeployerAddressPrivateKey = this.ethereumConfig.contractDeployerAddressPrivateKey;
+        }
+
         if (this.ethereumConfig.fromAddressSeed) {
             let hdwallet = EthereumHDKey.fromMasterSeed(this.ethereumConfig.fromAddressSeed);
             let wallet = hdwallet.derivePath('m/44\'/60\'/' + this.clientIndex + '\'/0/0').getWallet();


### PR DESCRIPTION
Without this change, it's impossible to configure Ownable contracts and similar from within the benchmark callback script. This is useful for RBAC contracts as well.