### PR TITLE
ethereum: disallow http(s) RPC transports

### DIFF
--- a/packages/caliper-ethereum/lib/ethereum.js
+++ b/packages/caliper-ethereum/lib/ethereum.js
@@ -38,12 +38,41 @@ class Ethereum extends BlockchainInterface {
      */
     constructor(workerIndex) {
         super();
-        let configPath = CaliperUtils.resolvePath(ConfigUtil.get(ConfigUtil.keys.NetworkConfig));
         this.bcType = 'ethereum';
-        this.ethereumConfig = require(configPath).ethereum;
+
+        let configPath = CaliperUtils.resolvePath(ConfigUtil.get(ConfigUtil.keys.NetworkConfig));
+        let ethereumConfig = require(configPath).ethereum;
+
+        // throws on configuration error
+        this.checkConfig(ethereumConfig);
+
+        this.ethereumConfig = ethereumConfig;
         this.web3 = new Web3(this.ethereumConfig.url);
         this.web3.transactionConfirmationBlocks = this.ethereumConfig.transactionConfirmationBlocks;
         this.clientIndex = workerIndex;
+    }
+
+    /**
+     * Check the ethereum networkconfig file for errors, throw if invalid
+     * @param {object} ethereumConfig The ethereum networkconfig to check.
+     */
+    checkConfig(ethereumConfig) {
+        if (!ethereumConfig.url) {
+            throw new Error(
+                'No URL given to access the Ethereum SUT. Please check your network configuration. ' +
+                'Please see https://hyperledger.github.io/caliper/v0.3/ethereum-config/ for more info.'
+            );
+        }
+
+        if (ethereumConfig.url.toLowerCase().indexOf('http') === 0) {
+            throw new Error(
+                'Ethereum benchmarks must not use http(s) RPC connections, as there is no way to guarantee the ' +
+                'order of submitted transactions when using other transports. For more information, please see ' +
+                'https://github.com/hyperledger/caliper/issues/776#issuecomment-624771622'
+            );
+        }
+
+        //TODO: add validation logic for the rest of the configuration object
     }
 
     /**

--- a/packages/caliper-tests-integration/besu_tests/phase1/networkconfig.json
+++ b/packages/caliper-tests-integration/besu_tests/phase1/networkconfig.json
@@ -7,7 +7,7 @@
           }
     },
     "ethereum": {
-        "url": "http://localhost:8545",
+        "url": "ws://localhost:8546",
         "contractDeployerAddress": "0xD1cf9D73a91DE6630c2bb068Ba5fDdF9F0DEac09",
         "contractDeployerAddressPrivateKey": "0x797c13f7235c627f6bd013dc17fff4c12213ab49abcf091f77c83f16db10e90b",
         "fromAddressSeed": "0x3f841bf589fdf83a521e55d51afddc34fa65351161eead24f064855fc29c9580",

--- a/packages/caliper-tests-integration/besu_tests/phase2/networkconfig.json
+++ b/packages/caliper-tests-integration/besu_tests/phase2/networkconfig.json
@@ -7,7 +7,7 @@
           }
     },
     "ethereum": {
-        "url": "http://localhost:8545",
+        "url": "ws://localhost:8546",
         "contractDeployerAddress": "0xD1cf9D73a91DE6630c2bb068Ba5fDdF9F0DEac09",
         "contractDeployerAddressPrivateKey": "0x797c13f7235c627f6bd013dc17fff4c12213ab49abcf091f77c83f16db10e90b",
         "fromAddressSeed": "0x3f841bf589fdf83a521e55d51afddc34fa65351161eead24f064855fc29c9580",

--- a/packages/caliper-tests-integration/besu_tests/phase3/networkconfig.json
+++ b/packages/caliper-tests-integration/besu_tests/phase3/networkconfig.json
@@ -7,7 +7,7 @@
           }
     },
     "ethereum": {
-        "url": "http://localhost:8545",
+        "url": "ws://localhost:8546",
         "contractDeployerAddress": "0xD1cf9D73a91DE6630c2bb068Ba5fDdF9F0DEac09",
         "contractDeployerAddressPrivateKey": "0x797c13f7235c627f6bd013dc17fff4c12213ab49abcf091f77c83f16db10e90b",
         "fromAddressSeed": "0x3f841bf589fdf83a521e55d51afddc34fa65351161eead24f064855fc29c9580",

--- a/packages/caliper-tests-integration/ethereum_tests/config/docker-compose.yml
+++ b/packages/caliper-tests-integration/ethereum_tests/config/docker-compose.yml
@@ -23,5 +23,5 @@ services:
     volumes:
       - ./keys:/root/.ethereum/keystore
     ports:
-      - 8545:8545
-    command: --unlock 0xc0A8e4D217eB85b812aeb1226fAb6F588943C2C2 --password /root/.ethereum/keystore/password --mine --minerthreads 2 --etherbase 0xc0A8e4D217eB85b812aeb1226fAb6F588943C2C2 --rpc --rpcaddr 0.0.0.0 --rpcvhosts=* --rpcapi admin,eth,miner,personal,web3 --allow-insecure-unlock --nodiscover --gasprice 1
+      - 8546:8546
+    command: --unlock 0xc0A8e4D217eB85b812aeb1226fAb6F588943C2C2 --password /root/.ethereum/keystore/password --mine --minerthreads 2 --etherbase 0xc0A8e4D217eB85b812aeb1226fAb6F588943C2C2 --ws --wsaddr 0.0.0.0 --wsorigins='*' --wsapi admin,eth,miner,personal,web3 --allow-insecure-unlock --nodiscover --gasprice 1

--- a/packages/caliper-tests-integration/ethereum_tests/networkconfig.json
+++ b/packages/caliper-tests-integration/ethereum_tests/networkconfig.json
@@ -7,7 +7,7 @@
           }
     },
     "ethereum": {
-        "url": "http://localhost:8545",
+        "url": "ws://localhost:8546",
         "contractDeployerAddress": "0xc0A8e4D217eB85b812aeb1226fAb6F588943C2C2",
         "contractDeployerAddressPassword": "password",
         "fromAddress": "0xc0A8e4D217eB85b812aeb1226fAb6F588943C2C2",


### PR DESCRIPTION
Fixes #776. See https://github.com/hyperledger/caliper/issues/776#issuecomment-624771622 for more info.

Signed-off-by: Ben Burns <803016+benjamincburns@users.noreply.github.com>