### PR TITLE
0.3.1 release docs and bump fix for minor versions

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,55 +1,27 @@
-# Welcome to Jekyll!
-#
-# This config file is meant for settings that affect your whole blog, values
-# which you are expected to set up once and rarely edit after that. If you find
-# yourself editing this file very often, consider using Jekyll's data files
-# feature for the data you need to update frequently.
-#
-# For technical reasons, this file is *NOT* reloaded automatically when you use
-# 'bundle exec jekyll serve'. If you change this file, please restart the server process.
-
-# Site settings
-# These are used to personalize your new site. If you look in the HTML files,
-# you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
-# You can create any custom variable you would like, and they will be accessible
-# in the templates via {{ site.myvariable }}.
 title: Hyperledger Caliper
-description: >- # this means to ignore newlines until "baseurl:"
-  Caliper is a blockchain performance benchmark framework, which allows users to test different blockchain solutions with predefined use cases, and get a set of performance test results.
-
-url       : https://hyperledger.github.io # the base hostname & protocol for the site
-baseurl   : /caliper # the subpath of the site, represents version in this example repo
-repository: hyperledger/caliper # GitHub username/repo-name e.g. "mmistakes/minimal-mistakes"
-repo      : caliper
-
+description: >-
+  Caliper is a blockchain performance benchmark framework, which allows users to
+  test different blockchain solutions with predefined use cases, and get a set
+  of performance test results.
+url: 'https://hyperledger.github.io'
+baseurl: /caliper
+repository: hyperledger/caliper
+repo: caliper
 caliper:
-  v0_2: v0.2
-  v0_3: v0.3
-  current_release: v0.3
-  next_release: vNext
-
-# Build settings
+  v0_2: v0.2/
+  v0_3: v0.3/
+  current_release: v0.3.1/
+  next_release: vNext/
+  v0_3_1: v0.3.1/
 markdown: kramdown
 kramdown:
   parse_block_html: true
 theme: minima
 plugins:
   - jekyll-feed
-categories: [docs]
-
+categories:
+  - docs
 collections:
   docs:
     output: true
     permalink: '/:collection/:path/'
-
-# Exclude from processing.
-# The following items will not be processed, by default. Create a custom list
-# to override the default setting.
-# exclude:
-#   - Gemfile
-#   - Gemfile.lock
-#   - node_modules
-#   - vendor/bundle/
-#   - vendor/cache/
-#   - vendor/gems/
-#   - vendor/ruby/

--- a/_includes/v0.3.1.html
+++ b/_includes/v0.3.1.html
@@ -2,9 +2,9 @@
   <p style="color: #2a7ae2;">Version</p>
   <select id="versionSelect" onchange="location = this.options[this.selectedIndex].value;"
     style="width:5rem; height: 1.5rem;">
-    <option value="/caliper/v0.2/getting-started/" selected> v0.2</option>
+    <option value="/caliper/v0.2/getting-started/"> v0.2</option>
     <option value="/caliper/v0.3/getting-started/"> v0.3</option>
-    <option value="/caliper/v0.3.1/getting-started/">v0.3.1</option>
+    <option value="/caliper/v0.3.1/getting-started/" selected>v0.3.1</option>
     <option value="/caliper/vNext/getting-started/">vNext</option>
   </select>
 </div>
@@ -12,7 +12,7 @@
 {% assign sorted_pages = site.pages | sort:"order" %}
 {% for page in sorted_pages %}
 {% if page.categories contains 'docs'%}
-{% if page.permalink contains site.caliper.v0_2 %}
+{% if page.permalink contains site.caliper.v0_3_1 %}
 <div class="item">
   <!-- <p>{{page.description}}</p> -->
   <li><a href="{{ page.url | relative_url }}">{{ page.title }}</a></li>
@@ -23,7 +23,7 @@
 <hr>
 {% for page in sorted_pages %}
 {% if page.categories contains 'config' %}
-{% if page.permalink contains site.caliper.v0_2 %}
+{% if page.permalink contains site.caliper.v0_3_1 %}
 <div class="item">
   <!-- <p>{{page.description}}</p> -->
   <li><a href="{{ page.url | relative_url }}">{{ page.title }}</a></li>
@@ -34,7 +34,7 @@
 <hr>
 {% for page in sorted_pages %}
 {% if page.categories contains 'reference' %}
-{% if page.permalink contains site.caliper.v0_2 %}
+{% if page.permalink contains site.caliper.v0_3_1 %}
 <div class="item">
   <!-- <p>{{page.description}}</p> -->
   <li><a href="{{ page.url | relative_url }}">{{ page.title }}</a></li>
@@ -45,7 +45,7 @@
 <hr>
 {% for page in sorted_pages %}
 {% if page.categories contains 'opensource' %}
-{% if page.permalink contains site.caliper.v0_2 %}
+{% if page.permalink contains site.caliper.v0_3_1 %}
 <div class="item">
   <!-- <p>{{page.description}}</p> -->
   <li><a href="{{ page.url | relative_url }}">{{ page.title }}</a></li>

--- a/_includes/v0.3.html
+++ b/_includes/v0.3.html
@@ -4,6 +4,7 @@
     style="width:5rem; height: 1.5rem;">
     <option value="/caliper/v0.2/getting-started/"> v0.2</option>
     <option value="/caliper/v0.3/getting-started/" selected> v0.3</option>
+    <option value="/caliper/v0.3.1/getting-started/">v0.3.1</option>
     <option value="/caliper/vNext/getting-started/">vNext</option>
   </select>
 </div>

--- a/_includes/vNext.html
+++ b/_includes/vNext.html
@@ -4,6 +4,7 @@
     style="width:5rem; height: 1.5rem;">
     <option value="/caliper/v0.2/getting-started/"> v0.2</option>
     <option value="/caliper/v0.3/getting-started/"> v0.3</option>
+    <option value="/caliper/v0.3.1/getting-started/">v0.3.1</option>
     <option value="/caliper/vNext/getting-started/" selected>vNext</option>
   </select>
 </div>

--- a/_layouts/v0.3.1.html
+++ b/_layouts/v0.3.1.html
@@ -1,0 +1,22 @@
+---
+layout: default
+---
+<div class="wrapper-3">
+  <div class="docs-wrapper">
+    <div class="docs-nav">
+        {%- include v0.3.1.html -%}
+    </div>
+    <div class="article-post">
+      <article class="post">
+        <header class="post-header">
+          <h1 class="post-title">{{ page.title | escape }}</h1>
+        </header>
+        <div class="post-content">
+          {{ content }}
+        </div>
+      </article>
+    </div>
+  </div>
+</div>
+<br>
+<br>

--- a/docs.json
+++ b/docs.json
@@ -1,3 +1,3 @@
 {
-	"target_release": "v0.4"
+	"target_release": "v0.3.1"
 }

--- a/docs/v0.3.1/Architecture.md
+++ b/docs/v0.3.1/Architecture.md
@@ -1,0 +1,192 @@
+---
+layout: v0.3.1
+title:  "Architecture"
+categories: docs
+permalink: /v0.3.1/architecture/
+order: 4
+---
+
+## Table of contents
+{:.no_toc}
+
+- TOC
+{:toc}
+
+## Overview
+
+Caliper is a general framework for executing benchmarks against different blockchain platforms. Caliper was designed with scalability and extensibility in mind to easily integrate with today's popular monitoring and infrastructure solutions. Accordingly, the architecture of Caliper can seem a bit complicated at first.
+
+This page aims to gradually ease you into the intricacies of Caliper's architecture, taking one step at a time. By the end of this page, you should be familiar with the general concepts and API of Caliper. As you read along, you will find references to other, more technical documentation pages. Feel free to explore them once you are familiar with the basic building blocks of Caliper.
+
+## Bird's eye view
+
+At its most simple form, Caliper is a service that generates a workload against a specific system under test (SUT) and continuously monitors its responses. Finally, Caliper generates a report based on the observed SUT responses. This simplistic view is depicted in the following figure. 
+
+<img src="{{ site.baseurl }}/assets/img/arch_high_level.png" alt="arch_high_level">
+
+Caliper requires several inputs to run a benchmark, independently of the used SUT. The following subsections give a brief overview of these inputs.
+
+### Benchmark configuration file
+
+The benchmark configuration file describes how the benchmark should be executed. It tells Caliper how many rounds it should execute, at what rate the TXs should be submitted, and which module will generate the TX content. It also includes settings about monitoring the SUT.
+
+You can consider this file as the "flow orchestrator" of the benchmark. For the most part, the settings are independent of the SUT, so you can easily reuse them when performing multiple benchmarks against different SUT types or versions.
+
+> __Note:__ For a more technical introduction to the benchmark configuration file, see the [corresponding page](./BenchmarkConfiguration.md).
+
+### Network configuration file
+
+The content of the network configuration file is SUT-specific. The file usually describes the topology of the SUT, where its nodes are (their endpoint addresses), what identities/clients are present in the network, and what smart contracts Caliper should deploy or interact with.
+
+For the exact structure of the network configuration files, refer to the corresponding SUT adapter documentations (we'll discuss adapters a bit later on this page):
+* [Hyperledger Besu & Ethereum](./Ethereum_Configuration.md)
+* [Hyperledger Burrow](./Burrow_Configuration.md)
+* [Hyperledger Fabric](./Fabric_Configuration.md)
+* [Hyperledger Iroha](./Iroha_Configuration.md)
+* [Hyperledger Sawtooth](./Sawtooth_Configuration.md)
+* [FISCO BCOS](./FISCO_BCOS_Configuration.md)
+
+### Workload modules
+
+Workload modules are the brain of a benchmark. Since Caliper is a general benchmark framework, it does not include any concrete benchmark implementation. When Caliper schedules TXs for a given round, it is the task of the round's workload module to generate the content of the TXs and submit it. Each round can have a different associated workload module, so separating your workload implementation based on phases/behavior should be easy.
+
+Workload modules are simply Node.JS modules that must export a given API/functions. Other than that, the workload module logic can be arbitrary. Really, anything you can code in Node.JS.
+
+> __Note:__ For a more technical introduction to workload modules, see the [corresponding page](./Workload_Module.md).
+
+### Benchmark artifacts
+
+There might be additional artifacts necessary to run a benchmark that can vary between different benchmarks and runs. These usually include the followings:
+* Crypto materials necessary to interact with the SUT.
+* Smart contract source code for Caliper to deploy (if the SUT adapter supports such operation).
+* [Runtime configuration](./Runtime_Configuration.md) files.
+* Pre-installed third party packages for your workload modules.
+
+Refer to the SUT adapter configuration pages for the additional necessary artifacts. 
+
+> __Note:__ From here on out, we will refer to the introduced Caliper inputs simply as benchmark artifacts and denote them with the database symbol seen in the first figure. 
+
+## Multi-platform support
+
+Before we further dive into the architecture of Caliper, let's see how Caliper can support multiple SUT types. Caliper implements the well-known adapter/facade pattern to hide the peculiarities of different SUT types and provide a unified interface towards the Caliper (and external) modules.
+
+> __Note:__ The adapter and facade design patterns have some overlap in the problems they aim to solve. Caliper borrows pieces from both. However, we use the adapter terminology throughout the entire documentation for consistency reasons.
+
+A SUT adapter provides a simplified interface towards internal Caliper modules, as well as towards the workload modules. Accordingly, Caliper can request the execution of simple things, like "initialize the adapter/SUT", and the adapter implementation will take care of the rest. The exact tasks to perform during the initialization are often determined by the content of the network configuration file (and by the remote administrative actions the SUT supports).
+
+> __Note:__ For the technical details of how to implement an adapter, refer to the [corresponding page](./Writing_Adapters.md).
+
+## Caliper processes
+
+Caliper considers scalability one of its most important goals (besides extensibility/flexibility). Workload generation from a single machine can quickly reach the resource limitations of the machine. If we want the workload rate to match the scalability and performance characteristics of the evaluated SUT then we need a distributed approach!
+
+Accordingly, Caliper (as a framework) comprises of two different services/processes: a master process and numerous worker processes.
+* The master process initializes the SUT (if supported) and coordinates the run of the benchmark (i.e., schedules the configured rounds) and handles the performance report generation based on the observed TX statistics.
+* The worker processes perform the actual workload generation, independently of each other. Even if a worker process reaches the limits of its host machine, using more worker processes (on multiple machines) can further increase the workload rate of Caliper. Thus worker processes are the backbone of Caliper's scalability.
+
+The described setup is illustrated in the next figure.
+
+<img src="{{ site.baseurl }}/assets/img/arch_processes.png" alt="arch_processes">
+
+> __Note:__ For the time being, we will ignore the technical details of the distributed architecture, like the messaging between the processes. We will come back to it in a later section.
+
+### The master process
+
+The Caliper master process is the orchestrator of the entire benchmark run. It goes through several predefined stages as depicted by the figure below.
+
+<img src="{{ site.baseurl }}/assets/img/arch_master_process.png" alt="arch_master_process">
+
+1. In the first stage, Caliper executes the startup script (if present) from the network configuration file. This step is mainly useful for local Caliper and SUT deployments as it provides a convenient way to start the network and Caliper in one step.
+  > __Note:__ The deployment of the SUT is not the responsibility of Caliper. Technically, Caliper only connects to an already running SUT, even if it was started through the startup script.
+2. In the second stage, Caliper initializes the SUT. The tasks performed here are highly dependent on the capabilities of the SUT and the SUT adapter. For example, the Hyperledger Fabric adapter uses this stage to create/join channels and register/enroll new users.
+3. In the third stage, Caliper deploys the smart contracts to the SUT, if the SUT and the adapter support such operation (like with the Hyperledger Fabric adapter). 
+4. In the fourth stage Caliper schedules and executes the configured rounds through the worker processes. This is the stage where the workload generation happens (through the workers!). 
+5. In the last stage, after executing the rounds and generating the report, Caliper executes the cleanup script (if present) from the network configuration file. This step is mainly useful for local Caliper and SUT deployments as it provides a convenient way to tear down the network and any temporary artifacts.
+
+If your SUT is already deployed an initialized, then you only need Caliper to execute the rounds and nothing else. Luckily, you can configure every stage one-by-one whether it should be executed or not. See the [flow control settings](./Runtime_Configuration.md#benchmark-phase-settings) for details.
+
+The above figure only shows the high-level steps of executing a benchmark. Some components are omitted for the sake of simplicity, like the monitor and worker progress observer components. To learn more about the purpose and configuration of these components, refer to the [Monitors and Observers](./MonitorsAndObservers.md) documentation page. 
+
+### The worker process
+
+The interesting things (from a user perspective) happen inside the worker processes. A worker process starts its noteworthy tasks when the master process sends a message to it about executing the next round (the 4th step in the previous section). The important components of a worker process are shown in the figure below.
+
+<img src="{{ site.baseurl }}/assets/img/arch_worker_process.png" alt="arch_worker_process">
+
+The worker process spends most of its time in the workload generation loop. The loop consists of two important steps:
+1. Waiting for the rate controller to enable the next TX. Think of the rate controller as a delay circuit. Based on what kind of rate controller is used, it delays/halts the execution of the worker (in an asynchronous manner) before enabling the next TX. For example, if a fixed 50 TXs per second (TPS) rate is configured, the rate controller will halt for 20ms between each TX.
+  > __Note:__ The rate controllers of each round can be configured in the [benchmark configuration file](./Benchmark_Configuration.md). For the available rate controllers, see the [Rate Controllers](./Rate_Controllers.md) page.
+2. Once the rate controller enables the next TX, the worker gives control to the workload module. The workload module assembles the parameters of the TX (specific to the SUT and smart contract API) and calls the simple API of the SUT adapter that will, in turn, send the TX request to the SUT (probably using the SDK of the SUT).
+  > __Note:__ The workload modules of each round can be configured in the [benchmark configuration file](./Benchmark_Configuration.md). For the technical details of workload modules, see the [Workload Modules](./Workload_Module.md) page. 
+
+During the workload loop, the worker process sends progress updates to the master process. Multiple approaches are available for signaling worker progress, achieved by different observers. For the available methods, see the [Monitors and Observers](./MonitorsAndOvservers.md) page.
+
+## Process distribution models
+
+The last part of the architecture discussion is demystifying the worker process management. Based on how worker processes are started and what messaging method is used between the master and worker processes, we can distinguish the following distribution/deployment models:
+1. Automatically spawned worker processes on the same host, using interprocess communication (IPC) with the master process.
+2. Automatically spawned worker processes on the same host, using a remote messaging mechanism with the master process.
+3. Manually started worker processes on an arbitrary number of hosts, using a remote messaging mechanism with the master process.
+
+Even though the third method is the way to go for more complex scenarios, the first two methods can help you get familiar with Caliper, and gradually aid you with the transition to the third method.
+
+### Modular message transport
+
+The different deployment approaches are made possible by how Caliper handles messaging internally, as shown by the following figure.
+
+<img src="{{ site.baseurl }}/assets/img/arch_messages.png" alt="arch_messages">
+
+The internal Caliper modules only deal with predefined messages whose content is independent of how the messages are sent. The module that sends the messages between the processes is swappable, thus enabling different communication methods.
+
+The deployment model is configurable with the following two setting keys:
+* `caliper-worker-remote`: if set to `false` (the default), then the master process will spawn the required number of worker processes locally, resulting in the models 1 or 2.
+* `caliper-worker-communication-method`: can take the values `process` (the default) or `mqtt` and determines the message transport implementation to use. The `process` communication corresponds to the first model, while `mqtt` denotes models 2 and 3.
+
+The following table summarizes the different models and how to select them:
+
+| `remote` value | `method` value | Corresponding deployment model |
+|:---:|:---:|:----|
+| `false` | `process` | 1. Interprocess communication with local workers |
+| `false` | `mqtt` | 2. Remote messaging-based communication with local workers |
+| `true` | `mqtt` | 3. Remote messaging-based communication with remote workers |
+| `true` | `process` | Invalid, since IPC does not apply to remote communication |
+
+> __Note:__ For the technical details on configuration the messaging transport, see the [Messengers](./Messengers.md) page. 
+
+### Interprocess communication
+
+The examples on the [Install & Usage](./Installing_Caliper.md) page all use the IPC approach since it is the default behavior. The setup is illustrated in the figure below.
+
+The `caliper launch master` CLI command starts the master process, which in turn will automatically spawn the configured number of worker processes (using the `caliper launch worker` CLI command). The communication between the processes is IPC, utilizing the built-in Node.JS method available for the parent-children process relationships.  
+
+<img src="{{ site.baseurl }}/assets/img/arch_ipc.png" alt="arch_ipc">
+
+This is the simplest deployment model for Caliper, requiring no additional configuration and third party messaging components. Accordingly, it is ideal when you first start using Caliper, or when you are still assembling the benchmark artifacts for your project, and just quickly want to test them. 
+
+Unfortunately, this model is constrained to a single host, thus suffers from scalability issues in the sense that only vertical scalability of the host is possible. 
+
+### Local message broker communication
+
+As a stepping stone towards the fully-distributed setup, the second deployment model replaces IPC with a third party messaging solution, while still hiding the worker process management from the user. The setup is illustrated in the figure below.
+
+<img src="{{ site.baseurl }}/assets/img/arch_local_mqtt.png" alt="arch_local_mqtt">
+
+Like before, the `caliper launch master` CLI command starts the master process, which in turn will automatically spawn the configured number of worker processes (using the `caliper launch worker` CLI command). However, the messaging happens through a separate component, which could be deployed anywhere as long as its endpoint is reachable by the Caliper processes.
+
+Unfortunately, this model is also constrained to a single host from the aspect of the Caliper processes. However, it is a useful model for taking your deployment to the next level once your benchmark artifacts are in place. Once you successfully integrated the messaging component, you are ready to move to the fully distributed Caliper setup. 
+
+### Distributed message broker communication
+
+When you take the management of the worker processes into your own hands, that's when the full potential of Caliper is unlocked. At this point, you can start as many workers on as many hosts as you would like, using the `caliper launch worker` CLI command. The setup is illustrated in the figure below.
+
+<img src="{{ site.baseurl }}/assets/img/arch_remote_mqtt.png" alt="arch_remote_mqtt">
+
+The fully distributed deployment enables the horizontal scaling of the worker processes, greatly increasing the achievable workload rate. To ease the management of the many Caliper processes, you will probably utilize some automatic deployment/management solution, like Docker Swarm or Kubernetes. Luckily, the flexibility of the [Caliper Docker image](./Installing_Caliper.md#using-the-docker-image) makes such integration painless.
+
+However, there are some caveats you have to keep in mind:
+1. Distributing the necessary benchmark artifacts to the Caliper processes is your responsibility. Different infrastructure solutions provide different means for this, so check your favorite vendor's documentation.
+2. Setting up proper networking in distributed systems is always a challenge. Make sure that the Caliper processes can access the configured messaging component and the SUT components.
+3. A single host may run multiple Caliper worker processes. When planning the worker distribution (or setting resource requirements for container management solutions) make sure that enough resources are allocated for workers to keep the configured TX scheduling precision.
+
+## License
+The Caliper codebase is released under the [Apache 2.0 license](./LICENSE.md). Any documentation developed by the Caliper Project is licensed under the Creative Commons Attribution 4.0 International License. You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/docs/v0.3.1/BenchmarkConfiguration.md
+++ b/docs/v0.3.1/BenchmarkConfiguration.md
@@ -1,0 +1,114 @@
+---
+layout: v0.3.1
+title:  "Benchmark Configuration"
+categories: docs
+permalink: /v0.3.1/bench-config/
+order: 5
+---
+
+## Table of contents
+{:.no_toc}
+
+- TOC
+{:toc}
+
+## Overview
+
+The `benchmark configuration file` is one of the required configuration files necessary to run a Caliper benchmark. In contrast to the [runtime configurations](./Runtime_Configuration.md), used for tweaking the internal behavior of Caliper, the benchmark configuration pertains only to the execution of the benchmark workload and collection of the results.
+
+> __Note:__ In theory, a benchmark configuration is independent of the system under test (SUT) and the internal configuration of Caliper. However, this independence might be limited by the implementation details of the benchmark workload module, which could target only a single SUT type.
+
+The benchmark configuration consists of three main parts:
+1. [Test settings](#benchmark-test-settings)
+2. [Observer settings](#observer-settings)
+3. [Monitoring settings](#monitoring-settings)
+
+For a complete benchmark configuration example, refer to the [last section](#example).
+
+> __Note:__ The configuration file can be either a YAML or JSON file, conforming to the format described below. The benchmark configuration file path can be specified for the master and worker processes using the `caliper-benchconfig` setting key. 
+
+## Benchmark test settings
+
+The settings related to the benchmark workload all reside under the root `test` attribute, which has some general child attributes, and the important `rounds` attribute.
+
+| Attribute | Description |
+|:----------|:------------|
+| test.name | Short name of the benchmark to display in the report. |
+| test.description | Detailed description of the benchmark to display in the report. |
+| test.workers | Object of worker-related configurations. |
+| test.workers.type | Currently unused. |
+| test.workers.number | Specifies the number of worker processes to use for executing the workload. |
+| test.rounds | Array of objects, each describing the settings of a round. |
+| test.rounds[i].label | A short name of the rounds, usually corresponding to the types of submitted TXs. |
+| test.rounds[i].txNumber | The number of TXs Caliper should submit during the round. |
+| test.rounds[i].txDuration | The length of the round in seconds during which Caliper will submit TXs. |
+| test.rounds[i].rateControl | The object describing the [rate controller](./Rate_Controllers.md) to use for the round. |
+| test.rounds[i].callback | The path to the benchmark [workload module](./Workload_Module.md) that will construct the TXs to submit |
+| test.rounds[i].arguments | Arbitrary object that will be passed to the workload module as configuration. |
+
+A benchmark configuration with the above structure will define a benchmark run that consists of multiple rounds. Each round is associated with a [rate controller](./Rate_Controllers.md) that is responsible for the scheduling of TXs, and a [workload module](./Workload_Module.md) that will generate the actual content of the scheduled TXs. 
+
+## Observer settings
+
+The observer configuration determines how the master process gathers progress information from the worker processes. The configuration resides under the `observer` attribute. Refer to the [observer configuration page](./MonitorsAndObservers.md#observers) for the details.
+
+## Monitoring settings
+
+The monitoring configuration determines what kind of metrics the master process can gather and from where. The configuration resides under the `monitor` attribute. Refer to the [monitor configuration page](./MonitorsAndObservers.md#monitors) for the details.
+
+## Example
+
+The example configuration below says the following:
+* Perform the benchmark run using 5 worker processes.
+* There will be two rounds.
+* The first `init` round will submit 500 TXs at a fixed 25 TPS send rate.
+* The content of the TXs are determined by the `init.js` workload module.
+* The second `query` round will submit TXs for 60 seconds at a fixed 5 TPS send rate.
+* The content of the TXs are determined by the `query.js` workload module.
+* The master process will observe the progress of the worker processes through a separate Prometheus instance at every 5 seconds.
+* The master process should include the predefined metrics of all local Docker containers in the report.
+* The master process should include the custom metric `Endorse Time (s)` based on the provided query for every available (peer) instance.
+
+```yaml
+test:
+  clients:
+    type: local
+    number: 5
+  rounds:
+  - label: init
+    txNumber: 500
+    rateControl:
+      type: fixed-rate
+      opts:
+        tps: 25
+    callback: benchmarks/samples/fabric/marbles/init.js
+  - label: query
+    txDuration: 60
+    rateControl:
+    - type: fixed-rate
+      opts:
+        tps: 5
+    callback: benchmarks/samples/fabric/marbles/query.js
+observer:
+  type: prometheus
+  interval: 5
+monitor:
+  interval: 1
+  type: ['docker', 'prometheus']
+  docker:
+    containers: ['all']
+  prometheus:
+    url: "http://prometheus:9090"
+    push_url: "http://pushGateway:9091"
+    metrics:
+      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter]
+      include:
+        Endorse Time (s):
+          query: rate(endorser_propsal_duration_sum{chaincode="marbles:v0"}[5m])/rate(endorser_propsal_duration_count{chaincode="marbles:v0"}[5m])
+          step: 1
+          label: instance
+          statistic: avg
+```
+
+## License
+The Caliper codebase is released under the [Apache 2.0 license](./LICENSE.md). Any documentation developed by the Caliper Project is licensed under the Creative Commons Attribution 4.0 International License. You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/docs/v0.3.1/Benchmark_Generator.md
+++ b/docs/v0.3.1/Benchmark_Generator.md
@@ -1,0 +1,164 @@
+---
+layout: v0.3.1
+title:  "Benchmark Generator"
+categories: reference
+permalink: /v0.3.1/benchmark-generator/
+order: 7
+---
+
+## Table of contents
+{:.no_toc}
+
+- TOC
+{:toc}
+
+## Overview
+The Caliper benchmark generator is a Yeoman generator for generating the configuration and callback files used to perform benchmarks on deployed smart contracts. This page will take you through installing and using the generator.
+
+## Installation
+You must first have Yeoman installed to be able to install and use the generator. You can do this using the following command:
+```bash
+npm install -g yo
+```
+
+Once Yeoman is installed, use the following command to install the generator:
+```bash
+npm install -g @hyperledger/generator-caliper
+```
+
+## Using the Generator
+To use the generator, run the following command
+```bash
+yo caliper
+```
+If successful, you should get the following output where you will be prompted to choose a generator - choose **Benchmark** to run the Caliper benchmark generator:
+```console
+Welcome to the Hyperledger Caliper generator!
+? Which generator would you like to run? (Use arrow keys)
+❯ Benchmark 
+```
+
+> Alternatively, you can run the benchmark generator using: `yo caliper:benchmark`.
+
+You will then get the following output where you will be prompted to name your workspace:
+```console
+Welcome to the Hyperledger Caliper benchmark generator!
+Let's start off by creating a workspace folder!
+? What would you like to call your workspace? myWorkspace
+```
+
+### Callback Prompts
+The benchmark generator will inititally take you through generating the callback file and you will be prompted for:
+* the **name** of your smart contract,
+* the **version** of your smart contract,
+* a smart contract **function**
+* the argument variables of your smart contract function, which must be entered in array format
+
+By the end, you should have something similar to the following:
+
+```console
+Now for the callback file...
+? What is the name of your smart contract? fabcar
+? What is the version of your smart contract? 0.0.1
+? Which smart contract function would you like to perform the benchmark on? changeCarOwner
+? What are the arguments of your smart contract function? (e.g. ["arg1", "arg2"]) ["CAR001", "Tom"]
+```
+
+### Configuration Prompts
+Next, you will be taken through generating the [configuration file](./Architecture#ConfigurationFile) and you will be prompted for:
+* the **name** of the benchmark
+* a **description** of the benchmark
+* the number of **workers**
+
+> __Note:__ On an invalid input value for workers, a default value will be used.
+
+* a **label** for differentiating between multiple rounds
+* the **rate controller** you would like to use. The generator currently provides the rate controllers displayed below as options. The generated configuration file will use default `opts` for whichever rate controller is chosen.
+
+```console
+? Which rate controller would you like to use? (Use arrow keys)
+❯ Fixed Rate 
+  Fixed Backlog 
+  Linear Rate 
+  Fixed Feedback Rate
+  ```
+* the method of which you should like to measure the length of the round. The round may be measured using either **transaction duration**, which defines the length of the round in seconds, or **transaction number**, which defines the length of the round using the number of transactions to be generated in the round.
+
+```console
+? How would you like to measure the length of the round? (Use arrow keys)
+❯ Transaction Duration 
+  Transaction Number
+```
+* a value for either `txNumber` or `txDuration` depending on the answer to previous prompt.
+
+> __Note:__ On an invalid input value for either **txDuration** or **txNumber**, a default value will be used.
+
+By the end, you should have something similar to the following:
+
+```console
+Now for the benchmark configuration file...
+? What would you like to name your benchmark? Fabcar benchmark
+? What description would you like to provide for your benchamrk? Benchmark for performance testing fabcar contract modules
+? How many workers would you like to have? 5
+? What label (hint for test) would you like to provide for your benchmark? Round for changing car owner
+? Which rate controller would you like to use? Fixed Rate
+? How would you like to measure the length of the round? Transaction Number
+? How many transactions would you like to have in this round? 60
+```
+
+On successful generation, you should see the following:
+
+```console
+Generating benchmarking files...
+   create myBenchmark/benchmarks/callbacks/changeCarOwner.js
+   create myBenchmark/benchmarks/config.yaml
+Finished generating benchmarking files
+```
+
+The generator can also be run non-interactively from the command line using the following command line options:
+
+| Options                  | Default | Description                                                                                    |
+| ------------------------ | ------- | ---------------------------------------------------------------------------------------------- |
+| `--workspace`            |         | A workspace to put all the generate benchmark files.                                           |
+| `--chaincodeId`          |         | The name of your smart contract.                                                               |
+| `--version`              |         | The version of your smart contract.                                                            |
+| `--chaincodeFunction`    |         | Your smart contract function.                                                                  |
+| `--chaincodeArguments`   | []      | The arguments of your smart contract function. These must be in an array format.               |
+| `--benchmarkName`        |         | A name for your benchmark.                                                                     |
+| `--benchmarkDescription` |         | A description for your benchmark.                                                              |
+| `--workers`              | 5       | A value for the number of workers.                                                             |
+| `--label`                |         | A label for the round.                                                                         |
+| `--rateController`       |         | The rate controller.                                                                           |
+| `--txType`               |         | The way you would like to measure the length of the round - either "txDuration" or "txNumber". |
+| `--txDuration`           | 50      | The value for transaction duration if "txDuration" was entered for txType.                     |
+| `--txNumber`             | 50      | The value for transaction number if "txNumber" was entered for txType.                         |
+
+
+Below is an example of the generator being run non-interactively from the command line using the options above:
+
+```console
+yo caliper:benchmark -- --workspace 'myWorkspace' --chaincodeId 'fabcar' --version '0.0.1' --chaincodeFunction 'changeCarOwner' --chaincodeArguments '["CAR001", "Tom"]' --benchmarkName 'Fabcar benchmark' --benchmarkDescription 'Benchmark for performance testing fabcar contract modules' --workers 5 --label 'Round for changing car owner' --rateController 'fixed-rate' --txType 'txDuration' --txDuration 50
+```
+
+> __Note:__ All the options above are required when using the generator non-interactively.
+
+## Next Steps
+
+The generated files will be placed within the workspace directory you named at the beginning of the generator, and you should have a directory structure similar to the one shown below:
+
+```
+.myWorkspace
+└── benchmarks
+    │  callbacks
+    │  └── changeCarOwner.js
+    └─ config.yaml
+```
+
+Currently, the generator does not provide `invokerIdentity` or `chaincodeArguments` as inputs to your callback file. Should these be required, you will need to provide these in the `run` function of your callback file.
+
+The generator only generates a single callback file for a single smart contract function. If you would like to test other smart contract functions, you may create more callback files under the callbacks directory. You will also need to update your benchmnark configuration file to take into account the extra callbacks.
+
+> __Note:__ The benchmark generator will only create the benchmark configuration file and the callback file. You will still need to provide a network configuration file to be able to perform the benchmark.
+
+## License
+The Caliper codebase is released under the [Apache 2.0 license](./LICENSE.md). Any documentation developed by the Caliper Project is licensed under the Creative Commons Attribution 4.0 International License. You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/docs/v0.3.1/Burrow_Configuration.md
+++ b/docs/v0.3.1/Burrow_Configuration.md
@@ -1,0 +1,24 @@
+---
+layout: v0.3.1
+title:  "Burrow Configuration"
+categories: config
+permalink: /v0.3.1/burrow-config/
+---
+
+> The latest supported version of Hyperledger Burrow is v0.23.1
+
+* The NPM package is in Alpha, so please contact us on RocketChat if you have any issues!
+
+## Using Alternative Burrow Versions
+If you wish to use a specific Burrow version, it is necessary to modify the `@monax/burrow` version levels listed as dependancies in `packages/caliper-burrow/package.json`, and then rebuild the Caliper project using the following commands issued at the root Caliper project location:
+
+- `npm install`
+- `npm run repoclean`
+- `npm run bootstrap`
+
+## Issues
+
+Burrow integration is currently in an early phase of development, if you think you can help us out, please send a PR!
+
+## License
+The Caliper codebase is released under the [Apache 2.0 license](./LICENSE.md). Any documentation developed by the Caliper Project is licensed under the Creative Commons Attribution 4.0 International License. You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/docs/v0.3.1/CONTRIBUTING.md
+++ b/docs/v0.3.1/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+---
+layout: v0.3.1
+title:  "Contributing"
+categories: opensource
+permalink: /v0.3.1/contributing/
+---
+
+## Contributing to Hyperledger Caliper
+
+Welcome to Hyperledger Caliper project, we are excited about the prospect of you contributing.
+
+## How to contribute
+
+We are using GitHub issues for bug reports and feature requests.
+
+If you find any bug in the source code or have any trivial changes (such as typos fix, minor feature), you can raise an issue or delivery a fix via a pull request directly.
+
+If you have any enhancement suggestions or want to help extend caliper with more DLTs or have any other major changes, please start by opening an issue first.
+That way, relevant parties (e.g. maintainers or main contributors of the relevant subsystem) can have a chance to look at it before you do any work.
+
+All PRs must get at least one review, you can ask `hyperledger/caliper-committers` for review.
+Normally we will review your contribution in one week.
+If you haven't heard from anyone in one week, feel free to @ or mail a maintainer to review it.
+
+All PRs must be signed before be merged, be sure to use `git commit -s` to commit your changes.
+
+We use Travis Ci to test the build - please test on your local branch before raising a PR. More information on Travis, and linking to your github repository may be found here: https://docs.travis-ci.com/user/for-beginners/
+   
+There is also a [RocketChat Channel](https://chat.hyperledger.org/channel/caliper) for communication, anybody is welcome to join. 
+
+## Caliper Structure
+Caliper is modularised under `packages` into the following components:
+
+### caliper-samples
+This contains samples that may be run using the caliper-cli, and extended to include more adaptor scenarios. The package contains the following folders:
+- benchmark: contains benchmark configuration files
+- src: contains smart contracts to be tested
+- network: contains blockchain (network) configuration files
+
+### caliper-cli
+This is the Caliper CLI that enables the running of a benchmark
+
+### caliper-core
+Contains all the Caliper core code. Interested developers can follow the code flow from the above `run-benchmark.js` file, that enters `caliper-flow.js` in the core package.
+
+### caliper-adaptor
+Each `caliper-<adapter>` is a separate package that contains a distinct adaptor implementation to interact with different blockchain technologies. Current adaptors include:
+- caliper-burrow
+- caliper-besu
+- caliper-ethereum
+- caliper-fabric
+- caliper-fisco-bcos
+- caliper-iroha
+- caliper-sawtooth
+
+Each adaptor implements the `BlockchainInterface` from the core package, as well as a `ClientFactory` and `ClientWorker` that are bespoke to the adaptor.
+
+### caliper-tests-integration
+This is the integration test suite used for caliper; it runs in the Travis build and can (*should*) be run locally when checking code changes. Please see the readme within the package for more details.
+
+## Creating a New Test Case
+
+Currently the easiest way to create a new test case is to extend or add to the `caliper-samples` package. You have options from this point:
+- run the integration tests to get the CLI module installed, then use the command line comand `caliper benchmark run --caliper-workspace <path>/caliper-samples --caliper-benchconfig benchmark/my-config.yaml --caliper-networkconfig network/my-network.yaml`
+- directly run `node ./packages/caliper-cli/caliper.js benchmark run --caliper-benchconfig benchmark/my-config.yaml --caliper-networkconfig network/my-network.yaml --caliper-workspace ./packages/caliper-samples` from the root folder
+
+Before adding a benchmark, please inspect the `caliper-samples` structure and example benchmarks; you will need to add your own configuration files for the blockchain system under test, the benchmark configuration, smart contracts, and test files (callbacks) that interact with the deployed smart contract. You can then run the benchmark using the approaches above.
+    
+## Add an Adaptor for a New DLT
+  
+New adaptors must be added within a new package, under `packages`, with the naming convention `caliper-<adaptor_name>`. Each adaptor must implement a new class inherited from `BlockchainInterface` as the adaptor for the DLT, as well as a `ClientFactory` and `ClientWorker`. For more information, consult our main documentation.
+  
+## License
+The Caliper codebase is released under the [Apache 2.0 license](./LICENSE.md). Any documentation developed by the Caliper Project is licensed under the Creative Commons Attribution 4.0 International License. You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/docs/v0.3.1/Caliper_FAQ.md
+++ b/docs/v0.3.1/Caliper_FAQ.md
@@ -1,0 +1,66 @@
+---
+layout: v0.3.1
+title:  "Caliper FAQ"
+categories: opensource
+permalink: /v0.3.1/caliper-faq/
+---
+
+
+### I. Environment, Platform & Version
+**Q:** How do I run Caliper to test a blockchain system?  
+**A:** Details for setting up Caliper to run benchmark tests on a blockchain system are provided in the [Getting Started](./Getting_Started.md) page of the site.  
+When you run Caliper to test a blockchain network, you maybe encounter some errors. If so, first you should check the version of tools, SDKs and modules to make sure it is right.
+ 
+### II.	Configuration Files of Caliper  
+**Q:** What kind of configuration files are needed to run Caliper?  
+**A:** There are two kinds of configuration files in Caliper: the benchmark configuration file, which defines the arguments of the benchmark, like workload and monitoring settings; the blockchain configuration file, which specifies the information needed to interact with the backend blockchain system.  
+
+a. **Benchmark configuration file**: The example benchmark configuration files are named like `config-xxx.yaml` and are located in the directories of the sample benchmarks. The configuration contains test round and monitoring settings. You can refer to the [Architecture documentation](./Architecture.md) for details.  
+
+b. **Blockchain configuration file**: The blockchain configuration file is named like `xxx-yyy.json/`, where `xxx` is the blockchain type (for example, `fabric`, `sawtooth`, `burrow` or `iroha`), and `yyy` is some deployment-specific information, like the language of the chaincodes (for example, `fabric-go.json` for a Fabric deployment). You can refer to the platform-specific configuration pages for more information.
+
+c. There is another configuration file, namely `./config/default.yaml`, containing runtime setting for Caliper and the blockchain adapters. These settings can also be specified as command line arguments or environment variables.
+
+### III. Testing a Blockchain Network  
+**Q:** What kind of networks does Caliper support currently?  
+**A:** Now you can use Caliper to test Besu, Burrow, Ethereum, Fabric, FISCO-SCOS, Iroha, and Sawtooth networks. Caliper provides some example networks out-of-the-box. For Fabric, example networks are located in the `network/fabric-v<VERSION>/<X>org<Y>peer<STATEDB>` directories, where `<VERSION>` is the version of Fabric binaries comprising the network, `<X>` is the number of organizations in the network, `<Y>` is the number of peers each organization has and `<STATEDB>` denotes the type of the DB storing the world state (`goleveldb` or `couchdb`).
+
+**Q:** How can I change the network topology that Caliper tests?  
+**A:** Caliper provides example configurations for each platform. Below are the steps needed to test a custom Fabric network:  
+
+a.	Before the test, you should modify the `configtx.yaml` and `crypto-config.yaml` files (add extra organizations and/or peers) as needed and regenerate the artifacts (crypto materials, genesis block and channel configuration) used to bootstrap the network. 
+ 
+b.	Modify a `docker-compose.yaml` file according to your new network topology, which can start the docker containers of the blockchain nodes.  
+
+c.	Modify the Fabric network configuration file according to your new Fabric network topology (possibly including a new chaincode to deploy and test).  
+
+d.	Run Caliper to test your blockchain network.   
+
+**Q:** How can I test a blockchain system that Caliper does not support currently？  
+**A:** If you want to test the blockchain system that Caliper does not support now, you must write your own blockchain adapter that Caliper can use to inferface with the backend network. For details, you can refer to the [Writing Adapters](./Writing_Adapters.md) page. The Caliper-specific configurations remain unchanged. Take a look at the provided adapter implementations and example networks to gather some best-practices.  
+
+### IV.	Other Questions Related to Caliper  
+**Q:** How can I calculate the throughput (TPS)?  
+**A:** Caliper will record the submitting time and committing time (the time when the Tx is committed on the ledger or when the failure occurred) for each Tx.
+So the send rate is calculated by `(Succ+Fail) / (last submitting time - first submitting time)`.
+The throughput is calculated by `Succ/(last committing time - first submitting time)`, here only successful committed Txs will be calculated.
+
+### V. Other Questions Related to the Backend Blockchain System  
+
+**Q:** How can I test my own Fabric chaincode?  
+**A:** You can modify the chaincode property information in the blockchain network configuration file according to your own chaincode properties (path, arguments, etc.). You also can put the chaincode files into the `./src/contract/fabric` directory.
+
+**Q:** How can I test a Kafka ordering service for a Fabric network?  
+**A:** Kafka is one of the supported consensus algorithms in Fabric (details at the [Kafka consensus documentation](https://hyperledger-fabric.readthedocs.io/en/latest/kafka.html)). For the support of multiple orderer nodes, refer to the adapter configuration page. 
+
+**Q:** How can I test multiple hosts for a Fabric network?  
+**A:** Caliper performs automatic load balancing if multiple targets are nodes in the network. Refer to the custom Fabric network question for putting together a multiple-host network. 
+
+**Q:** How can I use TLS communication?  
+**A:** Fabric supports secure communication between nodes and clients using TLS. TLS communication can use both one-way (server only) and two-way (server and client) authentication. You can refer to the [Fabric TLS configuration](https://hyperledger-fabric.readthedocs.io/en/release-1.4/enable_tls.html) page for server side settings. For Caliper-side settings, check the adapter documentation that details how to set the necessary credentials.  
+
+**Q:** How can I monitor remote Docker containers?  
+**A:** If you need to access the Docker daemon remotely, you need to explicitly enable remote access. Beware that the default setup provides unencrypted and unauthenticated direct access to the Docker daemon. For details, refer to the official [Docker documentation](https://success.docker.com/article/how-do-i-enable-the-remote-api-for-dockerd).
+
+## License
+The Caliper codebase is released under the [Apache 2.0 license](./LICENSE.md). Any documentation developed by the Caliper Project is licensed under the Creative Commons Attribution 4.0 International License. You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/docs/v0.3.1/Ethereum_Configuration.md
+++ b/docs/v0.3.1/Ethereum_Configuration.md
@@ -1,0 +1,304 @@
+---
+layout: v0.3.1
+title:  "Ethereum Configuration"
+categories: config
+permalink: /v0.3.1/ethereum-config/
+---
+
+This page introduces the Ethereum adapter suitable for all the Ethereum clients that expose the web3 RPC interface over websockets.
+
+> This adapter relies on web3js 1.2.x that is the stable version coming from 1.0.0-beta.37
+
+> Hyperledger Besu and Geth are the current tested clients. The tests are driven via standard Ethereum JSON-RPC APIs so other clients should be compatible once docker configurations exist.
+
+> Hyperledger Besu does not provide wallet services, so the `contractDeployerPassword` and `fromAddressPassword` options are not supported and the private key variants must be used.
+
+> Some highlights of the provided features:
+> * configurable confirmation blocks threshold
+
+The page covers the following aspects of using the Ethereum adapter:
+* how to [assemble a connection profile file](#assembling-the-network-configuration-file), a.k.a., the blockchain network configuration file;
+* how to [use the adapter interface](#using-the-adapter-interface) from the user callback module;
+* [transaction data gathered](#transaction-data-gathered-by-the-adapter) by the adapter;
+* and a [complete example](#connection-profile-example) of a connection profile.
+
+# Assembling the Network Configuration File
+
+The JSON network configuration file of the adapter essentially defines which contract are expected to be on the network and which account the adapter should use to deploy the pointed contracts and which account use to invoke them. Contract necessary for the benchmark are automatically deployed at benchmark startup while the special `registry` contract needs to be already deployed on the network. ABI and bytecode of the registry contract are reported in the src/contract/ethereum/registry/registry.json.
+
+## Connection profile example
+We will provide an example of the configuration and then we'll in deep key by key
+
+```json
+{
+    "caliper": {
+        "blockchain": "ethereum",
+        "command" : {
+            "start": "docker-compose -f network/ethereum/1node-clique/docker-compose.yml up -d && sleep 3",
+            "end" : "docker-compose -f network/ethereum/1node-clique/docker-compose.yml down"
+          }
+    },
+    "ethereum": {
+        "url": "ws://localhost:8545",
+        "contractDeployerAddress": "0xc0A8e4D217eB85b812aeb1226fAb6F588943C2C2",
+        "contractDeployerAddressPassword": "password",
+        "fromAddress": "0xc0A8e4D217eB85b812aeb1226fAb6F588943C2C2",
+        "fromAddressPassword": "password",
+        "transactionConfirmationBlocks": 12,
+        "contracts": {
+            "simple": {
+                "path": "src/contract/ethereum/simple/simple.json",
+                "gas": {
+                    "open": 45000,
+                    "query": 100000,
+                    "transfer": 70000
+                }
+            }
+        }
+    }
+}
+```
+
+The top-level `caliper` attribute specifies the type of the blockchain platform, so Caliper can instantiate the appropriate adapter when it starts. To use this adapter, specify the `ethereum` value for the `blockchain` attribute. 
+
+Furthermore, it also contains two optional commands: a `start` command to execute once before the tests and an `end` command to execute once after the tests. Using these commands is an easy way, for example, to automatically start and stop a test network. When connecting to an already deployed network, you can omit these commands.
+
+These are the keys to provide inside the configuration file under the `ethereum` one:
+* [URL](#url) of the RPC endpoint to connect to. Only websocket is currently supported.
+* [Deployer address](#deployer-address) with which deploy required contracts
+* [Deployer address private key](#deployer-address-private-key) the private key of the deployer address
+* [Deployer address password](#deployer-address-password) to unlock the deployer address
+* [Address](#benchmark-address) from which invoke methods of the benchmark
+* [Private Key](#benchmark-address-private-key) the private key of the benchmark address
+* [Password](#benchmark-address-password) to unlock the benchmark address
+* Number of [confirmation blocks](#confirmation-blocks) to wait to consider a transaction as successfully accepted in the chain
+* [Contracts configuration](#contracts-configuration)
+
+The following sections detail each part separately. For a complete example, please refer to the [example section](#connection-profile-example) or one of the example files in the `network/ethereum` directories
+
+## URL
+
+The URL of the node to connect to. Any host and port can be used if it is reachable. Currently only websocket is supported.
+
+```json
+"url": "ws://localhost:8545"
+```
+
+Unfortunately, HTTP connections are explicitly disallowed, as
+
+1. there is no efficient way to guarantee the order of transactions submitted over http, which leads to nonce errors, and
+2. this adapter relies on web3.js, and this library has deprecated its support for RPC over HTTP.
+
+## Deployer address
+
+The address to use to deploy contracts of the network. Without particular or specific needs it can be set to be equal to the [benchmark address](#benchmark-address). Its private key must be hold by the node connected with [URL](#url) and it must be provided in the checksum form (the one with both lowercase and uppercase letters).
+
+```json
+"contractDeployerAddress": "0xc0A8e4D217eB85b812aeb1226fAb6F588943C2C2"
+```
+
+## Deployer address private key
+
+The private key for the [deployer address](#deployer-address). If present then transactions are signed inside caliper and sent "raw" to the ethereum node.
+
+```json
+"contractDeployerAddressPrivateKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+```
+
+## Deployer address password
+
+The password to use to unlock [deployer address](#deployer-address). If there isn't an unlock password, this key must be present as empty string. If the deployer address private key is present this is not used.
+
+```json
+"contractDeployerAddressPassword": "gottacatchemall"
+```
+
+## Benchmark address
+
+The address to use while invoking all the methods of the benchmark. Its private key must be hold by the node connected with [URL](#url) and it must be provided in the checksum form (the one with both lowercase and uppercase letters).
+
+```json
+"fromAddress": "0xc0A8e4D217eB85b812aeb1226fAb6F588943C2C2"
+```
+
+## Benchmark address seed
+
+As an alternative to `fromAddress`, `fromAddressPrivateKey`, and `fromAddressPassword` the network configuration can use a fixed seed and derive needed addresses via [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) key derivation.  Each caliper test worker will generate an address for use as `fromAddress` and `fromAddressPrivateKey` using the derivation path `m/44'/60'/<x>'/0/0`, where <x> is the `clientIdx` passed into `getContext`.
+
+This configuration does not override `fromAddress`, but it takes priority over `fromAddressPrivateKey` and `fromAddressPassword`.
+
+```json
+"fromAddressSeed": "0x3f841bf589fdf83a521e55d51afddc34fa65351161eead24f064855fc29c9580"
+```
+
+## Benchmark address private key
+
+The private key for the [benchmark address](#benchmark-address). If present then transactions are signed inside caliper and sent "raw" to the ethereum node.
+
+This configuration takes priority over `fromAddressPassword`.
+
+```json
+"fromAddressPrivateKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+```
+
+## Benchmark address password
+
+The password to use to unlock [benchmark address](#benchmark-address). If there isn't an unlock password, this key must be present as empty string. If the benchmark address private key is present this is not used.
+
+```json
+"fromAddressPassword": "gottacatchemall"
+```
+
+## Confirmation blocks
+
+It is the number of blocks the adapter will wait before warn Caliper that a transaction has been successfully executed on the network. You can freely tune it from 1 to the desired confirmations. Keep in mind that in the Ethereum main net (PoW), 12 to 20 confirmations can be required to consider a transaction as accepted in the blockchain. If you're using different consensus algorith (like clique in the example network provided) it can be safely brought to a lower value. In any case it is up to you.
+
+```json
+"transactionConfirmationBlocks": 12
+```
+
+## Contract configuration
+It is the list, provided as a json object, of contracts to deploy on the network before running the benchmark. You should provide a json entry for each contract; the key will represent the contract identifier to invoke methods on that contract.
+
+For each key you must provide a JSON object with the `path` field pointing to the [contract definition file](#contract-definition-file).
+
+It is also strongly recommended to specify a `gas` field, which is an object with one field per contract function that you will call in your test. The value of these fields should be set to the amount of gas that will be required to execute your transaction. There is no need for this number to be an exact match, as it's used to set the gas limit for the transaction, so if your transaction might have a variable gas cost, just set this value to the highest gas usage that you would expect to see for your transaction.
+
+**Note**: If you do not specify the gas for your contract functions, web3 will automatically call out to your node to estimate the gas requirement before submitting the transaction. This causes three problems. First, it means that your transaction will effectively execute twice, doubling the load on the node serving as your RPC endpoint. Second, the extra call will add significant additional latency to every transaction. Third, your transactions may be reordered, causing transaction failures due to out of order nonces.
+
+```json
+"contracts": {
+    "simple": {
+        "path": "src/contract/ethereum/simple/simple.json",
+        "gas": {
+            "open": 45000,
+            "query": 100000,
+            "transfer": 70000
+        }
+    },
+    "second": {
+        "path": "src/contract/ethereum/second/second.json",
+        "gas": {
+            "function": 12345
+        }
+    }
+}
+```
+
+## Contract definition file
+Contract definition file is a simple JSON file containing basic information to deploy and use an Ethereum contract. Four keys are required:
+* [Name](#name)
+* [ABI](#abi)
+* [Byetcode](#bytecode)
+* [Gas](#gas)
+
+Here is an example:
+```json
+{
+    "name": "The simplest workload contract",
+    "abi": [{"constant":true,"inputs":[{"nam......ype":"function"}],
+    "bytecode": "0x608060405.........b0029",
+    "gas": 259823
+}
+```
+
+### Name
+It is a name to display in logs when the contract gets deployed. It is only a description name.
+
+### ABI
+It is the ABI generated when compiling the contract. It is required in order to invoke methods on a contract.
+
+### Bytecode
+It is the bytecode generated when compiling the contract. Note that since it is an hexadecimal it must start with the `0x`.
+
+### Gas
+It is the gas required to deploy the contract. It can be easily calculated with widely used solidity development kits or querying to a running Ethereum node.
+
+# Using the Adapter Interface
+
+The [user callback modules](./Architecture.md#user-defined-test-module) interact with the adapter at two phases of the tests: during the initialization of the user module (the `init` callback), and when submitting invoke or query transactions (the `run` callback).
+
+## The _init_ Callback
+
+The first argument of the `init` callback is a `blockchain` object. We will discuss it in the next section for the `run` callback.
+
+The second argument of the `init` callback is a `context`, which is a platform-specific object provided by the backend blockchain's adapter. The context object provided by this adapter is the following:
+
+```mson
+{
+  fromAddress: "0xA89....7G"
+  web3: Web3
+}
+```
+
+The `fromAddress` property is the [benchmark address](#benchmark-address) while web3 is the configured instance of the Web3js client.
+
+
+## The _run_ Callback
+
+The `blockchain` object received (and saved) in the `init` callback is of type `Blockchain` you can find in `packages/caliper-core/lib/blockchain.js`, and it wraps the adapter object (if you know what you are doing, it can be reached at the `blockchain.bcObj` property). The `blockchain.bcType` property has the `ethereum` string value.
+
+### Invoking a contract method
+
+To submit a transaction, call the `blockchain.invokeSmartContract` function. It takes five parameters: the previously saved `context` object, the `contractID` of the contract (that is the key specified [here](#contract-configuration)), an unused contract version (you can put whatever), the `invokeData` array with methods data and a `timeout` value in seconds that is currently unimplemented (the default web3js timeout is used).
+
+The `invokeData` parameter can be a single or array of JSON, that must contain:
+* `verb`: _string. Required._ The name of the function to call on the contract.
+* `args`: _mixed[]. Optional._ The list of arguments to pass to the method in the correct order as they appear in method signature. It must be an array.
+
+```js
+let invokeData = [{
+    verb: 'open',
+    args: ['sfogliatella', 1000]
+},{
+    verb: 'open',
+    args: ['baba', 900]
+}];
+
+return blockchain.invokeSmartContract(context, 'simple', '', invokeData, 60);
+```
+
+Currently each method call inside `invokeData` is sent separately, that is, they are NOT sent as a batch of calls on RPC.
+
+### Querying a contract
+
+To query a state on a contract state, call the `blockchain.querySmartContract` function that has exactly same arguments as the `blockchain.invokeSmartContract` function. The difference is that it can't produce any change on the blockchain and node will answer with its local view of data. For backward compatibility reasons also the `blockchain.queryState` is present. It takes five parameters: the previously saved `context` object, the `contractID` of the contract, an unused contract version, the `key` to request information on and `fcn` to point which function call on the contract. `fcn` function on the contract must accept exactly one parameter; the `key` string will be passed as that parameter. `fcn` can also be omitted and the adapter will search on the contract for a function called `query`.
+  
+  > Querying a value in a contract is always counted in the workload. So keep it in mind that if you think to query a value when executing a workload.
+
+Querying a chaincode looks like the following:
+
+```js
+let queryData = [{
+    verb: 'queryPastryBalance',
+    args: ['sfogliatella']
+},{
+    verb: 'queryPastryBalance',
+    args: ['baba']
+}];
+
+return blockchain.querySmartContract(context, 'pastryBalance', '', queryData, 60);
+```
+or
+```js
+let balance = blockchain.queryState(context, 'simple', '', 'sfogliatella');
+```
+assuming that `simple` contract has the `query` function that takes only one argument.
+
+Like invoke, currently there is not any support for batch calls.
+
+---
+
+# Transaction Data Gathered by the Adapter
+
+The previously discussed  `invokeSmartContract` and `queryState` functions return an array whose elements correspond to the result of the submitted request(s) with the type of [TxStatus](https://github.com/hyperledger/caliper/blob/master/packages/caliper-core/lib/transaction-status.js). The class provides some standard and platform-specific information about its corresponding transaction.
+
+The standard information provided by the type are the following:
+* `GetID():string` returns the transaction ID for `invokeSmartContract`, `null` for `queryState` and `querySmartContract`.
+* `GetStatus():string` returns the final status of the transaction, either `success` or `failed`.
+* `GetTimeCreate():number` returns the epoch when the transaction was submitted.
+* `GetTimeFinal():number` return the epoch when the transaction was finished.
+* `IsVerified():boolean` indicates whether we are sure about the final status of the transaction. Always true for successful transactions. False in all other cases.
+
+## License
+The Caliper codebase is released under the [Apache 2.0 license](./LICENSE.md). Any documentation developed by the Caliper Project is licensed under the Creative Commons Attribution 4.0 International License. You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/docs/v0.3.1/FISCO_BCOS_Configuration.md
+++ b/docs/v0.3.1/FISCO_BCOS_Configuration.md
@@ -1,0 +1,170 @@
+---
+layout: v0.3.1
+title:  "FISCO BCOS Configuration"
+categories: config
+permalink: /v0.3.1/fisco-config/
+---
+
+>*The required minimal version of FISCO BCOS is v2.0.0*
+
+This page introduces the FISCO BCOS adapter that may be used by Caliper. For general information on FISCO BCOS, please refer to their [documenation pages](https://fisco-bcos-documentation.readthedocs.io/en/latest).
+
+### Node Configuration
+
+A FISCO BCOS node uses several configuration files to control the network settings and certificates for connecting verification, which are described below:
+
+*\*we refer the root directory of node as `node/`*
+
+| Name | Location | Function |
+| :--- | :---- | :---- |
+| config.ini | `node/` | `ini` format, contains network ports (PRC, P2P and channel), black list of nodes, path of data and certificates, etc.
+| group.***n***.genesis | `node/conf/` | `ini` format, the ***fixed configuration*** of group ***n***'s genesis block. FISCO BCOS support running several uncorrelated groups on the same set of nodes, you can get more information about concept "group" from [introduction of group architecture](https://fisco-bcos-documentation.readthedocs.io/en/latest/docs/design/architecture/group.html). The configuration contains the type of consensus algorithm,  ID of initial nodes, etc.|
+| group.***n***.ini | `node/conf/` | `ini` format, the ***changeable configuration*** of group ***n***,  includes parameters of consensus module and storage module, configuration for features, etc. |
+| node.key | `node/conf/` | `PEM` format, the private key used to connect to other nodes via SSL/TLS, using ECDSA-secp256k1. |
+| node.crt | `node/conf/` | the certificate used in SSL/TLS connection between nodes. |
+| ca.crt | `node/conf/` | the root certificate used in SSL/TLS connection between nodes. The ca.crt is used to verify whether the cerficate of peer node is correct or not. |
+
+More detail information about configuration files and configuration items please refer [Configuration files and configuration items](https://fisco-bcos-documentation.readthedocs.io/en/latest/docs/manual/configuration.html).
+
+### Network Configuration
+
+This JSON-format configuration file describes how the nodes interact with each other in network and which smart contracts is used by a benchmark. It has the following top-level attributes.
+
+- `caliper`, specifying the platform type for Caliper.
+- `fisco-bcos`, specifying the network configuration for Caliper.
+- `info`, specifying the customized content for the generated report.
+
+The details of those sections will be described below.
+
+#### caliper
+
+*Caliper-specific.*
+
+`caliper` attribute specifies the platform type for Caliper to instantiate the appropriate adapter. To test FISCO BCOS network, specify the `fisco-bcos` value for the `blockchain` attribute.
+
+It also contains two optional command attributes: a `start` command that executes once before all the tests and an `end` command that executes once after all the tests. It is easy to use these commands start and stop a test network for benchmarking. When benchmarking a deployed network, you can omit these commands.
+
+``` JSON
+"caliper": {
+    "blockchain": "fisco-bcos",
+    "command": {
+        "start": "docker-compose -f network/fisco-bcos/4nodes1group/docker-compose.yaml up -d; sleep 3s",
+        "end": "docker-compose -f network/fisco-bcos/4nodes1group/docker-compose.yaml down"
+    }
+}
+```
+
+In the configuration example above, `start` command is specified to launch four FISCO BCOS nodes via docker-compose, and the `end` command is specified to shut them down.
+
+#### fisco-bcos
+
+`fisco-bcos` attribute indicates how the adapter interact with the network of SUT. It contains following child attributes:
+
+- `config`, when FISCO BCOS adapter interact with nodes, it will be asked to show its identity, and all necessary information should be provided in adapter's `fisco-bcos.config` configuration. The configuration includes the following attributes:
+  - `privateKey`, is used to sign transactions to confer them legitimacy. Private key is a large random number generated from third-party tools such as OpenSSL. In our simplified configuration example, a pre-defined and static private key is used to launch tests.
+  - `account`, is calculated from `privateKey`, to point out the sender of a transaction. Similarly, we use a pre-defined account value in the adapter.
+
+```JSON
+"config": {
+    "privateKey": "bcec428d5205abe0f0cc8a734083908d9eb8563e31f943d760786edf42ad67dd",
+    "account": "0x64fa644d2a694681bd6addd6c5e36cccd8dcdde3"
+}
+```
+
+- `network`: specifies the network information of nodes in the SUT. For simplicity, only sealer nodes (the node who is responsible for processing transactions and producing new blocks) can be specified now, which includes the following attributes:
+  - `nodes`: a list of endpoints of the nodes. For each endpoint, the following child attributes are required. `ip` attribute is used to tell adapter the IP address of a peer node. `rpcPort` is the port of RPC service offered by the node. RPC service is used to send read-only request for better response speed, like getting block height. `channelPort`is the port of channel service offered by the node. Channel service is based on TLS (Transport Layer Security) protocol and is used to send the transactions that will be recorded by the blockchain, for stability and accurate performance statistics.
+  - `authentication`, a set of certificates to use channel service of FISCO BCOS node, it includes file paths of private key, certificate and CA (Certificate Authorities) root certificate of the node.
+  - `timeout`: the max waiting time before a node returns a transaction receipt back to adapter. A transaction receipt is the proof of that this transaction had been processed. But on some occasions, some nodes may not work well and stop responding to the requests. To avoid the adapter from infinite waiting, the value of `timeout` is necessary to be set. The unit of `timeout` is millisecond.
+  - `groupID`:  FISCO BCOS allows several independent group running simultaneously on the same set of nodes. This attribute specifies which group to test for a benchmark.
+
+```JSON
+"network": {
+    "nodes": [
+        {
+            "ip": "127.0.0.1",
+            "rpcPort": "8914",
+            "channelPort": "20914"
+        },
+        {
+            "ip": "127.0.0.1",
+            "rpcPort": "8915",
+            "channelPort": "20915"
+        },
+        {
+            "ip": "127.0.0.1",
+            "rpcPort": "8916",
+            "channelPort": "20916"
+        },
+        {
+            "ip": "127.0.0.1",
+            "rpcPort": "8917",
+            "channelPort": "20917"
+        }
+    ],
+    "authentication": {
+        "key": "/path/to/adapter/private/key",
+        "cert": "/path/to/adapter/certificate",
+        "ca": "/path/to/CA/certificate"
+    },
+    "groupID": 1,
+    "timeout": 100000
+}
+```
+
+In the example above, there are four nodes in the topology of network, whose actual RPC service port and channel service port can be found in nodes' configuration. Certificate files included in `authentication` is used for [channel](https://fisco-bcos-documentation.readthedocs.io/en/latest/docs/design/protocol_description.html#network-transmission-protocol) connection and they are alway be produced during the process of FISCO BCOS chain's building. The introduction to those certificate files can be found in can be found in [Node file organization](https://fisco-bcos-documentation.readthedocs.io/en/latest/docs/manual/build_chain.html#node-file-organization). During the test, the benchmark will be run on `group` 1, and the `timeout` time for nodes to return a receipt is 100 seconds (100,000 milliseconds).
+
+- `smartContracts`, a list of smart contracts used by the benchmark:
+  - `id`, the unique ID of a smart contract.
+  - `language`,  if the smart contract is implemented by Solidity, the value of this attribute should be `solidity`. If it is a FISCO BCOS precompiled contract, the value of this attribute should be `precompiled`.
+  - `path`, if the smart contract is implemented by Solidity, this attribute need to be set to the Solidity code file's path, otherwise this attribute is not used.
+  - `address`, if the smart contract is a FISCO BCOS precompiled contract, this attribute should be set to the preset address of the contract, otherwise this attribute is not used.
+  - `version`, the version of the smart contract
+
+```JSON
+"smartContracts": [
+    {
+        "id": "helloworld",
+        "path": "src/contract/fisco-bcos/helloworld/HelloWorld.sol",
+        "language": "solidity",
+        "version": "v0"
+    },
+    {
+        "id": "parallelok",
+        "path": "src/contract/fisco-bcos/transfer/ParallelOk.sol",
+        "language": "solidity",
+        "version": "v0"
+    },
+    {
+        "id": "dagtransfer",
+        "address": "0x0000000000000000000000000000000000005002",
+        "language": "precompiled",
+        "version": "v0"
+    }
+]
+```
+
+In the example above, there are three smart contracts need to be deployed on the blockchain. The first two are implemented by Solidity and their source code can be found in `src/contract/fisco-bcos/` directory. The last one is a FISCO BCOS precompiled contract, its source code can be found [here](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/master/libprecompiled/extension/DagTransferPrecompiled.cpp).
+
+#### info
+
+This attribute specifies custom key-value pairs that will be included in the generated report. For example:
+
+```JSON
+"info": {
+    "Version": "2.0.0",
+    "Size": "4 Nodes",
+    "Distribution": "Single Host"
+}
+```
+
+### Running your own benchmark test instance
+
+To run your own benchmarks on your own network topology, you should:
+
+- Deploy you own FISCO BCOS network. To complete this step, please follow the instructions in [installation tutorial](https://fisco-bcos-documentation.readthedocs.io/en/latest/docs/installation.html).
+- Add a new network configuration file.
+- Create a test script that includes an `init`, `run` and `end` phase.
+- Add the new test script to the test config file as a test round, making sure that the correct callback for Caliper is specified.
+
+## License
+The Caliper codebase is released under the [Apache 2.0 license](./LICENSE.md). Any documentation developed by the Caliper Project is licensed under the Creative Commons Attribution 4.0 International License. You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/docs/v0.3.1/Fabric_Configuration.md
+++ b/docs/v0.3.1/Fabric_Configuration.md
@@ -1,0 +1,1735 @@
+---
+layout: v0.3.1
+title:  "Fabric Configuration"
+categories: config
+permalink: /v0.3.1/fabric-config/
+---
+
+## Table of contents
+{:.no_toc}
+
+- TOC
+{:toc}
+
+## Overview
+
+This page introduces the Fabric adapter that utilizes the Common Connection Profile (CCP) feature of the Fabric SDK to provide compatibility and a unified programming model across different Fabric versions. 
+
+> The latest supported version of Hyperledger Fabric is v2.0.0
+
+The adapter exposes many SDK features directly to the user callback modules, making it possible to implement complex scenarios.
+
+> Some highlights of the provided features:
+> * supporting multiple orderers
+> * automatic load balancing between peers and orderers
+> * supporting multiple channels and chaincodes
+> * metadata and private collection support for chaincodes
+> * support for TLS and mutual TLS communication
+> * dynamic registration of users with custom affiliations and attributes
+> * option to select the identity for submitting a TX/query
+> * transparent support for every version of Fabric since v1.0 (currently up to v2.0.0)
+> * detailed execution data for every TX
+
+## Installing dependencies
+
+To install the Fabric SDK dependencies of the adapter, configure the binding command as follows:
+* Set the `caliper-bind-sut` setting key to `fabric`
+* Set the `caliper-bind-sdk` setting key to a [supported SDK binding](./Installing_Caliper.md#the-bind-command).
+
+You can set the above keys either from the command line:
+```console
+user@ubuntu:~/caliper-benchmarks$ npx caliper bind --caliper-bind-sut fabric --caliper-bind-sdk 1.4.0
+```
+or from environment variables:
+```console
+user@ubuntu:~/caliper-benchmarks$ export CALIPER_BIND_SUT=fabric
+user@ubuntu:~/caliper-benchmarks$ export CALIPER_BIND_SDK=1.4.0
+user@ubuntu:~/caliper-benchmarks$ npx caliper bind
+```
+or from various [other sources](./Runtime_Configuration.md).
+
+### Binding with Fabric SDK 2.0.x
+> Note that when using the binding target for the Fabric SDK 2.0.x there are capability restrictions:
+> * The 2.0 SDK does not facilitate administration actions. It it not possible to create/join channels, nor install/instantiate chaincode. Consequently the 2.0 binding only facilitates operation with a `--caliper-flow-only-test` flag
+> * The 2.0 SDK currently only supports operation using a `gateway`. Consequently the 2.0.0 binding requires a `--caliper-fabric-gateway-usegateway` flag
+>
+> When testing with the 2.0 SDK, it is recommended to configure the system in advance with a network tool of your choice, or using Caliper bound to a 1.4 SDK. The 2.0 SDK may then be bound to Caliper and used for testing.
+> Caliper does not support the Fabric v2.0 chaincode lifecycle, however the legacy commands of install/instantiate are still valid, and so Caliper can perform basic network configuration using 1.4 SDK bindings.
+
+## Runtime settings
+
+### Common settings
+
+Some runtime properties of the adapter can be set through Caliper's [runtime configuration mechanism](./Runtime_Configuration.md). For the available settings, see the `caliper.fabric` section of the [default configuration file](https://github.com/hyperledger/caliper/blob/master/packages/caliper-core/lib/common/config/default.yaml) and its embedded documentation.
+
+The above settings are processed when starting Caliper. Modifying them during testing will have no effect. However, you can override the default values _before Caliper starts_ from the usual configuration sources.
+
+> __Note:__ An object hierarchy in a configuration file generates a setting entry for every leaf property. Consider the following configuration file:
+> ```yaml
+> caliper:
+>   fabric:
+>     gateway:
+>       usegateway: true
+>       discovery: true
+> ```
+> After naming the [project settings](./Runtime_Configuration.md#project-level) file `caliper.yaml` and placing it in the root of your workspace directory, it will override the following two setting keys with the following values:
+> * Setting `caliper-fabric-gateway-usegateway` is set to `true`
+> * Setting `caliper-fabric-gateway-discovery` is set to `true`
+>
+> __The other settings remain unchanged.__
+
+### Skip channel creation
+
+Additionally, the adapter provides a dynamic setting (family) for skipping the creation of a channel. The setting key format is `caliper-fabric-skipcreatechannel-<channel_name>`. Substitute the name of the channel you want to skip creating into `<channel_name>`, for example:
+
+```console
+user@ubuntu:~/caliper-benchmarks$ export CALIPER_FABRIC_SKIPCREATECHANNEL_MYCHANNEL=true
+```
+
+> __Note:__ This settings is intended for easily skipping the creation of a channel that is specified in the network configuration file as "not created". However, if you know that the channel always will be created during benchmarking, then it is recommended to denote this explicitly in the network configuration file.
+
+Naturally, you can specify the above setting multiple ways (e.g., command line argument, configuration file entry). 
+
+## The adapter API
+
+The [user callback modules](./Architecture.md#user-defined-test-module) interact with the adapter at two phases of the tests: during the initialization of the user module (in the `init` callback), and when submitting invoke or query transactions (in the `run` callback).
+
+### The `init` callback
+
+The first argument of the `init` callback is a `blockchain` object. We will discuss it in the next section for the `run` callback.
+
+The second argument of the `init` callback is a `context`, which is a platform-specific object provided by the backend blockchain's adapter. The context object provided by this adapter exposes the following properties:
+* The `context.networkInfo` property is a `FabricNetwork` instance that provides simple string-based "queries" and results about the network topology, so user callbacks can be implemented in a more general way. For the current details/documentation of the API, refer to the [source code](https://github.com/hyperledger/caliper/blob/master/packages/caliper-fabric/lib/fabricNetwork.js).
+
+### The `run` callback
+
+The `blockchain` object received (and saved) in the `init` callback is of type [Blockchain](https://github.com/hyperledger/caliper/blob/master/packages/caliper-core/lib/blockchain.js) and it wraps the adapter instance of type [Fabric](https://github.com/hyperledger/caliper/blob/master/packages/caliper-fabric/lib/fabric.js). The `blockchain.bcType` property has the `fabric` string value.
+
+The two main functions of the adapter are `invokeSmartContract` and `querySmartContract`, sharing a similar API.
+
+#### Invoking a chaincode
+
+To submit a transaction, call the `blockchain.invokeSmartContract` function. It takes five parameters:
+1. `context`: the same `context` object saved in the `init` callback.
+2. `contractID`: the unique (Caliper-level) ID of the chaincode.
+3. `version`: the chaincode version. __Unused.__
+4. `invokeSettings`:  an object containing different TX-related settings
+5. `timeout`: the timeout value for the transaction __in seconds__.
+
+The `invokeSettings` object has the following structure:
+* `chaincodeFunction`: _string. Required._ The name of the function to call in the chaincode.
+* `chaincodeArguments`: _string[]. Optional._ The list of __string__ arguments to pass to the chaincode.
+* `transientMap`: _Map<string, byte[]>. Optional._ The transient map to pass to the chaincode.
+* `invokerIdentity`: _string. Optional._ The name of the user who should invoke the chaincode. If an admin is needed, use the organization name prefixed with a `#` symbol (e.g., `#Org2`). Defaults to the first client in the network configuration file.
+* `targetPeers`: _string[]. Optional._ An array of endorsing peer names as the targets of the transaction proposal. If omitted, the target list will include endorsing peers selected according to the specified load balancing method. 
+* `orderer`: _string. Optional._ The name of the target orderer for the transaction broadcast. If omitted, then an orderer node of the channel will be used, according to the specified load balancing method.
+
+So invoking a chaincode looks like the following (with automatic load balancing between endorsing peers and orderers):
+
+```js
+let settings = {
+    chaincodeFunction: 'initMarble',
+    chaincodeArguments: ['MARBLE#1', 'Red', '100', 'Attila'],
+    invokerIdentity: 'client0.org2.example.com'
+};
+
+return blockchain.invokeSmartContract(context, 'marbles', '', settings, 10);
+```
+
+`invokeSmartContract` also accepts an array of `invokeSettings` as the second arguments. However, Fabric does not support submitting an atomic batch of transactions like Sawtooth, so there is no guarantee that the order of these transactions will remain the same, or whether they will reside in the same block. 
+
+Using "batches" also increases the expected workload of the system, since the rate controller mechanism of Caliper cannot account for these "extra" transactions. However, the resulting report will accurately reflect the additional load.
+
+#### Querying a chaincode
+
+To query the world state, call the `blockchain.bcObj.querySmartContract` function. It takes five parameters: 
+1. `context`: the same `context` object saved in the `init` callback.
+2. `contractID`: the unique (Caliper-level) ID of the chaincode.
+3. `version`: the chaincode version. __Unused.__
+4. `querySettings`:  an object containing different query-related settings
+5. `timeout`: the timeout value for the transaction __in seconds__.
+
+The `querySettings` object has the following structure:
+* `chaincodeFunction`: _string. Required._ The name of the function to call in the chaincode.
+* `chaincodeArguments`: _string[]. Optional._ The list of __string__ arguments passed to the chaincode.
+* `transientMap`: _Map<string, byte[]>. Optional._ The transient map passed to the chaincode.
+* `invokerIdentity`: _string. Optional._ The name of the user who should invoke the chaincode. If an admin is needed, use the organization name prefixed with a `#` symbol (e.g., `#Org2`). Defaults to the first client in the network configuration file.
+* `targetPeers`: _string[]. Optional._ An array of endorsing peer names as the targets of the query. If omitted, the target list will include endorsing peers selected according to the specified load balancing method. 
+* `countAsLoad`: _boolean. Optional._ Indicates whether the query should be counted as workload and reflected in the generated report. If specified, overrides the adapter-level `caliper-fabric-countqueryasload` setting.
+  
+  > Not counting a query in the workload is useful when _occasionally_ retrieving information from the ledger to use as a parameter in a transaction (might skew the latency results). However, count the queries into the workload if the test round specifically targets the query execution capabilities of the chaincode. 
+
+So querying a chaincode looks like the following (with automatic load balancing between endorsing peers):
+
+```js
+let settings = {
+    chaincodeFunction: 'readMarble',
+    chaincodeArguments: ['MARBLE#1'],
+    invokerIdentity: 'client0.org2.example.com'
+};
+
+return blockchain.querySmartContract(context, 'marbles', '', settings, 3);
+```
+
+`querySmartContract` also accepts an array of `querySettings` as the second arguments. However, Fabric does not support submitting an atomic batch of queries, so there is no guarantee that their execution order will remain the same (although it's highly probably, since queries have shorter life-cycles than transactions). 
+
+Using "batches" also increases the expected workload of the system, since the rate controller mechanism of Caliper cannot account for these extra queries. However, the resulting report will accurately reflect the additional load.
+
+## Gathered TX data
+
+The previously discussed  `invokeSmartContract` and `querySmartContract` functions return an array whose elements correspond to the result of the submitted request(s) with the type of [TxStatus](https://github.com/hyperledger/caliper/blob/master/packages/caliper-core/lib/transaction-status.js). The class provides some standard and platform-specific information about its corresponding transaction.
+
+The standard data provided are the following:
+* `GetID():string` returns the transaction ID.
+* `GetStatus():string` returns the final status of the transaction, either `success` or `failed`.
+* `GetTimeCreate():number` returns the epoch when the transaction was submitted.
+* `GetTimeFinal():number` return the epoch when the transaction was finished.
+* `IsVerified():boolean` indicates whether we are sure about the final status of the transaction. Unverified (considered failed) transactions could occur, for example, if the adapter loses the connection with every Fabric event hub, missing the final status of the transaction.
+* `GetResult():Buffer` returns one of the endorsement results returned by the chaincode as a `Buffer`. It is the responsibility of the user callback to decode it accordingly to the chaincode-side encoding.
+
+The adapter also gathers the following platform-specific data (if observed) about each transaction, each exposed through a specific key name. The placeholders `<P>` and `<O>` in the key names are node names taking their values from the top-level [peers](#peers) and [orderers](#orderers) sections from the network configuration file (e.g., `endorsement_result_peer0.org1.example.com`). The `Get(key:string):any` function returns the value of the observation corresponding to the given key. Alternatively, the `GetCustomData():Map<string,any>` returns the entire collection of gathered data as a `Map`.
+
+The adapter-specific data keys are the following:
+
+|            Key name            | Data type | Description                                                                                                                                                                                                                                                                  |
+|:------------------------------:|:---------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|         `request_type`         |  string   | Either the `transaction` or `query` string value for traditional transactions or queries, respectively.                                                                                                                                                                      |
+|         `time_endorse`         |  number   | The Unix epoch when the adapter received the proposal responses from the endorsers. Saved even in the case of endorsement errors.                                                                                                                                            |
+|        `proposal_error`        |  string   | The error message in case an error occurred during sending/waiting for the proposal responses from the endorsers.                                                                                                                                                            |
+| `proposal_response_error_<P>`  |  string   | The error message in case the endorser peer `<P>` returned an error as endorsement result.                                                                                                                                                                                   |
+|    `endorsement_result_<P>`    |  Buffer   | The encoded chaincode invocation result returned by the endorser peer `<P>`. It is the user callback's responsibility to decode the result.                                                                                                                                  |
+| `endorsement_verify_error_<P>` |  string   | Has the value of `'INVALID'` if the signature and identity of the endorser peer `<P>` couldn't be verified. This verification step can be switched on/off through the [runtime configuration options](#runtime-settings).                                                    |
+| `endorsement_result_error<P>`  |  string   | If the transaction proposal or query execution at the endorser peer `<P>` results in an error, this field contains the error message.                                                                                                                                        |
+|     `read_write_set_error`     |  string   | Has the value of `'MISMATCH'` if the sent transaction proposals resulted in different read/write sets.                                                                                                                                                                       |
+|       `time_orderer_ack`       |  number   | The Unix epoch when the adapter received the confirmation from the orderer that it successfully received the transaction. Note, that this isn't the actual ordering time of the transaction.                                                                                 |
+|     `broadcast_error_<O>`      |  string   | The warning message in case the adapter did not receive a successful confirmation from the orderer node `<O>`. Note, that this does not mean, that the transaction failed (e.g., a timeout occurred while waiting for the answer due to some transient network delay/error). |
+| `broadcast_response_error_<O>` |  string   | The error message in case the adapter received an explicit unsuccessful response from the orderer node `<O>`.                                                                                                                                                                |
+|       `unexpected_error`       |  string   | The error message in case some unexpected error occurred during the life-cycle of a transaction.                                                                                                                                                                             |
+|      `commit_timeout_<P>`      |  string   | Has the value of `'TIMEOUT'` in case the event notification about the transaction did not arrive in time from the peer node `<P>`.                                                                                                                                           |
+|       `commit_error_<P>`       |  string   | Contains the error code in case the transaction validation fails at the end of its life-cycle on peer node `<P>`.                                                                                                                                                            |
+|      `commit_success_<P>`      |  number   | The Unix epoch when the adapter received a successful commit event from the peer node `<P>`. Note, that transactions committed in the same block have nearly identical commit times, since the SDK receives them block-wise, i.e., at the same time.                         |
+|     `event_hub_error_<P>`      |  string   | The error message in case some event hub connection-related error occurs with peer node `<P>`.                                                                                                                                                                               |
+
+You can access these data in your user callback after calling `invokeSmartContract` or `querySmartContract`:
+
+```js
+let settings = {
+    chaincodeFunction: 'initMarble',
+    chaincodeArguments: ['MARBLE#1', 'Red', '100', 'Attila'],
+    invokerIdentity: 'client0.org2.example.com'
+};
+
+// "results" is of type TxStatus[] 
+// DO NOT FORGET "await"!!
+let results = await blockchain.invokeSmartContract(context, 'marbles', '', settings, 10);
+
+// do something with the data
+for (let result of results) {
+    let shortID = result.GetID().substring(8);
+    let executionTime = result.GetTimeFinal() - result.GetTimeCreate();
+    console.log(`TX [${shortID}] took ${executionTime}ms to execute. Result: ${result.GetStatus()}`);
+}
+
+// DO NOT FORGET THIS!!
+return results;
+```
+
+> __Note:__ Do not forget to return the result array at the end of the `run` function!
+
+## Network configuration file reference
+
+The YAML network configuration file of the adapter builds upon the CCP of the Fabric SDK while adding some Caliper-specific extensions. The definitive documentation for the base CCP is the [corresponding Fabric SDK documentation page](https://fabric-sdk-node.github.io/master/tutorial-network-config.html). However, this page also includes the description of different configuration elements to make this documentation as self-contained as possible.
+
+The following sections detail each part separately. For a complete example, please refer to the [example section](#connection-profile-example) or one of the files in the [Caliper benchmarks](https://github.com/hyperledger/caliper-benchmarks/tree/master/networks/fabric) repository. Look for files in the `fabric-v*` directories that start with `fabric-*`.
+
+> __Note:__ Unknown keys are not allowed anywhere in the configuration. The only exception is the `info` property and when network artifact names serve as keys (peer names, channel names, etc.).
+
+
+<details><summary markdown="span">__name__
+</summary>
+_Required. Non-empty string._ <br> 
+The name of the configuration file.
+
+```yaml
+name: Fabric
+```
+</details>
+
+<details><summary markdown="span">__version__
+</summary>
+_Required. Non-empty string._ <br> 
+Specifies the YAML schema version that the Fabric SDK will use. Only the `'1.0'` string is allowed.
+
+```yaml
+version: '1.0'
+```
+</details>
+
+<details><summary markdown="span">__mutual-tls__
+</summary>
+_Optional. Boolean._ <br>
+Indicates whether to use client-side TLS in addition to server-side TLS. Cannot be set to `true` without using server-side TLS. Defaults to `false`.
+
+```yaml
+mutual-tls: true
+```
+</details>
+
+<details><summary markdown="span">__caliper__
+</summary>
+_Required. Non-empty object._ <br>
+Contains runtime information for Caliper. Can contain the following keys.
+
+*  <details><summary markdown="span">__blockchain__
+   </summary>
+   _Required. Non-empty string._ <br>
+   Only the `"fabric"` string is allowed for this adapter.
+   
+   ```yaml
+   caliper:
+     blockchain: fabric
+   ```
+   </details>
+   
+*  <details><summary markdown="span">__command__
+   </summary>
+   _Optional. Non-empty object._ <br>
+   Specifies the start and end scripts. <br>
+   > Must contain __at least one__ of the following keys.
+   
+   *  <details><summary markdown="span">__start__
+      </summary>
+      _Optional. Non-empty string._ <br>
+      Contains the command to execute at startup time. The current working directory for the commands is set to the workspace.
+      
+      ```yaml
+      caliper:
+        command:
+          start: my-startup-script.sh
+      ```
+      </details>
+      
+   *  <details><summary markdown="span">__end__
+      </summary>
+      _Optional. Non-empty string._ <br>
+      Contains the command to execute at exit time. The current working directory for the commands is set to the workspace.
+      
+      ```yaml
+      caliper:
+        command:
+          end: my-cleanup-script.sh
+      ```
+      </details>
+   </details>
+</details>
+
+<details><summary markdown="span">__info__
+</summary>
+_Optional. Object._ <br>
+ Specifies custom key-value pairs that will be included as-is in the generated report. The key-value pairs have no influence on the runtime behavior.
+
+```yaml
+info:
+  Version: 1.1.0
+  Size: 2 Orgs with 2 Peers
+  Orderer: Solo
+  Distribution: Single Host
+  StateDB: CouchDB
+```
+</details>
+
+<details><summary markdown="span">__wallet__
+</summary>
+_Optional. Non-empty string._ <br>
+Specifies the path to an exported `FileSystemWallet`. If specified, all interactions will be based on the identities stored in the wallet, and any listed client keys within the `clients` section *must* correspond to an existing identity within the wallet.
+
+```yaml
+wallet: path/to/myFileWallet
+```
+</details>
+
+<details><summary markdown="span">__certificateAuthorities__
+</summary>
+_Optional. Non-empty object._ <br>
+The adapter supports the Fabric-CA integration to manage users dynamically at startup. Other CA implementations are currently not supported. If you don't need to register or enroll users using Caliper, you can omit this section.
+
+The top-level `certificateAuthorities` section contains one or more CA names as keys (matching the `ca.name` or `FABRIC_CA_SERVER_CA_NAME` setting of the CA), and each key has a corresponding object (sub-keys) that describes the properties of that CA. The names will be used in other sections to reference a CA.
+
+```yaml
+certificateAuthorities:
+  ca.org1.example.com:
+    # properties of CA
+  ca.org2.example.com:
+    # properties of CA
+``` 
+
+*  <details><summary markdown="span">__url__
+   </summary>
+   _Required. Non-empty URI string._ <br>
+   The endpoint of the CA. The protocol must be either `http://` or `https://`. Must be `https://` when using TLS.
+   
+   ```yaml
+   certificateAuthorities:
+     ca.org1.example.com:
+       url: https://localhost:7054
+   ```
+   </details>
+
+*  <details><summary markdown="span">__httpOptions__
+   </summary>
+   _Optional. Object._ <br>
+   The properties specified under this object are passed to the `http` client verbatim when sending the request to the Fabric-CA server.
+   
+   ```yaml
+   certificateAuthorities:
+     ca.org1.example.com:
+       httpOptions:
+         verify: false
+   ```
+   </details>
+   
+*  <details><summary markdown="span">__tlsCACerts__
+   </summary>
+   _Required for TLS. Object._ <br>
+   Specifies the TLS certificate of the CA for TLS communication. Forbidden to set for non-TLS communication. <br> 
+   > Must contain __at most one__ of the following keys.
+   
+   *  <details><summary markdown="span">__path__
+      </summary>
+      _Optional. Non-empty string._ <br>
+      The path of the file containing the TLS certificate.
+
+      ```yaml
+      certificateAuthorities:
+        ca.org1.example.com:
+          tlsCACerts:
+            path: path/to/cert.pem
+      ```
+      </details>
+      
+   *  <details><summary markdown="span">__pem__
+      </summary>
+      _Optional. Non-empty string._ <br>
+      The content of the TLS certificate file.
+
+      ```yaml
+      certificateAuthorities:
+        ca.org1.example.com:
+          tlsCACerts:
+            pem: |
+              -----BEGIN CERTIFICATE-----
+              MIICSDCCAe+gAwIBAgIQfpGy5OOXBYpKZxg89x75hDAKBggqhkjOPQQDAjB2MQsw
+              CQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZy
+              YW5jaXNjbzEZMBcGA1UEChMQb3JnMS5leGFtcGxlLmNvbTEfMB0GA1UEAxMWdGxz
+              Y2Eub3JnMS5leGFtcGxlLmNvbTAeFw0xODA5MjExNzU3NTVaFw0yODA5MTgxNzU3
+              NTVaMHYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQH
+              Ew1TYW4gRnJhbmNpc2NvMRkwFwYDVQQKExBvcmcxLmV4YW1wbGUuY29tMR8wHQYD
+              VQQDExZ0bHNjYS5vcmcxLmV4YW1wbGUuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0D
+              AQcDQgAED4FM1+iq04cjveIDyn4uj90lJlO6rASeOIzm/Oc2KQOjpRRlB3H+mVnp
+              rXN6FacjOp0/6OKeEiW392dcdCMvRqNfMF0wDgYDVR0PAQH/BAQDAgGmMA8GA1Ud
+              JQQIMAYGBFUdJQAwDwYDVR0TAQH/BAUwAwEB/zApBgNVHQ4EIgQgPQRWjQR5EUJ7
+              xkV+zbfY618IzOYGIpfLaV8hdlZfWVIwCgYIKoZIzj0EAwIDRwAwRAIgYzk8553v
+              fWAOZLxiDuMN9RiHve1o5aAQad+uD+eLpxMCIBmv8CtXf1C60h/0zyG1D6tTTnrB
+              H8Zua3x+ZQn/kqVv
+              -----END CERTIFICATE-----
+      ```
+      </details>
+   </details>
+
+*  <details><summary markdown="span">__registrar__
+   </summary>
+   _Required. Non-empty, non-spares array._<br>
+   A collection of registrar IDs and secrets. Fabric-CA supports dynamic user enrollment via REST APIs. A "root" user, i.e., a registrar is needed to register and enroll new users. Note, that currently __only one registrar per CA__ is supported (regardless of the YAML list notation).
+
+   ```yaml
+   certificateAuthorities:
+     ca.org1.example.com:
+       registrar:
+       - enrollId: admin
+         enrollSecret: adminpw
+   ```
+   
+   *  <details><summary markdown="span">__[item].enrollId__
+      </summary>
+      _Required. Non-empty string._ <br>
+      The enrollment ID of the registrar. Must be unique on the collection level.
+      </details>
+
+   *  <details><summary markdown="span">__[item].enrollSecret__
+      </summary>
+      _Required. Non-empty string._ <br>
+      The enrollment secret of the registrar.
+      </details>
+   </details>
+</details>
+
+<details><summary markdown="span">__peers__
+</summary>
+_Required. Non-empty object._ <br>
+Contains one or more, arbitrary but unique peer names as keys, and each key has a corresponding object (sub-keys) that describes the properties of that peer. The names will be used in other sections to reference a peer. 
+
+Can be omitted if only the start/end scripts are executed during benchmarking.
+
+```yaml
+peers:
+  peer0.org1.example.com:
+    # properties of peer
+  peer0.org2.example.com:
+    # properties of peer
+``` 
+
+A peer object (e.g., `peer0.org1.example.com`) can contain the following properties.
+*  <details><summary markdown="span">__url__
+   </summary>
+   _Required. Non-empty URI string._ <br>
+   The (local or remote) endpoint of the peer to send the requests to. If TLS is configured, the protocol must be `grpcs://`, otherwise it must be `grpc://`.
+    
+   ```yaml
+   peers:
+     peer0.org1.example.com:
+       url: grpcs://localhost:7051   
+   ``` 
+   </details>
+
+*  <details><summary markdown="span">__eventUrl__
+   </summary>
+   _Optional. Non-empty URI string._ <br>
+   The (local or remote) endpoint of the peer event service used by the event hub connections. If TLS is configured, the protocol must be `grpcs://`, otherwise it must be `grpc://`. Either all peers must contain this setting, or none of them.
+
+   ```yaml
+   peers:
+     peer0.org1.example.com:
+       eventUrl: grpcs://localhost:7053
+   ``` 
+   </details>
+
+*  <details><summary markdown="span">__grpcOptions__
+   </summary>
+   _Optional. Object._ <br>
+   The properties specified under this object set the gRPC settings used on connections to the Fabric network. See the available options in the [gRPC settings tutorial](https://fabric-sdk-node.github.io/master/tutorial-grpc-settings.html) of the Fabric SDK.
+   
+   ```yaml
+   peers:
+     peer0.org1.example.com:
+       grpcOptions:
+         ssl-target-name-override: peer0.org1.example.com
+         grpc.keepalive_time_ms: 600000
+   ``` 
+   </details>
+
+*  <details><summary markdown="span">__tlsCACerts__
+   </summary>
+   _Required for TLS. Object._ <br>
+   Specifies the TLS certificate of the peer for TLS communication. Forbidden to set for non-TLS communication. <br> 
+   > Must contain __at most one__ of the following keys.
+   
+   *  <details><summary markdown="span">__path__
+      </summary>
+      _Optional. Non-empty string._ <br>
+      The path of the file containing the TLS certificate.
+
+      ```yaml
+      peers:
+        peer0.org1.example.com:
+          tlsCACerts:
+            path: path/to/cert.pem
+      ```
+      </details>
+      
+   *  <details><summary markdown="span">__pem__
+      </summary>
+      _Optional. Non-empty string._ <br>
+      The content of the TLS certificate file.
+
+      ```yaml
+      peers:
+        peer0.org1.example.com:
+          tlsCACerts:
+            pem: |
+              -----BEGIN CERTIFICATE-----
+              MIICSDCCAe+gAwIBAgIQfpGy5OOXBYpKZxg89x75hDAKBggqhkjOPQQDAjB2MQsw
+              CQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZy
+              YW5jaXNjbzEZMBcGA1UEChMQb3JnMS5leGFtcGxlLmNvbTEfMB0GA1UEAxMWdGxz
+              Y2Eub3JnMS5leGFtcGxlLmNvbTAeFw0xODA5MjExNzU3NTVaFw0yODA5MTgxNzU3
+              NTVaMHYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQH
+              Ew1TYW4gRnJhbmNpc2NvMRkwFwYDVQQKExBvcmcxLmV4YW1wbGUuY29tMR8wHQYD
+              VQQDExZ0bHNjYS5vcmcxLmV4YW1wbGUuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0D
+              AQcDQgAED4FM1+iq04cjveIDyn4uj90lJlO6rASeOIzm/Oc2KQOjpRRlB3H+mVnp
+              rXN6FacjOp0/6OKeEiW392dcdCMvRqNfMF0wDgYDVR0PAQH/BAQDAgGmMA8GA1Ud
+              JQQIMAYGBFUdJQAwDwYDVR0TAQH/BAUwAwEB/zApBgNVHQ4EIgQgPQRWjQR5EUJ7
+              xkV+zbfY618IzOYGIpfLaV8hdlZfWVIwCgYIKoZIzj0EAwIDRwAwRAIgYzk8553v
+              fWAOZLxiDuMN9RiHve1o5aAQad+uD+eLpxMCIBmv8CtXf1C60h/0zyG1D6tTTnrB
+              H8Zua3x+ZQn/kqVv
+              -----END CERTIFICATE-----
+      ```
+      </details>
+   </details>
+</details>
+
+<details><summary markdown="span">__orderers__
+</summary>
+_Required. Non-empty object._ <br>
+Contains one or more, arbitrary but unique orderer names as keys, and each key has a corresponding object (sub-keys) that describes the properties of that orderer. The names will be used in other sections to reference an orderer. 
+
+Can be omitted if only the start/end scripts are executed during benchmarking, or if discovery is enabled.
+
+```yaml
+orderers:
+  orderer1.example.com:
+    # properties of orderer
+  orderer2.example.com:
+    # properties of orderer
+``` 
+
+An orderer object (e.g., `orderer1.example.com`) can contain the following properties.
+*  <details><summary markdown="span">__url__
+   </summary>
+   _Required. Non-empty URI string._ <br>
+   The (local or remote) endpoint of the orderer to send the requests to. If TLS is configured, the protocol must be `grpcs://`, otherwise it must be `grpc://`.
+    
+   ```yaml
+   orderers:
+     orderer1.example.com:
+       url: grpcs://localhost:7050   
+   ``` 
+   </details>
+
+*  <details><summary markdown="span">__grpcOptions__
+   </summary>
+   _Optional. Object._ <br>
+   The properties specified under this object set the gRPC settings used on connections to the Fabric network. See the available options in the [gRPC settings tutorial](https://fabric-sdk-node.github.io/master/tutorial-grpc-settings.html) of the Fabric SDK.
+   
+   ```yaml
+   orderers:
+     orderer1.example.com:
+       grpcOptions:
+         ssl-target-name-override: orderer1.example.com
+         grpc.keepalive_time_ms: 600000
+   ``` 
+   </details>
+
+*  <details><summary markdown="span">__tlsCACerts__
+   </summary>
+   _Required for TLS. Object._ <br>
+   Specifies the TLS certificate of the orderer for TLS communication. Forbidden to set for non-TLS communication. <br> 
+   > Must contain __at most one__ of the following keys.
+   
+   *  <details><summary markdown="span">__path__
+      </summary>
+      _Optional. Non-empty string._ <br>
+      The path of the file containing the TLS certificate.
+
+      ```yaml
+      orderers:
+        orderer1.example.com:
+          tlsCACerts:
+            path: path/to/cert.pem
+      ```
+      </details>
+      
+   *  <details><summary markdown="span">__pem__
+      </summary>
+      _Optional. Non-empty string._ <br>
+      The content of the TLS certificate file.
+
+      ```yaml
+      orderers:
+        orderer1.example.com:
+          tlsCACerts:
+            pem: |
+              -----BEGIN CERTIFICATE-----
+              MIICSDCCAe+gAwIBAgIQfpGy5OOXBYpKZxg89x75hDAKBggqhkjOPQQDAjB2MQsw
+              CQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZy
+              YW5jaXNjbzEZMBcGA1UEChMQb3JnMS5leGFtcGxlLmNvbTEfMB0GA1UEAxMWdGxz
+              Y2Eub3JnMS5leGFtcGxlLmNvbTAeFw0xODA5MjExNzU3NTVaFw0yODA5MTgxNzU3
+              NTVaMHYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQH
+              Ew1TYW4gRnJhbmNpc2NvMRkwFwYDVQQKExBvcmcxLmV4YW1wbGUuY29tMR8wHQYD
+              VQQDExZ0bHNjYS5vcmcxLmV4YW1wbGUuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0D
+              AQcDQgAED4FM1+iq04cjveIDyn4uj90lJlO6rASeOIzm/Oc2KQOjpRRlB3H+mVnp
+              rXN6FacjOp0/6OKeEiW392dcdCMvRqNfMF0wDgYDVR0PAQH/BAQDAgGmMA8GA1Ud
+              JQQIMAYGBFUdJQAwDwYDVR0TAQH/BAUwAwEB/zApBgNVHQ4EIgQgPQRWjQR5EUJ7
+              xkV+zbfY618IzOYGIpfLaV8hdlZfWVIwCgYIKoZIzj0EAwIDRwAwRAIgYzk8553v
+              fWAOZLxiDuMN9RiHve1o5aAQad+uD+eLpxMCIBmv8CtXf1C60h/0zyG1D6tTTnrB
+              H8Zua3x+ZQn/kqVv
+              -----END CERTIFICATE-----
+      ```
+      </details>
+   </details>
+</details>
+
+<details><summary markdown="span">__organizations__
+</summary>
+ _Required. Non-empty object._ <br>
+Contains one or more, arbitrary but unique organization names as keys, and each key has a corresponding object (sub-keys) that describes the properties of the organization. The names will be used in other sections to reference an organization.
+
+Can be omitted if only the start/end scripts are executed during benchmarking.
+
+```yaml
+organizations:
+  Org1:
+    # properties of the organization
+  Org2:
+    # properties of the organization
+```
+
+An organization object (e.g., `Org1`) can contain the following properties.
+
+*  <details><summary markdown="span">__mspid__
+   </summary>
+   _Required. Non-empty string._ <br>
+   The unique MSP ID of the organization.
+
+   ```yaml
+   organizations:
+     Org1:
+       mspid: Org1MSP
+   ```
+   </details>
+
+*  <details><summary markdown="span">__peers__
+   </summary>
+   _Optional. Non-empty, non-sparse array of strings._ <br>
+   The list of peer names (from the top-level `peers` section) that are managed by the organization. Cannot contain duplicate or invalid peer entries.
+
+   ```yaml
+   organizations:
+     Org1:
+       peers:
+       - peer0.org1.example.com
+       - peer1.org1.example.com
+   ```
+   </details>
+
+*  <details><summary markdown="span">__certificateAuthorities__
+   </summary>
+   _Optional. Non-empty, non-sparse array of strings._ <br>
+   The list of CA names (from the top-level `certificateAuthorities` section) that are managed by the organization. Cannot contain duplicate or invalid CA entries. Note, that currently __only one CA__ is supported.
+
+   ```yaml
+   organizations:
+     Org1:
+       certificateAuthorities:
+       - ca.org1.example.com
+   ```
+   </details>
+
+*  <details><summary markdown="span">__adminPrivateKey__
+   </summary>
+   _Optional. Object._ <br>
+   Specifies the admin private key for the organization. Required, if an initialization step requires admin signing capabilities (e.g., creating channels, installing/instantiating chaincodes, etc.). <br> 
+   > Must contain __at most one__ of the following keys.
+   
+   *  <details><summary markdown="span">__path__
+      </summary>
+      _Optional. Non-empty string._ <br>
+      The path of the file containing the private key.
+
+      ```yaml
+      organizations:
+        Org1:
+          adminPrivateKey:
+            path: path/to/cert.pem
+      ```
+      </details>
+      
+   *  <details><summary markdown="span">__pem__
+      </summary>
+      _Optional. Non-empty string._ <br>
+      The content of the private key file.
+
+      ```yaml
+      organizations:
+        Org1:
+          adminPrivateKey:
+            pem: |
+              -----BEGIN CERTIFICATE-----
+              MIICSDCCAe+gAwIBAgIQfpGy5OOXBYpKZxg89x75hDAKBggqhkjOPQQDAjB2MQsw
+              CQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZy
+              YW5jaXNjbzEZMBcGA1UEChMQb3JnMS5leGFtcGxlLmNvbTEfMB0GA1UEAxMWdGxz
+              Y2Eub3JnMS5leGFtcGxlLmNvbTAeFw0xODA5MjExNzU3NTVaFw0yODA5MTgxNzU3
+              NTVaMHYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQH
+              Ew1TYW4gRnJhbmNpc2NvMRkwFwYDVQQKExBvcmcxLmV4YW1wbGUuY29tMR8wHQYD
+              VQQDExZ0bHNjYS5vcmcxLmV4YW1wbGUuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0D
+              AQcDQgAED4FM1+iq04cjveIDyn4uj90lJlO6rASeOIzm/Oc2KQOjpRRlB3H+mVnp
+              rXN6FacjOp0/6OKeEiW392dcdCMvRqNfMF0wDgYDVR0PAQH/BAQDAgGmMA8GA1Ud
+              JQQIMAYGBFUdJQAwDwYDVR0TAQH/BAUwAwEB/zApBgNVHQ4EIgQgPQRWjQR5EUJ7
+              xkV+zbfY618IzOYGIpfLaV8hdlZfWVIwCgYIKoZIzj0EAwIDRwAwRAIgYzk8553v
+              fWAOZLxiDuMN9RiHve1o5aAQad+uD+eLpxMCIBmv8CtXf1C60h/0zyG1D6tTTnrB
+              H8Zua3x+ZQn/kqVv
+              -----END CERTIFICATE-----
+      ```
+      </details>
+   </details>
+
+*  <details><summary markdown="span">__signedCert__
+   </summary>
+   _Optional. Object._ <br>
+   Specifies the admin certificate for the organization. Required, if an initialization step requires admin signing capabilities (e.g., creating channels, installing/instantiating chaincodes, etc.). <br> 
+   > Must contain __at most one__ of the following keys.
+   
+   *  <details><summary markdown="span">__path__
+      </summary>
+      _Optional. Non-empty string._ <br>
+      The path of the file containing the certificate.
+
+      ```yaml
+      organizations:
+        Org1:
+          signedCert:
+            path: path/to/cert.pem
+      ```
+      </details>
+      
+   *  <details><summary markdown="span">__pem__
+      </summary>
+      _Optional. Non-empty string._ <br>
+      The content of the certificate.
+
+      ```yaml
+      organizations:
+        Org1:
+          signedCert:
+            pem: |
+              -----BEGIN CERTIFICATE-----
+              MIICSDCCAe+gAwIBAgIQfpGy5OOXBYpKZxg89x75hDAKBggqhkjOPQQDAjB2MQsw
+              CQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZy
+              YW5jaXNjbzEZMBcGA1UEChMQb3JnMS5leGFtcGxlLmNvbTEfMB0GA1UEAxMWdGxz
+              Y2Eub3JnMS5leGFtcGxlLmNvbTAeFw0xODA5MjExNzU3NTVaFw0yODA5MTgxNzU3
+              NTVaMHYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQH
+              Ew1TYW4gRnJhbmNpc2NvMRkwFwYDVQQKExBvcmcxLmV4YW1wbGUuY29tMR8wHQYD
+              VQQDExZ0bHNjYS5vcmcxLmV4YW1wbGUuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0D
+              AQcDQgAED4FM1+iq04cjveIDyn4uj90lJlO6rASeOIzm/Oc2KQOjpRRlB3H+mVnp
+              rXN6FacjOp0/6OKeEiW392dcdCMvRqNfMF0wDgYDVR0PAQH/BAQDAgGmMA8GA1Ud
+              JQQIMAYGBFUdJQAwDwYDVR0TAQH/BAUwAwEB/zApBgNVHQ4EIgQgPQRWjQR5EUJ7
+              xkV+zbfY618IzOYGIpfLaV8hdlZfWVIwCgYIKoZIzj0EAwIDRwAwRAIgYzk8553v
+              fWAOZLxiDuMN9RiHve1o5aAQad+uD+eLpxMCIBmv8CtXf1C60h/0zyG1D6tTTnrB
+              H8Zua3x+ZQn/kqVv
+              -----END CERTIFICATE-----
+      ```
+      </details>
+   </details>
+
+</details>
+
+<details><summary markdown="span">__clients__
+</summary>
+_Required. Non-empty object._ <br>
+Contains one or more unique client names as keys, and each key has a corresponding object (sub-keys) that describes the properties of that client. These client names can be referenced from the user callback modules when submitting a transaction to set the identity of the invoker.
+
+```yaml
+clients:
+  client0.org1.example.com:
+    # properties of the client
+  client0.org2.example.com:
+    # properties of the client
+```
+
+For every client name, there is a single property, called `client` ( to match the expected format of the SDK), which will contain the actual properties of the client. So the `clients` section will look like the following:
+
+```yaml
+clients:
+  client0.org1.example.com:
+    client:
+      # properties of the client
+  client0.org2.example.com:
+    client:
+      # properties of the client
+```
+
+The `client` property of a client object (e.g., `client0.org1.example.com`) can contain the following properties. The list of required/forbidden properties depend on whether a wallet is configured or note. <br>
+> __Note:__ the following constraints apply when __a file wallet is configured__:
+> * The `credentialStore`, `clientPrivateKey`, `clientSignedCert`, `affiliation`, `attributes` and `enrollmentSecret` properties are forbidden.
+> * Each client name __must__ correspond to one of the identities within the provided wallet. If you wish to specify an `Admin Client` then the naming convention is that of `admin.<orgname>`. If no explicit admin client is provided for an organisation, it is assumed that the first listed client for that organisation is associated with an administrative identity.
+
+> __Note:__ the following constraints apply when __a file wallet is not configured__:
+> * `credentialStore` is required. 
+> * The following set of properties are mutually exclusive:
+>   * `clientPrivateKey`/`clientSignedCert` (if one is set, then the other must be set too)
+>   * `affiliation`/`attributes` (if `attributes` is set, then `affiliation` must be set too)
+>   * `enrollmentSecret`
+
+*  <details><summary markdown="span">__organization__
+   </summary>
+   _Required. Non-empty string._ <br>
+   The name of the organization (from the top-level `organizations` section) of the client.
+
+   ```yaml
+   clients:
+     client0.org1.example.com:
+       client:
+         organization: Org1
+   ```
+   </details>
+
+*  <details><summary markdown="span">__credentialStore__
+   </summary>
+   _Required without file wallet. Non-empty object._ <br>
+   The implementation-specific properties of the key-value store. A `FileKeyValueStore`, for example, has the following properties.
+
+   *  <details><summary markdown="span">__path__
+      </summary>
+      _Required. Non-empty string._ <br>
+      Path of the directory where the SDK should store the credentials.
+
+      ```yaml
+      clients:
+        client0.org1.example.com:
+          client:
+            credentialStore:
+              path: path/to/store
+      ```
+      </details>
+    
+   *  <details><summary markdown="span">__cryptoStore__
+      </summary>
+      _Required. Non-empty object._ <br>
+      The implementation-specific properties of the underlying crypto key store. A software-based implementation, for example, requires a store path.
+
+      *  <details><summary markdown="span">__path__
+         </summary>
+         _Required. Non-empty string._ <br>
+         The path of the crypto key store directory.
+
+         ```yaml
+         clients:
+           client0.org1.example.com:
+             client:
+               credentialStore:
+                 cryptoStore:
+                   path: path/to/crypto/store
+         ```
+         </details>
+      </details>
+   </details>
+
+*  <details><summary markdown="span">__clientPrivateKey__
+   </summary>
+   _Optional. Object._ <br>
+   Specifies the private key for the client identity. <br> 
+   > Must contain __at most one__ of the following keys.
+   
+   *  <details><summary markdown="span">__path__
+      </summary>
+      _Optional. Non-empty string._ <br>
+      The path of the file containing the private key.
+
+      ```yaml
+      clients:
+        client0.org1.example.com:
+          client:
+            clientPrivateKey:
+              path: path/to/cert.pem
+      ```
+      </details>
+      
+   *  <details><summary markdown="span">__pem__
+      </summary>
+      _Optional. Non-empty string._ <br>
+      The content of the private key file.
+
+      ```yaml
+      clients:
+        client0.org1.example.com:
+          client:
+            clientPrivateKey:
+              pem: |
+                -----BEGIN CERTIFICATE-----
+                MIICSDCCAe+gAwIBAgIQfpGy5OOXBYpKZxg89x75hDAKBggqhkjOPQQDAjB2MQsw
+                CQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZy
+                YW5jaXNjbzEZMBcGA1UEChMQb3JnMS5leGFtcGxlLmNvbTEfMB0GA1UEAxMWdGxz
+                Y2Eub3JnMS5leGFtcGxlLmNvbTAeFw0xODA5MjExNzU3NTVaFw0yODA5MTgxNzU3
+                NTVaMHYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQH
+                Ew1TYW4gRnJhbmNpc2NvMRkwFwYDVQQKExBvcmcxLmV4YW1wbGUuY29tMR8wHQYD
+                VQQDExZ0bHNjYS5vcmcxLmV4YW1wbGUuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0D
+                AQcDQgAED4FM1+iq04cjveIDyn4uj90lJlO6rASeOIzm/Oc2KQOjpRRlB3H+mVnp
+                rXN6FacjOp0/6OKeEiW392dcdCMvRqNfMF0wDgYDVR0PAQH/BAQDAgGmMA8GA1Ud
+                JQQIMAYGBFUdJQAwDwYDVR0TAQH/BAUwAwEB/zApBgNVHQ4EIgQgPQRWjQR5EUJ7
+                xkV+zbfY618IzOYGIpfLaV8hdlZfWVIwCgYIKoZIzj0EAwIDRwAwRAIgYzk8553v
+                fWAOZLxiDuMN9RiHve1o5aAQad+uD+eLpxMCIBmv8CtXf1C60h/0zyG1D6tTTnrB
+                H8Zua3x+ZQn/kqVv
+                -----END CERTIFICATE-----
+      ```
+      </details>
+   </details>
+
+*  <details><summary markdown="span">__clientSignedCert__
+   </summary>
+   _Optional. Object._ <br>
+   Specifies the certificate for the client identity. <br> 
+   > Must contain __at most one__ of the following keys.
+   
+   *  <details><summary markdown="span">__path__
+      </summary>
+      _Optional. Non-empty string._ <br>
+      The path of the file containing the certificate.
+
+      ```yaml
+      clients:
+        client0.org1.example.com:
+          client:
+            clientSignedCert:
+              path: path/to/cert.pem
+      ```
+      </details>
+      
+   *  <details><summary markdown="span">__pem__
+      </summary>
+      _Optional. Non-empty string._ <br>
+      The content of the certificate file.
+
+      ```yaml
+      clients:
+        client0.org1.example.com:
+          client:
+            clientSignedCert:
+              pem: |
+                -----BEGIN CERTIFICATE-----
+                MIICSDCCAe+gAwIBAgIQfpGy5OOXBYpKZxg89x75hDAKBggqhkjOPQQDAjB2MQsw
+                CQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZy
+                YW5jaXNjbzEZMBcGA1UEChMQb3JnMS5leGFtcGxlLmNvbTEfMB0GA1UEAxMWdGxz
+                Y2Eub3JnMS5leGFtcGxlLmNvbTAeFw0xODA5MjExNzU3NTVaFw0yODA5MTgxNzU3
+                NTVaMHYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQH
+                Ew1TYW4gRnJhbmNpc2NvMRkwFwYDVQQKExBvcmcxLmV4YW1wbGUuY29tMR8wHQYD
+                VQQDExZ0bHNjYS5vcmcxLmV4YW1wbGUuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0D
+                AQcDQgAED4FM1+iq04cjveIDyn4uj90lJlO6rASeOIzm/Oc2KQOjpRRlB3H+mVnp
+                rXN6FacjOp0/6OKeEiW392dcdCMvRqNfMF0wDgYDVR0PAQH/BAQDAgGmMA8GA1Ud
+                JQQIMAYGBFUdJQAwDwYDVR0TAQH/BAUwAwEB/zApBgNVHQ4EIgQgPQRWjQR5EUJ7
+                xkV+zbfY618IzOYGIpfLaV8hdlZfWVIwCgYIKoZIzj0EAwIDRwAwRAIgYzk8553v
+                fWAOZLxiDuMN9RiHve1o5aAQad+uD+eLpxMCIBmv8CtXf1C60h/0zyG1D6tTTnrB
+                H8Zua3x+ZQn/kqVv
+                -----END CERTIFICATE-----
+      ```
+      </details>
+   </details>
+
+*  <details><summary markdown="span">__affiliation__
+   </summary>
+   _Optional. Non-empty string._ <br>
+   If you dynamically register a user through a Fabric-CA, you can provide an affiliation string. The adapter will create the necessary affiliation hierarchy, but you must provide a registrar for the CA that is capable of registering the given affiliation (hierarchy).
+
+   ```yaml
+   clients:
+     client0.org1.example.com:
+       client:
+         affiliation: org3.sales
+   ```
+   </details>
+
+*  <details><summary markdown="span">__attributes__
+   </summary>
+   _Optional. Non-empty, non-spare array of objects._ <br>
+   If you dynamically register a user through a Fabric-CA, you can provide a collection of key-value attributes to assign to the user.
+
+   ```yaml
+   clients:
+     client0.org1.example.com:
+       client:
+         attributes:
+         - name: departmentId
+           value: sales
+           ecert: true
+   ```
+
+   Each attribute has the following properties.
+   
+   *  <details><summary markdown="span">__[item].name__
+      </summary>
+      _Required. Non-empty string._ <br>
+      The unique name of the attribute in the collection.
+      </details>
+   
+   *  <details><summary markdown="span">__[item].value__
+      </summary>
+      _Required. String._ <br>
+      The string value of the attribute.
+      </details>
+
+   *  <details><summary markdown="span">__[item].ecert__
+      </summary>
+      _Optional. Boolean._ <br>
+      A value of `true` indicates that this attribute should be included in an enrollment certificate by default.
+      </details>
+   </details>
+
+*  <details><summary markdown="span">__enrollmentSecret__
+   </summary>
+   _Optional. Non-empty string._ <br>
+   For registered (but not enrolled) users you can provide the enrollment secret, and the adapter will enroll the user and retrieve the necessary crypto materials. However, this is a rare scenario.
+
+   ```yaml
+   clients:
+     client0.org1.example.com:
+       client:
+         enrollmentSecret: secretString
+   ```
+   </details>
+
+*  <details><summary markdown="span">__connection__
+   </summary>
+   _Optional. Non-empty object._ <br>
+   Specifies connection details for the client. Currently, it includes timeout values for different node services. Must contain the following key.
+   
+   *  <details><summary markdown="span">__timeout__
+      </summary>
+      _Required. Non-empty object._ <br>
+      Specifies timeout values for different node services. <br>
+      > __Note:__ must contain __at least one__ of the followign keys.
+
+      *  <details><summary markdown="span">__peer__
+         </summary>
+         _Optional. Non-empty object._ <br>
+         Specifies timeout values for peer services. <br>
+         > __Note:__ must contain __at least one__ of the following keys.
+
+         *  <details><summary markdown="span">__endorser__
+            </summary>
+            _Optional. Positive integer._ <br>
+            Timeout value in _seconds_ to use for peer requests. 
+            
+            ```yaml
+            clients:
+              client0.org1.example.com:
+                client:
+                  connection:
+                    peer:
+                      endorser: 120
+            ```
+            </details>
+         
+         *  <details><summary markdown="span">__eventhub__
+            </summary>
+            _Optional. Positive integer._ <br>
+            Timeout value in _seconds_ to use for waiting for registered events to occur. 
+            
+            ```yaml
+            clients:
+              client0.org1.example.com:
+                client:
+                  connection:
+                    peer:
+                      eventHub: 120
+            ```
+            </details>
+          
+         *  <details><summary markdown="span">__eventReg__
+            </summary>
+            _Optional. Positive integer._ <br>
+            Timeout value in _seconds_ to use when connecting to an event hub. 
+            
+            ```yaml
+            clients:
+              client0.org1.example.com:
+                client:
+                  connection:
+                    peer:
+                      eventReg: 120
+            ```
+            </details>
+         </details>
+
+      *  <details><summary markdown="span">__orderer__
+         </summary>
+         _Optional. Positive integer._ <br>
+         Timeout value in _seconds_ to use for orderer requests.
+
+         ```yaml
+         clients:
+           client0.org1.example.com:
+             client:
+               connection:
+                 orderer: 30
+         ```
+         </details>
+      </details>
+   </details>
+</details>
+
+<details><summary markdown="span">__channels__
+</summary>
+_Required. Non-empty object._ <br>
+Contains one or more unique channel names as keys, and each key has a corresponding object (sub-keys) that describes the properties of the channel.
+
+Can be omitted if only the start/end scripts are executed during benchmarking.
+
+```yaml
+channels:
+  mychannel:
+    # properties of the channel
+  yourchannel:
+    # properties of the channel
+``` 
+
+A channel object (e.g., `mychannel`) can contain the following properties.
+
+*  <details><summary markdown="span">__created__
+   </summary>
+   _Optional. Boolean._ <br>
+   Indicates whether the channel already exists or not. If `true`, then the adapter will not try to create the channel again (which would fail). Defaults to `false`.
+   
+   > __Note:__ when a channel needs to be created, either `configBinary` or `definition` must be set!
+   
+   ```yaml
+   channels:
+     mychannel:
+       created: false
+   ```
+   </details>
+
+*  <details><summary markdown="span">__configBinary__
+   </summary>
+   _Optional. Non-empty string._ <br>
+   If a channel doesn't exist yet, the adapter will create it based on the provided path of a channel configuration binary (which is typically the output of the [configtxgen](https://hyperledger-fabric.readthedocs.io/en/latest/commands/configtxgen.html) tool).
+   
+   > __Note:__ if `created` is false, and the `definition` property is provided, then this property is forbidden.
+   
+   ```yaml
+   channels:
+     mychannel:
+       configBinary: my/path/to/binary.tx
+   ```
+   </details>
+
+*  <details><summary markdown="span">__definition__
+   </summary>
+   _Optional. Object._ <br>
+   If a channel doesn't exist yet, the adapter will create it based on the provided channel definition, consisting of multiple properties.
+   
+   ```yaml
+   channels:
+     mychannel:
+       definition:
+         capabilities: []
+         consortium: SampleConsortium
+         msps: ['Org1MSP', 'Org2MSP']
+         version: 0
+   ``` 
+   
+   *  <details><summary markdown="span">__capabilities__
+      </summary>
+      _Required. Non-sparse array of strings._ <br>
+      List of channel capabilities to include in the configuration transaction.
+      </details>
+   
+   *  <details><summary markdown="span">__consortium__
+      </summary>
+      _Required. Non-empty string._ <br>
+      The name of the consortium.
+      </details>
+   
+   *  <details><summary markdown="span">__msps__
+      </summary>
+      _Required. Non-sparse array of unique strings._ <br>
+      The MSP IDs of the organizations in the channel.
+      </details>
+   
+   *  <details><summary markdown="span">__version__
+      </summary>
+      _Required. Non-negative integer._ <br>
+      The version number of the configuration.
+      </details>
+   </details>
+
+*  <details><summary markdown="span">__orderers__
+   </summary>
+   _Optional. Non-spares array of unique strings._ <br>
+   a list of orderer node names (from the top-level `orderers` section) that participate in the channel.
+   
+   > __Note:__ if discovery is disabled, then this property is required!
+   
+   ```yaml
+   channels:
+     mychannel:
+       orderers: ['orderer1.example.com', 'orderer2.example.com']
+   ``` 
+   </details>
+
+*  <details><summary markdown="span">__peers__
+   </summary>
+   _Required. Object._ <br>
+   Contains the peer node names as _properties_ (from the top-level `peers` section) that participate in the channel.
+   
+   ```yaml
+   channels:
+     mychannel:
+       peers:
+         peer0.org1.example.com:
+           # use default values when object is empty
+         peer0.org2.example.com:
+           endorsingPeer: true
+           chaincodeQuery: true
+           ledgerQuery: false
+           eventSource: true
+   ```
+   
+   Each key is an object that can have the following properties.
+   
+   *  <details><summary markdown="span">__endorsingPeer__
+      </summary>
+      _Optional. Boolean._ <br>
+      Indicates whether the peer will be sent transaction proposals for endorsement. The peer must have the chaincode installed. Caliper can also use this property to decide which peers to send the chaincode install request. Default: true
+      </details>
+    
+   *  <details><summary markdown="span">__chaincodeQuery__
+      </summary>
+      _Optional. Boolean._ <br>
+      Indicates whether the peer will be sent query proposals. The peer must have the chaincode installed. Caliper can also use this property to decide which peers to send the chaincode install request. Default: true
+      </details>
+
+   *  <details><summary markdown="span">__ledgerQuery__
+      </summary>
+      _Optional. Boolean._ <br>
+      Indicates whether the peer will be sent query proposals that do not require chaincodes, like `queryBlock()`, `queryTransaction()`, etc. Currently unused. Default: true
+      </details>
+
+   *  <details><summary markdown="span">__eventSource__
+      </summary>
+      _Optional. Boolean._ <br>
+      Indicates whether the peer will be the target of an event listener registration. All peers can produce events but Caliper typically only needs to connect to one to listen to events. Default: true
+      </details>
+   </details>
+
+*  <details><summary markdown="span">__chaincodes__
+   </summary>
+   _Required. Non-sparse array of objects._ <br>
+   Each array element contains information about a chaincode in the channel. 
+
+   > __Note:__ the `contractID` value of __every__ chaincode in __every__ channel must be unique on the configuration file level! If `contractID` is not specified for a chaincode then its default value is the `id` of the chaincode.
+   
+   ```yaml
+   channels:
+     mychannel:
+       chaincodes:
+       - id: simple
+         # other properties of simple CC
+       - id: smallbank
+         # other properties of smallbank CC
+   ```
+   Some prorperties are required depending on whether a chaincode needs to be deployed. The following constraints apply:
+   > __Note:__ 
+   >
+   > Constraints for installing chaincodes:
+   > * if `metadataPath` is provided, `path` is also required
+   > * if `path` is provided, `language` is also required
+   >
+   > Constraints for instantiating chaincodes:
+   > * if any of the following properties are provided, `language` is also needed: `init`, `function`, `initTransientMap`, `collections-config`, `endorsement-policy`
+   Each element can contain the following properties.
+   
+   *  <details><summary markdown="span">__[item].id__
+      </summary>
+      _Required. Non-empty string._ <br>
+      The ID of the chaincode.
+
+      ```yaml
+      channels:
+        mychannel:
+          chaincodes:
+          - id: simple
+            # other properties
+      ```
+      </details>
+
+   *  <details><summary markdown="span">__[item].version__
+      </summary>
+      _Required. Non-empty string._ <br>
+      The version string of the chaincode.
+      
+      ```yaml
+      channels:
+        mychannel:
+          chaincodes:
+          - version: v1.0
+            # other properties
+      ```
+      </details>
+
+   *  <details><summary markdown="span">__[item].contractID__
+      </summary>
+      _Optional. Non-empty string._ <br>
+      The Caliper-level unique ID of the chaincode. This ID will be referenced from the user callback modules. Can be an arbitrary name, it won't effect the chaincode properties on the Fabric side.
+
+      If omitted, it defaults to the `id` property value.
+
+      ```yaml
+      channels:
+        mychannel:
+          chaincodes:
+          - contractID: simpleContract
+            # other properties
+      ```
+      </details>
+   
+   *  <details><summary markdown="span">__[item].language__
+      </summary>
+      _Optional. Non-empty string._ <br>
+      Denotes the language of the chaincode. Currently supported values: `golang`, `node` and `java`.
+      
+      ```yaml
+      channels:
+        mychannel:
+          chaincodes:
+          - language: node
+            # other properties
+      ```
+      </details>
+
+   *  <details><summary markdown="span">__[item].path__
+      </summary>
+      _Optional. Non-empty string._ <br>
+      The path to the chaincode directory. For golang chaincodes, it is the fully qualified package name (relative to the `GOPATH/src` directory). Note, that `GOPATH` is temporarily set to the workspace directory by default. To disable this behavior, set the `caliper-fabric-overwritegopath` setting key to `false`.
+
+      ```yaml
+      channels:
+        mychannel:
+          chaincodes:
+          - path: contracts/mycontract
+            # other properties
+      ```
+      </details>
+
+   *  <details><summary markdown="span">__[item].metadataPath__
+      </summary>
+      _Optional. Non-empty string._ <br>
+      The directory path for additional metadata for the chaincode (like CouchDB indexes). Only supported since Fabric v1.1.
+
+      ```yaml
+      channels:
+        mychannel:
+          chaincodes:
+          - metadataPath: contracts/mycontract/metadata
+            # other properties
+      ```
+      </details>
+
+   *  <details><summary markdown="span">__[item].init__
+      </summary>
+      _Optional. Non-sparse array of strings._ <br>
+      The list of string arguments to pass to the chaincode's `Init` function during instantiation.
+
+      ```yaml
+      channels:
+        mychannel:
+          chaincodes:
+          - init: ['arg1', 'arg2']
+            # other properties
+      ```
+      </details>
+
+   *  <details><summary markdown="span">__[item].function__
+      </summary>
+      _Optional. String._ <br>
+      The function name to pass to the chaincode's `Init` function during instantiation.
+
+      ```yaml
+      channels:
+        mychannel:
+          chaincodes:
+          - function: 'init'
+            # other properties
+      ```
+      </details>
+
+   *  <details><summary markdown="span">__[item].initTransientMap__
+      </summary>
+      _Optional. Object containing string keys associated with string values._ <br>
+      The transient key-value map to pass to the `Init` function when instantiating a chaincode. The adapter encodes the values as byte arrays before sending them.
+
+      ```yaml
+      channels:
+        mychannel:
+          chaincodes:
+          - initTransientMap:
+              pemContent: |
+                -----BEGIN PRIVATE KEY-----
+                MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgQDk37WuVcnQUjE3U
+                NTW7PpPfcp54q/KBKNrtFXjAtUChRANCAAQ0xnSUxoocDsb2YIrmtFIKZ4XAiwqu
+                V0BCfsl+ByVKUUdXypNrluQfm28AxX7sEDQLKtHVmuMi/BGaKahZ6Snk
+                -----END PRIVATE KEY-----
+              stringArg: this is also passed as a byte array
+            # other properties
+      ```
+      </details>
+
+   *  <details><summary markdown="span">__[item].collections-config__
+      </summary>
+      _Optional. Non-empty, non-sparse array of objects._ <br>
+      List of private collection definitions for the chaincode or a path to the JSON file containing the definitions. For details about the content of such definitions, refer to the [SDK page](https://fabric-sdk-node.github.io/release-1.4/tutorial-private-data.html).
+      
+      ```yaml
+      channels:
+        mychannel:
+          chaincodes:
+          - collections-config:
+            - name: twoOrgCollection
+              policy:
+                identities:
+                - role:
+                    name: member
+                    mspId: Org1MSP
+                - role:
+                    name: member
+                    mspId: Org2MSP
+                policy:
+                  2-of:
+                  - signed-by: 0
+                  - signed-by: 1
+              requiredPeerCount: 1
+              maxPeerCount: 1
+              blockToLive: 0
+            # other properties
+      ```
+      </details>
+
+   *  <details><summary markdown="span">__[item].endorsement-policy__
+      </summary>
+      _Optional. Object._ <br>
+      The endorsement policy of the chaincode as required by the Fabric Node.js SDK. If omitted, then a default N-of-N policy is used based on the target peers (thus organizations) of the chaincode.
+
+      ```yaml
+      channels:
+        mychannel:
+          chaincodes:
+          - endorsement-policy:
+              identities:
+              - role:
+                  name: member
+                  mspId: Org1MSP
+              - role:
+                  name: member
+                  mspId: Org2MSP
+              policy:
+                2-of:
+                - signed-by: 0
+                - signed-by: 1
+            # other properties
+      ```
+      </details>
+
+   *  <details><summary markdown="span">__[item].targetPeers__
+      </summary>
+      _Optional. Non-empty, non-sparse array of strings._ <br>
+      Specifies custom target peers (from the top-level `peers` section) for chaincode installation/instantiation. Overrides the peer role-based channel-level targets.
+
+      ```yaml
+      channels:
+        mychannel:
+          chaincodes:
+          - targetPeers:
+            - peer0.org1.example.com
+            - peer1.org1.example.com
+            - peer0.org2.example.com
+            - peer1.org2.example.com
+            # other properties
+      ```
+      </details>
+   </details>
+</details>
+
+## Connection Profile Example
+
+The following example is a Fabric v1.1 network configuration for the following network topology and artifacts:
+* two organizations;
+* each organization has two peers and a CA;
+* the first organization has one user/client, the second has two (and the second user is dynamically registered and enrolled);
+* one orderer;
+* one channel named `mychannel` that is created by Caliper;
+* `marbles@v0` chaincode installed and instantiated in `mychannel` on every peer;
+* the nodes of the network use TLS communication, but not mutual TLS;
+* the local network is deployed and cleaned up automatically by Caliper.
+
+
+```yaml
+name: Fabric
+version: "1.0"
+
+mutual-tls: false
+
+caliper:
+  blockchain: fabric
+  command:
+    start: docker-compose -f network/fabric-v1.1/2org2peergoleveldb/docker-compose-tls.yaml up -d;sleep 3s
+    end: docker-compose -f network/fabric-v1.1/2org2peergoleveldb/docker-compose-tls.yaml down;docker rm $(docker ps -aq);docker rmi $(docker images dev* -q)
+
+info:
+  Version: 1.1.0
+  Size: 2 Orgs with 2 Peers
+  Orderer: Solo
+  Distribution: Single Host
+  StateDB: GoLevelDB
+
+clients:
+  client0.org1.example.com:
+    client:
+      organization: Org1
+      credentialStore:
+        path: "/tmp/hfc-kvs/org1"
+        cryptoStore:
+          path: "/tmp/hfc-cvs/org1"
+      clientPrivateKey:
+        path: network/fabric-v1.1/config/crypto-config/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp/keystore/key.pem
+      clientSignedCert:
+        path: network/fabric-v1.1/config/crypto-config/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp/signcerts/User1@org1.example.com-cert.pem
+  client0.org2.example.com:
+    client:
+      organization: Org2
+      credentialStore:
+        path: "/tmp/hfc-kvs/org2"
+        cryptoStore:
+          path: "/tmp/hfc-cvs/org2"
+      clientPrivateKey:
+        path: network/fabric-v1.1/config/crypto-config/peerOrganizations/org2.example.com/users/User1@org2.example.com/msp/keystore/key.pem
+      clientSignedCert:
+        path: network/fabric-v1.1/config/crypto-config/peerOrganizations/org2.example.com/users/User1@org2.example.com/msp/signcerts/User1@org2.example.com-cert.pem
+  client1.org2.example.com:
+    client:
+      organization: Org2
+      affiliation: org2.department1
+      role: client
+      credentialStore:
+        path: "/tmp/hfc-kvs/org2"
+        cryptoStore:
+          path: "/tmp/hfc-cvs/org2"
+
+channels:
+  mychannel:
+    configBinary: network/fabric-v1.1/config/mychannel.tx
+    created: false
+    orderers:
+    - orderer.example.com
+    peers:
+      peer0.org1.example.com:
+        endorsingPeer: true
+        chaincodeQuery: true
+        ledgerQuery: true
+        eventSource: true
+      peer1.org1.example.com:
+      peer0.org2.example.com:
+      peer1.org2.example.com:
+
+    chaincodes:
+    - id: marbles
+      version: v0
+      targetPeers:
+      - peer0.org1.example.com
+      - peer1.org1.example.com
+      - peer0.org2.example.com
+      - peer1.org2.example.com
+      language: node
+      path: src/marbles/node
+      metadataPath: src/marbles/node/metadata
+      init: []
+      function: init
+      
+      initTransientMap:
+        pemContent: |
+          -----BEGIN PRIVATE KEY-----
+          MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgQDk37WuVcnQUjE3U
+          NTW7PpPfcp54q/KBKNrtFXjAtUChRANCAAQ0xnSUxoocDsb2YIrmtFIKZ4XAiwqu
+          V0BCfsl+ByVKUUdXypNrluQfm28AxX7sEDQLKtHVmuMi/BGaKahZ6Snk
+          -----END PRIVATE KEY-----
+        stringArg: this is also passed as a byte array
+        
+      endorsement-policy:
+        identities:
+        - role:
+            name: member
+            mspId: Org1MSP
+        - role:
+            name: member
+            mspId: Org2MSP
+        policy:
+          2-of:
+          - signed-by: 0
+          - signed-by: 1
+
+organizations:
+  Org1:
+    mspid: Org1MSP
+    peers:
+    - peer0.org1.example.com
+    - peer1.org1.example.com
+    certificateAuthorities:
+    - ca.org1.example.com
+    adminPrivateKey:
+      path: network/fabric-v1.1/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/key.pem
+    signedCert:
+      path: network/fabric-v1.1/config/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem
+
+  Org2:
+    mspid: Org2MSP
+    peers:
+    - peer0.org2.example.com
+    - peer1.org2.example.com
+    certificateAuthorities:
+    - ca.org2.example.com
+    adminPrivateKey:
+      path: network/fabric-v1.1/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/key.pem
+    signedCert:
+      path: network/fabric-v1.1/config/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem
+
+orderers:
+  orderer.example.com:
+    url: grpcs://localhost:7050
+    grpcOptions:
+      ssl-target-name-override: orderer.example.com
+      grpc-max-send-message-length: 15
+    tlsCACerts:
+      path: network/fabric-v1.1/config/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
+
+peers:
+  peer0.org1.example.com:
+    url: grpcs://localhost:7051
+    grpcOptions:
+      ssl-target-name-override: peer0.org1.example.com
+      grpc.keepalive_time_ms: 600000
+    tlsCACerts:
+      path: network/fabric-v1.1/config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp/tlscacerts/tlsca.org1.example.com-cert.pem
+
+  peer1.org1.example.com:
+    url: grpcs://localhost:7057
+    grpcOptions:
+      ssl-target-name-override: peer1.org1.example.com
+      grpc.keepalive_time_ms: 600000
+    tlsCACerts:
+      path: network/fabric-v1.1/config/crypto-config/peerOrganizations/org1.example.com/peers/peer1.org1.example.com/msp/tlscacerts/tlsca.org1.example.com-cert.pem
+
+  peer0.org2.example.com:
+    url: grpcs://localhost:8051
+    grpcOptions:
+      ssl-target-name-override: peer0.org2.example.com
+      grpc.keepalive_time_ms: 600000
+    tlsCACerts:
+      path: network/fabric-v1.1/config/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/msp/tlscacerts/tlsca.org2.example.com-cert.pem
+
+  peer1.org2.example.com:
+    url: grpcs://localhost:8057
+    grpcOptions:
+      ssl-target-name-override: peer1.org2.example.com
+      grpc.keepalive_time_ms: 600000
+    tlsCACerts:
+      path: network/fabric-v1.1/config/crypto-config/peerOrganizations/org2.example.com/peers/peer1.org2.example.com/msp/tlscacerts/tlsca.org2.example.com-cert.pem
+
+certificateAuthorities:
+  ca.org1.example.com:
+    url: https://localhost:7054
+    httpOptions:
+      verify: false
+    tlsCACerts:
+      path: network/fabric-v1.1/config/crypto-config/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem
+    registrar:
+    - enrollId: admin
+      enrollSecret: adminpw
+
+  ca.org2.example.com:
+    url: https://localhost:8054
+    httpOptions:
+      verify: false
+    tlsCACerts:
+      path: network/fabric-v1.1/config/crypto-config/peerOrganizations/org2.example.com/tlsca/tlsca.org2.example.com-cert.pem
+    registrar:
+    - enrollId: admin
+      enrollSecret: adminpw
+```
+
+## License
+The Caliper codebase is released under the [Apache 2.0 license](./LICENSE.md). Any documentation developed by the Caliper Project is licensed under the Creative Commons Attribution 4.0 International License. You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/docs/v0.3.1/Getting_Started.md
+++ b/docs/v0.3.1/Getting_Started.md
@@ -1,0 +1,56 @@
+---
+layout: v0.3.1
+title:  "Getting Started"
+categories: docs
+permalink: /v0.3.1/getting-started/
+order: 1
+---
+
+## Table of contents
+{:.no_toc}
+
+- TOC
+{:toc}
+
+## Caliper Introduction
+
+Caliper is a blockchain performance benchmark framework, which allows users to test different blockchain solutions with custom use cases, and get a set of performance test results.
+
+### Supported blockchain solutions
+
+* [Hyperledger Besu](https://github.com/hyperledger/besu)
+* [Hyperledger Burrow](https://github.com/hyperledger/burrow)
+* [Ethereum](https://github.com/ethereum/)
+* [Hyperledger Fabric](https://github.com/hyperledger/fabric)
+* [FISCO BCOS](https://github.com/FISCO-BCOS/FISCO-BCOS)
+* [Hyperledger Iroha](https://github.com/hyperledger/iroha)
+* [Hyperledger Sawtooth](https://github.com/hyperledger/sawtooth-core)
+
+### Supported performance metrics
+
+* Transaction/read throughput
+* Transaction/read latency (minimum, maximum, average, percentile)
+* Resource consumption (CPU, Memory, Network IO, ...)
+
+See the [PSWG white paper](https://www.hyperledger.org/resources/publications/blockchain-performance-metrics#) for the exact definitions and corresponding measurement methods.  
+
+## Architecture
+
+It helps to have a basic understanding of how Caliper works before diving into the examples. Have a look at the [Architecture](./Architecture.md) page!
+
+## Installing Caliper
+
+Head to the [Install & Usage](./Installing_Caliper.md) page if you want to try Caliper right now. It's as simple as downloading an NPM package or starting a Docker container!
+
+## Sample Networks
+
+Sample benchmarks that may be used by Caliper are hosted on a companion [GitHub repository](https://github.com/hyperledger/caliper-benchmarks).
+
+Performance reports for the provided samples are hosted on the [documentation pages of the repository](https://hyperledger.github.io/caliper-benchmarks/).
+
+## How to Contribute
+
+Every contribution is welcome! See the [Contributing](./CONTRIBUTING.md) page for details.
+
+## License
+The Caliper codebase is released under the [Apache 2.0 license](./LICENSE.md). Any documentation developed by the Caliper Project is licensed under the Creative Commons Attribution 4.0 International License. You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/docs/v0.3.1/Installing_Caliper.md
+++ b/docs/v0.3.1/Installing_Caliper.md
@@ -1,0 +1,513 @@
+---
+layout: v0.3.1
+title:  "Installing and Running Caliper"
+categories: docs
+permalink: /v0.3.1/installing-caliper/
+order: 2
+---
+
+## Table of contents
+{:.no_toc}
+
+- TOC
+{:toc}
+
+## Overview
+
+Caliper is published as the [@hyperledger/caliper-cli](https://www.npmjs.com/package/@hyperledger/caliper-cli) NPM package and the [hyperledger/caliper](https://hub.docker.com/r/hyperledger/caliper) Docker image, both containing the CLI binary. Refer to the [Installing from NPM](#installing-from-npm) and [Using the Docker image](#using-the-docker-image) sections for the available versions and their intricacies.
+
+Installing and running Caliper usually consists of the following steps, thoroughly detailed by the remaining sections:
+1. Acquire the Caliper CLI either from NPM or from DockerHub.
+2. Execute a _bind_ command through the CLI. This step pulls the specified version of SDK packages for the selected platform.
+3. Start the benchmark through the CLI or by starting the Docker container.
+
+The examples in the rest of the documentation use the [caliper-benchmarks](https://github.com/hyperledger/caliper-benchmarks) repository as the Caliper _workspace_ since it contains many sample artifacts for benchmarking. Make sure you check out the appropriate tag/commit of the repository, matching the version of Caliper you use.
+
+To clone the `caliper-benchmarks` repository, run:
+```bash
+git clone https://github.com/hyperledger/caliper-benchmarks.git
+cd caliper-benchmarks
+git checkout <your Caliper version>
+```
+
+> __Note:__ If you are running your custom benchmark, then change this directory path (and other related configurations) accordingly in the examples.
+
+## The Caliper CLI
+
+Unless you are embedding the Caliper packages in your own application, you will probably use Caliper through its command line interface (CLI). The other sections will introduce the different ways of acquiring and calling the Caliper CLI. This section simply focuses on the API it provides.
+
+> __Note:__ The following examples assume a locally installed CLI in the `~/caliper-benchmarks` directory, hence the `npx` call before the `caliper` binary. Refer to the [Local NPM install](#local-npm-install) section for the specifics.
+
+The entry point of the CLI is the `caliper` binary. You can confirm whether the CLI is installed correctly by checking its version:
+
+```console
+user@ubuntu:~/caliper-benchmarks$ npx caliper --version
+v0.3.0
+```
+
+The CLI provides multiple commands to perform different tasks. To check the available commands and their descriptions, execute:
+
+```console
+user@ubuntu:~/caliper-benchmarks$ npx caliper --help
+caliper <command>
+
+Commands:
+  caliper bind [options]       Bind Caliper to a specific SUT and its SDK version
+  caliper launch <subcommand>  Launch a Caliper process either in a master or worker role.
+  caliper completion           generate completion script
+
+Options:
+  --help, -h  Show usage information  [boolean]
+  --version   Show version information  [boolean]
+
+Examples:
+  caliper bind
+  caliper launch master
+  caliper launch worker
+
+For more information on Hyperledger Caliper: https://hyperledger.github.io/caliper/
+```
+
+You can also request the help page of a specific command, as demonstrated by the next subsections.
+
+> __Note:__ the command options can be set either through the command line, or from various other sources supported by the [configuration mechanism](./Runtime_Configuration.md) of Caliper. This flexibility makes it easy to embed the CLI in different environments.
+
+### The bind command
+
+Acquiring Caliper is as easy as installing a single NPM package, or pulling a single Docker image. However, this single point of install necessitates an additional step of telling Caliper which platform to target and which platform SDK version to use. This step is called _binding_, provided by the `bind` CLI command. 
+
+To have a look at the help page of the command, execute:
+```console
+user@ubuntu:~/caliper-benchmarks$ npx caliper bind --help
+Usage:
+  caliper bind --caliper-bind-sut fabric:1.4.1 --caliper-bind-cwd ./ --caliper-bind-args="-g"
+
+Options:
+  --help, -h           Show usage information  [boolean]
+  --version            Show version information  [boolean]
+  --caliper-bind-sut   The name and version of the platform and its SDK to bind to  [string]
+  --caliper-bind-cwd   The working directory for performing the SDK install  [string]
+  --caliper-bind-args  Additional arguments to pass to "npm install". Use the "=" notation when setting this parameter  [string]
+  --caliper-bind-file  Yaml file to override default (supported) package versions when binding an SDK  [string]
+```
+
+ The binding step technically consists of an extra `npm install` call with the appropriate packages and install settings, fully managed by the CLI. The following parameters can be set for the command:
+ 
+ * __SUT/platform name and SDK version:__ specifies the name of the target platform and its SDK version to install e.g., `fabric:1.4.1`
+ * __Working directory:__ the directory from which the `npm install` command must be performed. Defaults to the current working directory
+ * __User arguments:__ additional arguments to pass to `npm install`, e.g., `--save`
+
+The following SUT name (column header) and SDK version (column value) combinations are supported:
+
+
+| besu   | burrow | ethereum | fabric    | fisco-bcos | iroha  | sawtooth |
+|:------:|:------:|:--------:|:---------:|:----------:|:------:|:--------:|
+| 1.3.2  | 0.23.0 | 1.2.1    | 1.0.0     | 2.0.0      | 0.6.3  | 1.0.0    |
+| 1.3    | latest | latest   | 1.1.0     | latest     | latest | 1.0.1    |
+| 1.4    |        |          | 1.2.0     |            |        | 1.0.2    |
+| latest |        |          | 1.3.0     |            |        | 1.0.4    |
+|        |        |          | 1.4.0     |            |        | 1.0.5    |
+|        |        |          | 1.4.1     |            |        | latest   |
+|        |        |          | 1.4.3     |            |        |          |
+|        |        |          | 1.4.4     |            |        |          |
+|        |        |          | 1.4.5     |            |        |          |
+|        |        |          | 1.4.6     |            |        |          |
+|        |        |          | 1.4.7     |            |        |          |
+|        |        |          | latest    |            |        |          |
+|        |        |          | 2.1.0     |            |        |          |
+|        |        |          | latest-v2 |            |        |          |
+
+
+> __Note:__ the `latest` value always points to the last explicit versions in the columns. However, it is recommended to explicitly specify the SDK version to avoid any surprise between two benchmark runs.
+
+> __Note:__ all patch versions of Besu are supported for each version.  The `1.3.2` SUT is deprecated and it is recommended you use `1.3` instead.
+
+The `bind` command is useful when you plan to run multiple benchmarks against the same SUT version. Bind once, then run different benchmarks without the need to bind again. As you will see in the next sections, the launcher commands for the master and worker processes can also perform the binding step if the required parameter is present.  
+
+> __Note:__ the built-in bindings can be overridden by setting the `caliper-bind-file` parameter to a YAML file path. The file must match the structure of the [default binding file](https://github.com/hyperledger/caliper/blob/master/packages/caliper-cli/lib/lib/config.yaml). This way you can use experimental SDK versions that are not (yet) officially supported by Caliper. __This also means that we cannot provide help for such SDK versions!__
+
+### The launch command
+
+Caliper runs a benchmark by using _worker_ processes to generate the workload, and by using a _master_ process to coordinate the different benchmark rounds among the worker processes. Accordingly, the CLI provides commands for launching both master and worker processes. 
+
+To have a look at the help page of the command, execute:
+```console
+user@ubuntu:~/caliper-benchmarks$ npx caliper launch --help
+caliper launch <subcommand>
+
+Launch a Caliper process either in a master or worker role.
+
+Commands:
+  caliper launch master [options]  Launch a Caliper master process to coordinate the benchmark run
+  caliper launch worker [options]  Launch a Caliper worker process to generate the benchmark workload
+
+Options:
+  --help, -h  Show usage information  [boolean]
+  --version   Show version information  [boolean]
+```
+
+#### The launch master command
+
+The Caliper master process can be considered as the entry point of a distributed benchmark run. It coordinates (and optionally spawns) the worker processes throughout the benchmark run.  
+
+To have a look at the help page of the command, execute:
+```console
+user@ubuntu:~/caliper-benchmarks$ npx caliper launch master --help
+Usage:
+ caliper launch master --caliper-bind-sut fabric:1.4.1 [other options]
+
+Options:
+  --help, -h           Show usage information  [boolean]
+  --version            Show version information  [boolean]
+  --caliper-bind-sut   The name and version of the platform to bind to  [string]
+  --caliper-bind-cwd   The working directory for performing the SDK install  [string]
+  --caliper-bind-args  Additional arguments to pass to "npm install". Use the "=" notation when setting this parameter  [string]
+  --caliper-bind-file  Yaml file to override default (supported) package versions when binding an SDK  [string]
+```
+
+As you can see, the `launch master` command can also process the parameters of the `bind` command, just in case you would like to perform the binding and the benchmark run in one step.
+
+However, the command __requires__ the following parameters to be set:
+* __caliper-workspace:__ the directory serving as the root of your project. Every relative path in other configuration files or settings will be resolved from this directory. The workspace concept was introduced to make Caliper projects portable across different machines.
+* __caliper-benchconfig:__ the path of the file containing the configuration of the test rounds, as detailed in the [Architecture page](./Architecture.md#configuration-file). _Should be relative_ to the workspace path. 
+* __caliper-networkconfig:__ the path of the file containing the network configuration/description for the selected SUT, detailed in the configuration pages of the respective adapters. _Should be relative_ to the workspace path.
+
+#### The launch worker command
+
+The Caliper worker processes are responsible for generating the workload during the benchmark run. Usually more than one worker process is running, coordinated by the single master process.  
+
+To have a look at the help page of the command, execute:
+```console
+user@ubuntu:~/caliper-benchmarks$ npx caliper launch worker --help
+Usage:
+ caliper launch master --caliper-bind-sut fabric:1.4.1 [other options]
+
+Options:
+  --help, -h           Show usage information  [boolean]
+  --version            Show version information  [boolean]
+  --caliper-bind-sut   The name and version of the platform to bind to  [string]
+  --caliper-bind-cwd   The working directory for performing the SDK install  [string]
+  --caliper-bind-args  Additional arguments to pass to "npm install". Use the "=" notation when setting this parameter  [string]
+  --caliper-bind-file  Yaml file to override default (supported) package versions when binding an SDK  [string]
+```
+
+As you can see, you can configure the worker processes the same way as the master process. Including the optional binding step, but also the three mandatory parameters mentioned in the previous section.
+
+#### Caliper test phase control
+
+Caliper commands are capable of passing all [runtime configuration settings](./Runtime_Configuration.md). A subset of these commands are for flow control that provide direct control over the following Caliper phases:
+- start
+- init
+- install
+- test
+- end
+
+It is possible to skip, or perform only one of the above phases through use of the correct flag. For instance, it is common to have an existing network that may be targeted by Caliper through the provision of a `--caliper-flow-only-test` flag.
+
+## Installing from NPM
+
+Caliper is published as the [@hyperledger/caliper-cli](https://www.npmjs.com/package/@hyperledger/caliper-cli) NPM package, providing a single point of install for every supported adapter. 
+
+### Versioning semantics
+
+Before explaining the steps for installing Caliper, let's take a look at the `Versions` page of the CLI package. You will see a list of tags and versions. If you are new to NPM, think of versions as _immutable_ pointers to a specific version (duh) of the source code, while tags are _mutable_ pointers to a specific version. So tags can change where they point to. Easy, right?
+
+But why is all this important to you? Because Caliper is still in its pre-release life-cycle (< v1.0.0), meaning that even minor version bumps are allowed to introduce breaking changes. And if you use Caliper in your project, you might run into some surprises depending on how you install Caliper from time to time. 
+
+> __Note:__ Until Caliper reaches v1.0.0, always use the explicit version numbers when installing from NPM. So let's forget about the `latest` and `unstable` tags, as of now they are just a mandatory hindrance of NPM. As you will see, we deliberately do not provide such tags for the Docker images.
+
+Now that we ignored the tags, let's see the two types of version numbers you will encounter:
+* `0.2.0`: Version numbers of this form denote releases deemed _stable_ by the maintainers. Such versions have a corresponding GitHub tag, both in the `caliper` and `caliper-benchmarks` repositories. Moreover, the latest stable version is documented by the `latest` version of the documentation page. So make sure to align the different versions if you run into some issue.
+* `0.3.0-unstable-20200206065953`: Such version "numbers" denote _unstable_ releases that are published upon every merged pull request (hence the timestamp at the end), and eventually will become a stable version, e.g., `0.3.0`. This way you always have access to the NPM (and Docker) artifacts pertaining to the `master` branch of the repository. Let's find and fix the bugs of new features before they make it to the stable release! 
+
+> __Note:__ The newest unstable release always corresponds to the up-to-date version of the related repositories, and the `vNext` version of the documentation page!
+
+### Pre-requisites
+
+The following tools are required to install the CLI from NPM:
+* node-gyp, python2, make, g++ and git (for fetching and compiling some packages during install)
+* Node.js v8.X LTS or v10.X LTS (for running Caliper)
+* Docker and Docker Compose (only needed when running local examples, or using Caliper through its Docker image)
+
+### Local NPM install
+
+> __Note:__ this is the highly recommended way to install Caliper for your project. Keeping the project dependencies local makes it easier to setup multiple Caliper projects. Global dependencies would require re-binding every time before a new benchmark run (to ensure the correct global dependencies). 
+
+1. Set your NPM project details with `npm init` (or just execute `npm init -y`) in your workspace directory (if you haven't done this already, i.e., you don't have a `package.json` file).
+2. Install the Caliper CLI as you would any other NPM package. It is highly recommended to explicitly specify the version number, e.g., `@hyperledger/caliper-cli@0.3.0` 
+3. Bind the CLI to the required platform SDK (e.g., `fabric` with the `1.4.0` SDK).
+4. Invoke the local CLI binary (using [npx](https://www.npmjs.com/package/npx)) with the appropriate parameters. You can repeat this step for as many Fabric 1.4.0 benchmarks as you would like.
+
+Putting it all together: 
+```console
+user@ubuntu:~/caliper-benchmarks$ npm init -y
+user@ubuntu:~/caliper-benchmarks$ npm install --only=prod \
+    @hyperledger/caliper-cli@0.3.0
+user@ubuntu:~/caliper-benchmarks$ npx caliper bind \
+    --caliper-bind-sut fabric:1.4.0
+user@ubuntu:~/caliper-benchmarks$ npx caliper launch master \
+    --caliper-workspace . \
+    --caliper-benchconfig benchmarks/scenario/simple/config.yaml \
+    --caliper-networkconfig networks/fabric/fabric-v1.4.1/2org1peergoleveldb/fabric-go.yaml
+```
+
+We could also perform the binding automatically when launching the master process (note the extra parameter for `caliper launch master`):
+```console
+user@ubuntu:~/caliper-benchmarks$ npm init -y
+user@ubuntu:~/caliper-benchmarks$ npm install --only=prod \
+    @hyperledger/caliper-cli@0.3.0
+user@ubuntu:~/caliper-benchmarks$ npx caliper launch master \
+    --caliper-bind-sut fabric:1.4.0 \
+    --caliper-workspace . \
+    --caliper-benchconfig benchmarks/scenario/simple/config.yaml \
+    --caliper-networkconfig networks/fabric/fabric-v1.4.1/2org1peergoleveldb/fabric-go.yaml
+```
+
+> __Note:__ specifying the `--only=prod` parameter in step 2 will ensure that the default __latest__ SDK dependencies for __every__ platform will __not__ be installed. Since we perform an explicit binding anyway (and only for a single platform), this is the desired approach, while also saving some storage and time.
+
+> __Note:__ always make sure that the versions of the SUT, the bound SDK and the used artifacts match!
+
+### Global NPM install
+
+> __Note:__ make sure that you have a really good reason for installing the Caliper CLI globally. The recommended approach is the local install. That way your project is self-contained and you can easily setup multiple projects (in multiple directories) that each target a different SUT (or just different SUT versions). Installing or re-binding dependencies globally can get tricky. 
+
+There are some minor differences compared to the local install:
+1. You don't need a `package.json` file.
+2. You can perform the install, bind and run steps from anywhere (just specify the workspace accordingly).
+3. You need to install the CLI globally (`-g` flag).
+4. You need to tell the binding step to install the packages also globally (`--caliper-bind-args` parameter).
+5. You can omit the `npx` command, since `caliper` will be in your `PATH`. 
+
+```console
+user@ubuntu:~$ npm install -g --only=prod @hyperledger/caliper-cli@0.3.0
+user@ubuntu:~$ caliper bind \
+    --caliper-bind-sut fabric:1.4.0 \
+    --caliper-bind-args=-g
+user@ubuntu:~$ caliper launch master \
+    --caliper-workspace ~/caliper-benchmarks \
+    --caliper-benchconfig benchmarks/scenario/simple/config.yaml \
+    --caliper-networkconfig networks/fabric/fabric-v1.4.1/2org1peergoleveldb/fabric-go.yaml
+```
+
+> __Note:__ for global install you don't need to change the directory to your workspace, you can simply specify `--caliper-workspace ~/caliper-benchmarks`. But this way you can't utilize the auto complete feature of your commandline for the relative paths of the artifacts. 
+
+Depending on your NPM settings, your user might need write access to directories outside of its home directory. This usually results in _"Access denied"_ errors. The following pointers [here](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) can guide you to circumvent the problem.
+
+## Using the Docker image
+
+Caliper is published as the [hyperledger/caliper](https://hub.docker.com/r/hyperledger/caliper) Docker image, providing a single point of usage for every supported adapter. The image builds upon the [node:10.16-alpine](https://hub.docker.com/_/node/) image to keep the image size as low as possible. 
+
+The important properties of the image are the following:
+* Working directory: `/hyperledger/caliper/workspace`
+* The commands are executed by the `node` user (created in the base image)
+* The environment variable `CALIPER_WORKSPACE` is set to the `/hyperledger/caliper/workspace` directory
+* The entry point is the __globally__ installed `caliper` binary
+* The environment variable `CALIPER_BIND_ARGS` is set to `-g`, so the binding step also occurs globally.
+* The default command is set to `--version`. This must be overridden when using the image.
+
+This has the following implications:
+1. It is recommended to mount your local workspace to the `/hyperledger/caliper/workspace` container directory. The default `CALIPER_WORKSPACE` environment variable value points to this location, so you don't need to specify it explicitly, one less setting to modify.
+2. You need to choose a command to execute, either `launch master` or `launch worker`. Check the Docker and Docker-Compose examples for the exact syntax.
+3. The binding step is still necessary, similarly to the NPM install approach. Whether you use the `launch master` or `launch worker` command, you only need to set the required binding parameter. The easiest way to do this is through the `CALIPER_BIND_SUT` environment variable. 
+4. You need to set the required parameters for the launched master or worker. The easiest way to do this is through the `CALIPER_BENCHCONFIG` and `CALIPER_NETWORKCONFIG` environment variables. 
+
+### Starting a container
+
+Parts of starting a Caliper container (following the recommendations above):
+1. Pick the required image version
+2. Mount your local working directory to a container directory
+3. Set the required binding and run parameters
+
+> __Note:__ the __latest__ (or any other) tag is __not supported__, i.e, you explicitly have to specify the image version you want: `hyperledger/caliper:0.3.0`, just like it's the recommended approach for the [NPM packages](#versioning-semantics).
+
+Putting it all together, split into multiple lines for clarity, and naming the container `caliper`:
+
+```console
+user@ubuntu:~/caliper-benchmarks$ docker run \
+    -v $PWD:/hyperledger/caliper/workspace \
+    -e CALIPER_BIND_SUT=fabric:1.4.0 \
+    -e CALIPER_BENCHCONFIG=benchmarks/scenario/simple/config.yaml \
+    -e CALIPER_NETWORKCONFIG=networks/fabric/fabric-v1.4.1/2org1peergoleveldb/fabric-go.yaml \
+    --name caliper hyperledger/caliper:0.3.0 launch master
+```
+
+> __Note:__ the above network configuration file contains a start script to spin up a local Docker-based Fabric network, which will not work in this form. So make sure to remove the start (and end) script, and change the node endpoints to remote addresses.
+
+### Using docker-compose
+
+The above command is more readable when converted to a `docker-compose.yaml` file:
+```yaml
+version: '2'
+
+services:
+    caliper:
+        container_name: caliper
+        image: hyperledger/caliper:0.3.0
+        command: launch master
+        environment:
+        - CALIPER_BIND_SUT=fabric:1.4.0
+        - CALIPER_BENCHCONFIG=benchmarks/scenario/simple/config.yaml
+        - CALIPER_NETWORKCONFIG=networks/fabric/fabric-v1.4.1/2org1peergoleveldb/fabric-go.yaml
+        volumes:
+        - ~/caliper-benchmarks:/hyperledger/caliper/workspace
+```
+
+Once you navigate to the directory containing the `docker-compose.yaml` file, just execute:
+```bash
+docker-compose up
+```
+
+> __Note:__ if you would like to test a locally deployed SUT, then you also need to add the necessary SUT containers to the above file and make sure that Caliper starts last (using the `depends_on` attribute).
+
+## Installing locally from source
+
+> __Note:__ this section is intended only for developers who would like to modify the Caliper code-base and experiment with the changes locally before raising pull requests. You should perform the following steps every time you make a modification you want to test, to correctly propagate any changes.
+
+The workflow of modifying the Caliper code-base usually consists of the following steps:
+1. [Bootstrapping the repository](#bootstrapping-the-caliper-repository)
+2. [Modifying and testing the code](#testing-the-code)
+3. [Publishing package changes locally](#publishing-to-local-npm-repository)
+4. [Building the Docker image](#building-the-docker-image)
+
+### Bootstrapping the Caliper repository
+
+To install the basic dependencies of the repository, and to resolve the cross-references between the different packages in the repository, you must execute the following commands from the root of the repository directory:
+1. `npm i`: Installs development-time dependencies, such as [Lerna](https://github.com/lerna/lerna#readme) and the license checking package.
+2. `npm run repoclean`: Cleans up the `node_modules` directory of all packages in the repository. Not needed for a freshly cloned repository.
+3. `npm run bootstrap`: Installs the dependencies of all packages in the repository and links any cross-dependencies between the packages. It will take some time to finish installation. If it is interrupted by `ctrl+c`, please recover the `package.json` file first and then run `npm run bootstrap` again.
+
+Or as a one-liner:
+```console
+user@ubuntu:~/caliper$ npm i && npm run repoclean -- --yes && npm run bootstrap
+```
+
+> __Note:__ do not run any of the above commands with `sudo`, as it will cause the bootstrap process to fail.
+
+### Testing the code
+
+The easiest way to test your changes is to run the CI process locally. Currently, the CI process runs benchmarks for specific adapters. You can trigger these tests by running the following script from the root directory of the repository, setting the `BENCHMARK` environment variable to the platform name:
+
+```console
+user@ubuntu:~/caliper$ BENCHMARK=fabric ./.travis/benchmark-integration-test-direct.sh
+```
+
+The following platform tests (i.e., valid `BENCHMARK` values) are available:
+* besu
+* ethereum
+* fabric
+* fisco-bcos
+* sawtooth
+
+The scripts will perform the following tests (also necessary for a successful pull request):
+* Linting checks
+* Licence header checks
+* Unit tests
+* Running sample benchmarks
+
+If you would like to run other examples, then you can directly access the CLI in the `packages/caliper-cli` directory, without publishing anything locally. 
+
+> __Note:__ the SDK dependencies in this case are fixed (the binding step is not supported with this approach), and you can check (and change) them in the `package.json` files of the corresponding packages. In this case the repository needs to be bootstrapped again.
+
+```console
+user@ubuntu:~/caliper$ node ./packages/caliper-cli/caliper.js launch master \
+    --caliper-workspace ~/caliper-benchmarks \
+    --caliper-benchconfig benchmarks/scenario/simple/config.yaml \
+    --caliper-networkconfig networks/fabric/fabric-v1.4.1/2org1peergoleveldb/fabric-go.yaml
+```
+
+### Publishing to local NPM repository
+
+The NPM publishing and installing steps for the modified code-base can be tested through a local NPM proxy server, Verdaccio. The steps to perform are the following:
+
+1. Start a local Verdaccio server to publish to
+2. Publish the packages from the local (and possible modified) Caliper repository to the Verdaccio server
+3. Install and bind the CLI from the Verdaccio server
+4. Run the integration tests or any sample benchmark
+
+The `packages/caliper-publish` directory contains an internal CLI for easily managing the following steps. So the commands of the following sections must be executed from the `packages/caliper-publish` directory:
+
+```console
+user@ubuntu:~/caliper$ cd ./packages/caliper-publish
+``` 
+
+> __Note:__ use the `--help` flag for the following CLI commands and sub-commands to find out more details.
+
+#### Starting Verdaccio
+
+To setup and start a local Verdaccio server, simply run the following command:
+```console
+user@ubuntu:~/caliper/packages/caliper-publish$ ./publish.js verdaccio start
+...
+[PM2] Spawning PM2 daemon with pm2_home=.pm2
+[PM2] PM2 Successfully daemonized
+[PM2] Starting /home/user/projects/caliper/packages/caliper-tests-integration/node_modules/.bin/verdaccio in fork_mode (1 instance)
+[PM2] Done.
+┌───────────┬────┬──────┬────────┬────────┬─────────┬────────┬─────┬───────────┬────────┬──────────┐
+│ App name  │ id │ mode │ pid    │ status │ restart │ uptime │ cpu │ mem       │ user   │ watching │
+├───────────┼────┼──────┼────────┼────────┼─────────┼────────┼─────┼───────────┼────────┼──────────┤
+│ verdaccio │ 0  │ fork │ 115203 │ online │ 0       │ 0s     │ 3%  │ 25.8 MB   │ user   │ disabled │
+└───────────┴────┴──────┴────────┴────────┴─────────┴────────┴─────┴───────────┴────────┴──────────┘
+ Use `pm2 show <id|name>` to get more details about an app
+```
+
+The Verdaccio server is now listening on the following address: `http://localhost:4873`
+
+#### Publishing the packages
+
+Once Verdaccio is running, you can run the following command to publish every Caliper package locally:
+
+```console
+user@ubuntu:~/caliper/packages/caliper-publish$ ./publish.js npm --registry "http://localhost:4873"
+...
++ @hyperledger/caliper-core@0.3.0-unstable-20200206065953
+[PUBLISH] Published package @hyperledger/caliper-core@0.3.0-unstable-20200206065953
+...
++ @hyperledger/caliper-fabric@0.3.0-unstable-20200206065953
+[PUBLISH] Published package @hyperledger/caliper-fabric@0.3.0-unstable-20200206065953
+...
++ @hyperledger/caliper-cli@0.3.0-unstable-20200206065953
+[PUBLISH] Published package @hyperledger/caliper-cli@0.3.0-unstable-20200206065953
+```
+
+Take note of the dynamic version number you see in the logs, you will need it to install you modified Caliper version from Verdaccio (the `unstable` tag is also present on NPM, so Verdaccio would probably pull that version instead of your local one).
+
+Since the published packages include a second-precision timestamp in their versions, you can republish any changes immediately without restarting the Verdaccio server and without worrying about conflicting packages.
+
+#### Running package-based tests
+
+Once the packages are published to the local Verdaccio server, we can use the usual NPM install approach. The only difference is that now we specify the local Verdaccio registry as the install source instead of the default, public NPM registry:
+
+```console
+user@ubuntu:~/caliper-benchmarks$ npm init -y
+user@ubuntu:~/caliper-benchmarks$ npm install --registry=http://localhost:4873 --only=prod \
+    @hyperledger/caliper-cli@0.3.0-unstable-20200206065953
+user@ubuntu:~/caliper-benchmarks$ npx caliper bind --caliper-bind-sut fabric:1.4.0
+user@ubuntu:~/caliper-benchmarks$ npx caliper launch master \
+    --caliper-workspace . \
+    --caliper-benchconfig benchmarks/scenario/simple/config.yaml \
+    --caliper-networkconfig networks/fabric/fabric-v1.4.1/2org1peergoleveldb/fabric-go.yaml
+```
+
+> __Note:__ we used the local registry only for the Caliper packages. The binding happens through the public NPM registry. Additionally, we performed the commands through npx and the newly installed CLI binary (i.e., not directly calling the CLI code file).
+
+### Building the Docker image
+
+Once the modified packages are published to the local Verdaccio server, you can rebuild the Docker image. The Dockerfile is located in the `packages/caliper-publish` directory.
+
+To rebuild the Docker image, execute the following:
+```console
+user@ubuntu:~/caliper/packages/caliper-publish$ ./publish.js docker
+...
+Successfully tagged hyperledger/caliper:0.3.0-unstable-20200206065953
+[BUILD] Built Docker image "hyperledger/caliper:0.3.0-unstable-20200206065953"
+```
+
+Now you can proceed with the Docker-based benchmarking as described in the previous sections.
+
+> __Note:__ once you are done with the locally published packages, you can clean them up the following way:
+> ```console
+> user@ubuntu:~/caliper/packages/caliper-publish$ ./publish.js verdaccio stop
+> ```
+
+## License
+The Caliper codebase is released under the [Apache 2.0 license](./LICENSE.md). Any documentation developed by the Caliper Project is licensed under the Creative Commons Attribution 4.0 International License. You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/docs/v0.3.1/Iroha_Configuration.md
+++ b/docs/v0.3.1/Iroha_Configuration.md
@@ -1,0 +1,24 @@
+---
+layout: v0.3.1
+title:  "Iroha Configuration"
+categories: config
+permalink: /v0.3.1/iroha-config/
+---
+
+> The latest supported version of Hyperledger Iroha is v1.0 beta-3
+
+* The npm package is in **alfa phase**, so if you have some problems with installing or compilation - please contact [Iroha maintainers](https://github.com/hyperledger/iroha/issues).
+
+## Using Alternative Iroha Versions
+If you wish to use a specific Iroha version, it is necessary to modify the iroha-lib version levels listed as dependancies in `packages/caliper-iroha/package.json`, and then rebuild the Caliper project using the following commands issued at the root Caliper project location:
+
+- `npm install`
+- `npm run repoclean`
+- `npm run bootstrap`
+
+## Issues
+
+Iroha integration is currently in an early phase of development, if you think you can help us out, please send a PR!
+
+## License
+The Caliper codebase is released under the [Apache 2.0 license](./LICENSE.md). Any documentation developed by the Caliper Project is licensed under the Creative Commons Attribution 4.0 International License. You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/docs/v0.3.1/LICENSE.md
+++ b/docs/v0.3.1/LICENSE.md
@@ -1,0 +1,208 @@
+---
+layout: v0.3.1
+title:  "License"
+categories: opensource
+permalink: /v0.3.1/license/
+---
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/docs/v0.3.1/Logging_Control.md
+++ b/docs/v0.3.1/Logging_Control.md
@@ -1,0 +1,466 @@
+---
+layout: v0.3.1
+title:  "Logging Control"
+categories: reference
+permalink: /v0.3.1/logging/
+order: 8
+---
+
+## Table of contents
+{:.no_toc}
+
+- TOC
+{:toc}
+
+## Overview
+
+Caliper builds on the [winston](https://github.com/winstonjs/winston) logger module to provide a flexible, multi-target logging mechanism. There are three different aspects when it comes to interacting with the Caliper logging subsystem:
+
+1. Customizing the logging style
+2. Configuring logging targets
+3. Creating your own loggers
+
+The first two points can be achieved through the [runtime configuration mechanism](./Runtime_Configuration.md) of Caliper. So make sure that you are familiar with the different way of overriding runtime settings before reading on. The examples below only set the different options through the command line. Naturally, any other setting source could be used.
+
+The runtime configuration settings corresponding to logging reside under the `caliper-logging` key hierarchy. See the `caliper.logging` section of the [default configuration file](https://github.com/hyperledger/caliper/blob/master/packages/caliper-core/lib/config/default.yaml) bundled with Caliper for the general structure of the settings.
+
+## Customizing the logging style
+
+The two main aspects of the logging style are the message structure and the different formats that modify the message appearance if applied. The corresponding attributes are the `caliper.logging.template` property and the entire `caliper.logging.formats` property hierarchy, respectively.
+
+The `caliper.logging.formats` hierarchy is special in a sense that every leaf property can be overridden one-by-one, even from the command line or from environment variables. As you will see later, this is not the case for the logging target settings.
+
+> __Note:__ the following style settings apply to every specified logging target!
+
+### Setting the message structure  
+
+The message structure can be easily customized through the `caliper.logging.template` property. It is a simple string that contains predefined placeholders for some special values. Some placeholders are only available, when a corresponding format is also applied.
+
+Let's start with examining the default structure:
+
+```yaml
+caliper:
+  logging:
+    template: '%timestamp% %level% [%label%] [%module%] %message% (%metadata%)'
+```
+
+The following placeholders are available at the moment.
+
+| Placeholder | Required format | Description                                                                       |
+|:-----------:|:---------------:|:----------------------------------------------------------------------------------|
+| `%timestamp%`    | _timestamp_     | Will be replaced with the timestamp of the log message.                           |
+| `%level%`   | -               | Will be replaced the severity level (e.g., info, warn, error) of the log message. |
+| `%label%`   | _label_         | Will be replaced with the configured label of the process.                        |
+| `%module%`  | -               | Will be replaced with the module name that logged the message.                    |
+| `%message%` | -               | Will be replaced with the actual message.                                         |
+| `%metadata%`    | -               | Will be replaced with the string representation of additional logging arguments.   |
+
+You can override this template by changing the `caliper-logging-template` setting key, for example, from the command line: `--caliper-logging-template="%time%: %message%"`
+
+> __Note:__ 
+> 1. Do not forget the two enclosing quotes, since the template can contain spaces!
+> 2. This template if applied after every format has been applied!
+> 3. Adding spaces and different brackets this way is fine for simple coloring scenarios (or when coloring is disabled). However, when coloring the entire log message (or just parts that should be surrounded with additional characters), the result looks inconsistent when formatted this way. See the [Tips & Tricks](#tips--tricks) section for advanced message formatting scenarios.
+
+### Applying formats
+
+The logging subsystem relies on winston's [format mechanism](https://github.com/winstonjs/logform#understanding-formats) to further modify the log messages. The corresponding settings are under the `caliper.logging.formats` property.
+
+Each of these formats can be easily disabled by setting its property to `false`. For example, to disable the `colorize` format, set its corresponding `caliper.logging.formats.colorize` property to false, for example, from the command line: `--caliper-logging-formats-colorize=false` 
+  
+Similarly, any sub-property of a format can be easily overridden. For example, changing the `caliper.logging.formats.colorize.colors.info` property from the command line: `--caliper-logging-formats-colorize-colors-info=blue`
+
+The following formats and their options (sub-properties) are supported.
+
+> __Note:__ the different formats are applied in the order they are presented, which is important (see the [Tips & Tricks](#tips--tricks) section for the reason).
+
+#### Timestamp
+Adds the timestamp to the message in the specified format. The format string must conform to the rules of the [fecha](https://github.com/taylorhakes/fecha#formatting-tokens) package.
+
+For example: `--caliper-logging-formats-timestamp="YYYY.MM.DD-HH:mm:ss.SSS"`
+
+> __Note:__ the format makes the `timestamp` attribute available in the message, thus it can be referenced in the message template, or in other formats that can access message attributes.
+
+#### Label
+Adds a custom label to the message. This is useful for differentiating multiple Caliper instances (or the distributed client instances) after collecting their logs.
+
+For example: `--caliper-logging-formats-label="caliper-test-1"`
+
+> __Note:__ the format makes the `label` attribute available in the message, thus it can be referenced in the message template, or in other formats that can access message attributes.
+
+#### JSON
+Outputs the messages as JSON strings. Useful for file-based logs that will be processed automatically by another tool. The format accepts a `space` sub-property as an options, which corresponds to the `space` parameter of the [JSON.stringify](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Syntax) function.
+
+For example: `--caliper-logging-formats-json="{space:0}"`
+
+> __Note:__
+> 1. Enabling this format is eaiser from a configuration file. See the [Tips & Tricks](#tips--tricks) section.
+> 2. Setting `space` to a non-zero number will effectively format the JSON output with indentations on multiple lines. This could "spam" the console a bit (not a problem for log files, unless you care about the extra newlines).
+> 3. If this format is enabled, the rest of the formats won't be applied, since their purpose is mainly to make console logs more readable.
+
+#### Padding
+Makes every log level string the same length, i.e., adds an extra space after `"info"` and `"warn"` make them the same length as `"error"` and `"debug"`.
+
+For example: `--caliper-logging-formats-pad=true`
+
+#### Align
+Prepends the message part of the log with a tabulator (`"\t"`) to align the messages of different logs in the same place.
+
+For example: `--caliper-logging-formats-align=true`
+
+> __Note:__ if the message format contains other information with variable lengths (e.g., the module name), it can cause misaligned messages. So this is just a "best effort" format to make console messages more readable.
+
+#### Attribute format
+Defines string formatting options for the different attributes of a message. A "format string" can be provided for each message attribute that will "reformat" its value. The format string can use the `%attribute%` placeholder to reference the original value.
+
+A format string can be specified for the following message attributes:
+* timestamp
+* level
+* label
+* module
+* message
+* metadata
+
+For example, to customize the level information of the log (enclose it in the `LEVEL[<level>]` string):
+
+`--caliper-logging-formats-attributeformat-level="LEVEL[%attribute%]"`
+
+> __Note:__ if the attribute is not a string (which can be the case for the "metadata" attribute), then first the attribute value is converted to string, using `JSON.stringify`, and then it's inserted into the format string.
+
+#### Colorize
+Applies color coding for the different attributes of a message. Enabling/disabling coloring is specified on an attribute basis. The following sub-properties can be set to `true/false` to enable/disable coloring for the corresponding attribute:
+
+* timestamp
+* level
+* label
+* module
+* message
+* metadata
+* __all:__ setting it to true enables coloring for every attribute  
+
+For example, to colorize every part of the message: `--caliper-logging-formats-colorize-all=true`
+
+Additionally, the format exposes a `colors` attribute, which contains coloring information for the `info`, `error`, `warn` and `debug` levels. The value of a level can be set to colors and styles provided by the [colors](https://github.com/Marak/colors.js#colors-and-styles) package. To apply multiple styles, separate the values with a space.
+
+For example, to really highlight error-level logs: `--caliper-logging-formats-colorize-colors-error="white bgRed bold italic"`
+
+> __Note:__ the `colors` package offers some exotic styles which seem tempting at first, but don't overdo it, for the sake of your eyes. Keep it simple.
+
+## Configuring logging targets
+
+The source and target(s) of log messages are decoupled, thanks to the [transport mechanism](https://github.com/winstonjs/winston/blob/master/docs/transports.md) of winston. This means that a log message can be easily logged to multiple places, like the console, or different log files. Moreover, this is completely transparent to the module generating the log message!
+
+The different targets are specified under the `caliper.logging.targets` property. The `caliper.logging.targets` section takes the following general form:
+
+```yaml
+caliper:
+  logging:
+    targets:
+      mylogger1:
+        target: console
+        enabled: true
+        options:
+          # console target-specific options
+      mylogger2:
+        target: file
+        enabled: true
+        options:
+          # file target-specific options
+```
+
+Each subproperty of `caliper.logging.targets` is an arbitrary name for the given logging target (e.g., `mylogger1`, `mylogger2`, etc.).
+
+Each target must specify the following properties:
+* `target`: the identifier of a supported target. See the table below.
+* `enabled`: indicates whether the target is enabled. Defaults to `true` if omitted.
+* `options`: this object will be given as-is to the specific winston transport as options. See the table below for the supported options of each transport.
+
+The following `target` values (i.e., transports) are supported. Click on the links for the official documentation of each transport.
+
+| Target | Available options |
+|:------:|:-----------------:|
+| `console` | [Console Transport](https://github.com/winstonjs/winston/blob/master/docs/transports.md#console-transport) |
+| `file` | [File Transport](https://github.com/winstonjs/winston/blob/master/docs/transports.md#file-transport) |
+| `daily-rotate-file` | [Daily Rotating File Transport](https://github.com/winstonjs/winston-daily-rotate-file#options) |
+
+### Disabling loggers
+
+Even though the setting keys/properties of the `caliper.logging.targets` section cannot be overridden one-by-one (like the properties in the `caliper.logging.formats` section), the `enabled` property is an exception. To easily disable a logger, set its `enabled` property to `false` (using the target's name in the property hierarchy).
+ 
+For example, to disable the `mylogger1` target, the following approaches are available:
+* From the command line: `--caliper-logging-targets-mylogger1-enabled=false`
+* From an environment variable: `export CALIPER_LOGGING_TARGETS_MYLOGGER1_ENABLED=false`
+
+> __Note:__ you must use lower-case letters (and/or digits) in your target name for this to work!
+
+### Overriding logger target settings
+
+But what if you would like to modify one of the options of a transport? You can use a [configuration file](./Runtime_Configuration.md#configuration-files) for that!
+
+For the next example, we will disable the default file logger, modify the logging level of the console target, and also add a new daily rotating file logger. We can do all of this with a single configuration file.   
+
+```yaml
+caliper:
+  logging:
+    targets:
+      console:
+        options:
+          # we don't care about info level messages anymore
+          level: warn 
+      file:
+        # we disable this
+        enabled: false
+      rotatingfile:
+        target: daily-rotate-file
+        # enabled by default
+        options:
+          # we log every message this way
+          level: debug
+          # start a new log file every hour
+          datePattern: 'YYYY-MM-DD-HH'
+          # compress old log files after rotating
+          zippedArchive: true
+          # include the hour-precision date in the file names
+          filename: 'caliper-%DATE%.log'
+          # options for opening the file for writing
+          options:
+            # append mode
+            flags: a
+            # make the file readable/writable by anyone
+            mode: 0666
+```
+
+If you save the above content as `caliper.yaml` in your workspace directory, then Caliper will pick it up automatically.
+
+> __Note:__ some remarks about the above file content:
+> 1. We only set the properties we wanted to override. The default configuration file will be merged with the above configuration file, the values in the latter taking precedence.
+> 2. The provided options for a transport are not verified by Caliper. It is simple passed to the specific transport. It is your responsibility to configure the transport the right way.
+> 3. We could have disabled the `file` logger also from the command line, or from an environment variable. The reason we did it from a config file is explained in the [Tips & tricks](#tips--tricks) section.  
+
+## Creating your own loggers
+
+The different modules of Caliper will automatically use the configured targets for logging. Moreover, your user test modules can also create logger instances to log runtime events related to your business logic.
+
+To create your own logger instance, use the following API:
+
+```js
+const logger = require('@hyperledger/caliper-core').CaliperUtils.getLogger('my-module');
+
+// ...
+
+logger.debug('My custom debug message', metadataObject1, metadataObject2);
+```
+
+Once a logger instance is created, it exposes the usual `info`, `warn`, `debug` and `error` functions that each take as parameter a log message and optional objects, considered as "metadata".
+
+This "metadata" is especially useful for debug level logs. When you perform an operation based on a complex input parameter/object, you can log the following at the beginning of your function:
+
+```js
+function complexCalculation(complexInput) {
+    logger.debug('Starting complex calculation. Input: ', complexInput);
+    // complex calculation
+}
+```
+
+The "metadata" will appear at the place of the `%metadata%` placeholder, as discussed in the message template section.
+
+> __Note:__ passing large metadata objects can hurt the performance of logging if done in a loop/hot path. Only use "metadata" logging for debug messages, since the debug level is usually switched off in production code.
+
+## Tips & tricks
+
+### The format pipeline
+
+Winston formats are a powerful feature that allow the arbitrary manipulation of log messages. From the user's perspective, a log message is a simple string displayed on the console, or saved in a file. However, to fully utilize the logging styles described in this documentation, it might help knowing what really happens under the hood. 
+
+> __Note:__ in the remainder of this section, we'll refer to log messages as LOG. 
+
+LOG can be considered an item/object, that is generated when issuing a call to `logger.info(...)` or similar functions. A LOG can have several attributes attached to it. Every LOG has the `level` and `message` attributes, containing the severity and the "description" of LOG. Additionally, Caliper automatically adds the `module` attribute to LOGs of every logger created through the Caliper API, denoting the name of the module who issued the log.  
+
+Let's introduce the format pipeline through an example.
+
+#### Assumptions
+
+Let's assume that the following `caliper.logging` configuration is used:
+
+```yaml
+template: '%timestamp%%level%%label%%module%%message%%metadata%'
+formats:
+    timestamp: 'YYYY.MM.DD-HH:mm:ss.SSS'
+    label: caliper
+    json: false
+    pad: true
+    align: false
+    attributeformat:
+        level: ' %attribute%'
+        label: ' [%attribute%]'
+        module: ' [%attribute%] '
+        metadata: ' (%attribute%)'
+    colorize:
+        all: true
+        colors:
+            info: green
+            error: red
+            warn: yellow
+            debug: grey
+```
+
+This means that the following formats will be applied to every LOG:
+* module (automatically added by Caliper)
+* timestamp
+* label
+* padding
+* attribute formats
+* colorizing
+* template substitution
+
+Furthermore, let's assume that the following code initiates the LOG:
+
+```js
+const logger = require('@hyperledger/caliper-core').CaliperUtils.getLogger('my-module');
+
+// ...
+
+logger.info('Doing operation X with:', 'someSetting', 'anotherSetting');
+```
+
+#### The life of a LOG
+
+The `logger.info` call generates the initial LOG with the following attributes:
+
+```yaml
+level: 'info'
+message: 'Doing operation X with:'
+```
+
+Before LOG enters the format pipeline, Caliper also adds the module name, and collects the additional parameters as metadata. Now LOG has the following attributes:
+
+```yaml
+level: 'info'
+message: 'Doing operation X with:'
+module: 'my-module'
+metadata: ['someSetting', 'anotherSetting']
+```
+
+This is the initial LOG entity that enters the format pipeline. Every enabled format is "just" a transformation on the attributes of LOG. A format can manipulate the value of an existing attribute or/and add/remove arbitrary attributes.
+
+The first step of the pipeline is the timestamp format. This adds the `timestamp` attribute containing the current time, in the specified format. After this step, LOG looks like this:
+
+```yaml
+level: 'info'
+message: 'Doing operation X with:'
+module: 'my-module'
+metadata: ['someSetting', 'anotherSetting']
+timestamp: '2019.10.07-12:45:47.962'
+```
+
+The next step if the label format, which adds the `label` attribute with the specified value (`caliper`, in this case):
+
+```yaml
+level: 'info'
+message: 'Doing operation X with:'
+module: 'my-module'
+metadata: ['someSetting', 'anotherSetting']
+timestamp: '2019.10.07-12:45:47.962'
+label: 'caliper'
+```
+
+The next step is the padding format, which ensure that every logging level string has the same length. This means, that an extra space is appended at the end of the `level` attribute:
+
+```yaml
+level: 'info '
+message: 'Doing operation X with:'
+module: 'my-module'
+metadata: ['someSetting', 'anotherSetting']
+timestamp: '2019.10.07-12:45:47.962'
+label: 'caliper'
+```
+
+The next step is the attribute formatter. This formatter is configured to modify multiple attributes of LOG, based on a string template:
+
+* level: add a space before it
+* label: enclose in `[]` and add a space before it
+* module: enclose in `[]` and add a space before and after it
+* metadata: enclose in `()` and add a space before it
+
+After these transformation, LOG looks like the following:
+```yaml
+level: ' info '
+message: 'Doing operation X with:'
+module: ' [my-module] '
+metadata: ' (["someSetting", "anotherSetting"])'
+timestamp: '2019.10.07-12:45:47.962'
+label: ' [caliper]'
+```
+
+> __Note:__ some remarks:
+> 1. `metadata` was an Array, not a string, so it was stringified before the formatting was applied.
+> 2. `message` and `timestamp` is unchanged.
+
+The next step is the colorizing format, which adds certain color/style codes to the configured values. Since `all` is set true, and the `level` of LOG is `info`, every attribute is surrounded with the color code for green (denoted by `<green>` for sake of readability):
+
+```yaml
+level: '<green> info <green>'
+message: '<green>Doing operation X with:<green>'
+module: '<green> [my-module] <green>'
+metadata: '<green> (["someSetting", "anotherSetting"])<green>'
+timestamp: '<green>2019.10.07-12:45:47.962<green>'
+label: '<green> [caliper]<green>'
+```
+
+The last step in the pipeline (since the JSON format is disabled) is substituting the attributes into the logging template, to create the final message, that will appear in the console and in the file. The result is the concatenation of LOG's attributes in the following order:
+1. timestamp
+2. level
+3. label
+4. module
+5. message
+6. metadata
+
+Omitting the color code for the sake of readability, this results in:
+```
+2019.10.07-12:45:47.962 info  [caliper] [my-module] Doing operation X with: (["someSetting", "anotherSetting"])
+```
+
+> __Note:__ try adding other characters to the template string. And then be surprised that they are not colorized with the rest of the line. Actually, this is not surprising at all. The template string is "evaluated" after the colorizing format. Since these extra characters are not part of any attributes of LOG, they won't be colorized.  
+
+### Use a configuration file
+
+Logging settings are usually determined by your log analysis requirements. This means that once you settle on some logging style and targets, those settings will rarely change.
+
+To this end, the ability to override the logging style settings from the command line or from environment variables is really just a convenience feature. Once you found your ideal settings, it's worth to record them in a configuration file.
+
+The easiest way to do that is with a project-level configuration file. If you name the following file `caliper.yaml` and place it in your workspace root, then Caliper will automatically apply the settings.
+
+> __Note:__ there are other ways to load a configuration file, as discussed in the [runtime configuration page](./Runtime_Configuration.md#configuration-files).
+
+```yaml
+caliper:
+  logging:
+    # no need for timestamp and label
+    template: '%level% [%module%]: %message% %meta%'
+    formats:
+      # color codes look ugly in log files
+      colorize: false
+      # don't need these, since won't appear in the template
+      label: false
+      timestamp: false
+    targets:
+      file:
+        options:
+          # bump the log level from debug to warn, only log the critical stuff in this file
+          level: warn
+          filename: 'critical.log'
+      rotatingfile:
+        target: daily-rotate-file
+        enabled: true
+        options:
+          level: debug
+          datePattern: 'YYYY-MM-DD-HH'
+          zippedArchive: true
+          filename: 'debug-%DATE%.log'
+          options:
+            flags: a
+            mode: 0666
+```
+
+## License
+The Caliper codebase is released under the [Apache 2.0 license](./LICENSE.md). Any documentation developed by the Caliper Project is licensed under the Creative Commons Attribution 4.0 International License. You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/docs/v0.3.1/Messengers.md
+++ b/docs/v0.3.1/Messengers.md
@@ -1,0 +1,38 @@
+---
+layout: v0.3.1
+title:  "Messengers"
+categories: reference
+permalink: /v0.3.1/caliper-messengers/
+order: 6
+---
+
+## Table of Contents
+
+* [Overview](#overview)
+* [Messengers](#monitors)
+
+## Overview
+Caliper uses an orchestrator to control workers that interact with the SUT in order to perform a benchmark. Messages are passed between the orchestrator and all workers in order to keep the workers synchronized, and to progress the specified benchmark tests. A user may specify the messaging protocol that is user by Caliper in order to facilitate communications between the orchestrator and worker.
+
+## Messengers
+The messaging protocol to be used for communications between the orchestrator and worker during a benchmark is declared in the `caliper runtime configuration file`. Unspecified values will default to those specified in the [default configuration file](https://github.com/hyperledger/caliper/blob/master/packages/caliper-core/lib/config/default.yaml).
+
+Permitted messengers are:
+- **Process:** The `process` messenger is the default messenger and is based on native NodeJS `process` based communications. This messenger type is only valid for instances when local workers are being used to perform a benchmark.
+- **MQTT:** The `mqtt` messenger uses [MQTT](https://mqtt.org/) to facilitate communication between the orchestrator and workers. This messenger type is valid for both local and distributed workers, and assumes the existence of an MQTT broker service that may be used, such as [mosquitto](https://mosquitto.org/).
+
+The following yaml extract specifies the use of an MQTT communication method, using an existing MQTT broker that may be connected to via the specified address:
+```
+    worker:
+        communication:
+            method: mqtt
+            address: mqtt://localhost:1883
+```
+
+If not specifying a `caliper.yaml` configuration file, the above may be specified as command line arguments to the CLI process as:
+```
+--caliper-worker-communication-method mqtt --caliper-worker-communication-address mqtt://localhost:1883
+```
+
+## License
+The Caliper codebase is released under the [Apache 2.0 license](./LICENSE.md). Any documentation developed by the Caliper Project is licensed under the Creative Commons Attribution 4.0 International License. You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/docs/v0.3.1/MonitorsAndObservers.md
+++ b/docs/v0.3.1/MonitorsAndObservers.md
@@ -1,0 +1,310 @@
+---
+layout: v0.3.1
+title:  "Monitors and Observers"
+categories: reference
+permalink: /v0.3.1/caliper-monitors/
+order: 5
+---
+
+## Table of Contents
+
+* [Overview](#overview)
+* [Monitors](#monitors)
+  * [Process monitor](#process-monitor)
+  * [Docker monitor](#docker-monitor)
+  * [Prometheus monitor](#prometheus-monitor)
+* [Observers](#observers)
+  * [Null observer](#null-observer)
+  * [Local observer](#local-observer)
+  * [Prometheus observer](#prometheus-observer)
+  * [Grafana](#grafana-visualization)
+* [Resource Charting](#resource-charting)
+  * [Process charting](#process-charting)
+  * [Docker charting](#docker-charting)
+  * [Prometheus charting](#prometheus-charting)
+
+
+## Overview
+Caliper monitors are used to collect statistics on resource utilization during benchmarking, the statistics are collated into a report at the culmination of the benchmark process, rendered charts may also be output as part of the report. Caliper also enables real time reporting of current transaction status through observers, or enhanced data visualization using Prometheus and Grafana.
+
+The operational precision of the monitors is set through the default Caliper configuration file, and may be overridden by the user to increase or decrease the numeric precision used in the output reports.
+
+## Monitors
+The type of monitoring to be performed during a benchmark is declared in the `benchmark configuration file` through the specification one or more monitor types in an array under the label `monitor.type`. The integer interval at which monitors fetch information from their targets, in seconds, is specified as an integer under the label `monitor.interval`.
+
+Permitted monitors are:
+- **None:** The `none` monitor declares that no monitors are to be used during the benchmark.
+- **Process:** The `process` monitor enables monitoring of a named process on the host machine, and is most typically used to monitor the resources consumed by the running clients. This monitor will retrieve statistics on: [memory(max), memory(avg), CPU(max), CPU(avg), Network I/O, Disc I/O]
+- **Docker:** The `docker` monitor enables monitoring of specified Docker containers on the host or a remote machine, through using the Docker Remote API to retrieve container statistics. This monitor will retrieve statistics on: [memory(max), memory(avg), CPU(max), CPU(avg), Network I/O, Disc I/O]
+- **Prometheus:** The `prometheus` monitor enables the retrieval of data from Prometheus. This monitor will only report based on explicit user provided queries that are issued to Prometheus. If defined, the provision of a Prometheus server will cause Caliper to default to using the Prometheus PushGateway.
+
+The following declares the use of no monitors:
+```
+monitor:
+  type:
+  - none
+```
+
+The following declares the use of docker, process and prometheus monitors:
+```
+monitor:
+  type:
+  - docker
+  - process
+  - prometheus
+```
+
+Each declared monitor must be accompanied by a block that describes the required configuration of the monitor.
+
+### Process Monitor
+The process monitor definition consists of an array of `[command, arguments, multiOutput]` key:value pairs. 
+- command: names the parent process to monitor
+- arguments: filters on the parent process being monitored
+- multiOutput: enables handling of the discovery of multiple processes and may be one of:
+  - avg: take the average of process values discovered under `command/name`
+  - sum: sum all process values discovered under `command/name`
+
+The following declares the monitoring of all local `node` processes that match `fabricClientWorker.js`, with the average of all discovered processes being taken.
+```
+monitor:
+  type:
+  - process
+  process: 
+    processes:
+    - command: node
+      arguments: fabricClientWorker.js
+      multiOutput: avg
+```
+### Docker Monitor
+The docker monitor definition consists of an array of container names that may relate to local or remote docker containers that are listed under a name label. If all local docker containers are to be monitored, this may be achieved by providing `all` as a name
+
+The following declares the monitoring of two named docker containers; one local and the other remote. 
+```
+monitor:
+  type:
+  - docker
+  docker:  
+    containers:
+    - peer0.org1.example.com
+    - http://192.168.1.100:2375/orderer.example.com
+```
+
+The following declares the monitoring of all local docker containers:
+```
+monitor:
+  type:
+  - docker
+  docker:  
+    containers:
+    - all
+```
+
+### Prometheus Monitor
+[Prometheus](https://prometheus.io/docs/introduction/overview/) is an open-source systems monitoring and alerting toolkit that scrapes metrics from instrumented jobs, either directly or via an intermediary push gateway for short-lived jobs. It stores all scraped samples locally and runs rules over this data to either aggregate and record new time series from existing data or generate alerts. [Grafana](https://grafana.com/) or other API consumers can be used to visualize the collected data.
+
+Caliper clients may use a Prometheus [PushGateway](https://prometheus.io/docs/practices/pushing/) in order to publish transaction statistics, as an alternative to reporting statistics locally. By doing so we enable all Caliper clients to publish to a remote URL and gain access to the capabilities of Prometheus, which includes the ability to scrape data from configured targets. If a Prometheus monitor is specified, Caliper will default to publishing all transaction statistics to the Prometheus PushGateway.
+
+All data stored on Prometheus may be queried by Caliper using the Prometheus query [HTTP API](https://prometheus.io/docs/prometheus/latest/querying/api/). At a minimum this may be used to perform aggregate queries in order to report back the transaction statistics, though it is also possible to perform custom queries in order to report back information that has been scraped from other connected sources. Queries issued are intended to generate reports and so are expected to result in either a single value, or a vector that can be condensed into a single value through the application of a statistical routine. It is advisable to create required queries using Grafana to ensure correct operation before transferring the query into the monitor. Please see [Prometheus](https://prometheus.io) and [Grafana](https://grafana.com/grafana) documentation for more information.
+
+#### Configuring The Prometheus Monitor
+The prometheus monitor definition consists of:
+- url: The Prometheus URL, used for direct queries
+- push_url: The Prometheus Push Gateway URL
+- metrics: The queries to be run for inclusion within the Caliper report, comprised of to keys: `ignore` and `include`. 
+  - `ignore` a string array that is used as a blacklist for report results. Any results where the component label matches an item in the list, will *not* be included in a generated report.
+  - `include` a series of blocks that describe the queries that are to be run at the end of each Caliper test.
+
+The `include` block is defined by:
+- query: the query to be issued to the Prometheus server at the end of each test. Note that Caliper will add time bounding for the query so that only results pertaining to the test round are included.
+- step: the timing step size to use within the range query
+- label: a string to match on the returned query and used when populating the report
+- statistic: if multiple values are returned, for instance if looking at a specific resource over a time range, the statistic will condense the values to a single result to enable reporting. Permitted options are:
+  - avg: return the average from all values
+  - max: return the maximum from all values
+  - min: return the minimum from all values
+  - sum: return the summation of all values
+- multiplier: An optional multiplier that may be used to convert exported metrics into a more convenient value (such as converting bytes to GB)
+
+The following declares a Prometheus monitor that will run two bespoke queries between each test within the benchmark
+```
+monitor:
+  type:
+  - prometheus
+  prometheus:  
+	url: "http://localhost:9090"
+	push_url: "http://localhost:9091"
+  metrics:
+	  ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter]
+	  include:
+	    Endorse Time (s):
+		    query: rate(endorser_propsal_duration_sum{chaincode="marbles:v0"}[5m])/rate(endorser_propsal_duration_count{chaincode="marbles:v0"}[5m])
+		    step: 1
+		    label: instance		
+		    statistic: avg
+	    Max Memory (MB):
+		    query: sum(container_memory_rss{name=~".+"}) by (name)
+		    step: 10
+		    label: name		
+		    statistic: max
+		    multiplier: 0.000001
+```
+The two queries above will be listed in the generated report as "Endorse Time (s)" and "Max Memory (MB)" respectively:
+ - **Endorse Time (s):** Runs the listed query with a step size of 1; filters on return tags using the `instance` label; exclude the result if the instance value matches any of the string values provided in the `ignore` array; if the instance does not match an exclude option, then determine the average of all return results and return this value to be reported under "Endorse Time (s)".
+ - **Max Memory (MB):** Runs the listed query with a step size of 10; filter return tags using the `name` label; exclude the result if the instance value matches any of the string values provided in the `ignore` array; if the instance does not match an exclude option, then determine the maximum of all return results; multiply by the provided multiplier and return this value to be reported under "Max Memory (MB)".
+
+
+#### Obtaining a Prometheus Enabled Network
+A sample network that includes a docker-compose file for standing up a Prometheus server, a Prometheus PushGateway and a linked Grafana analytics container, is available within the companion [caliper-benchmarks repository](https://github.com/hyperledger/caliper-benchmarks/tree/master/networks/prometheus-grafana).
+
+
+## Observers
+The type of observer to use during a benchmark is declared in the `benchmark configuration file` through the specification a supported observer type in under the label `observer.type`. The integer interval at which observers fetch information from their targets, in seconds, is specified as an integer under the label `observer.interval`; this is a required property for local and prometheus observers.
+
+Permitted observers are:
+ - none
+ - local
+ - prometheus
+
+### None Observer
+A `none` observer is used to ignore all transaction submissions of all clients. The following specifies the use of a none observer that will omit the console display of any transaction statistics during the benchmark process.
+
+```
+observer:
+  type: none
+```
+
+### Local Observer
+A `local` observer is used to view current transaction submissions of all clients on a local host machine. The following specifies the use of a local observer that collects and reports current transaction status at 1 second intervals.
+
+```
+observer:
+  type: local
+  interval: 1
+```
+
+If a Prometheus monitor is in use, then a Prometheus observer should also be used.
+
+### Prometheus Observer
+A `prometheus` observer is used to view current transaction submissions of all clients that are reporting transactions to a Prometheus server. The following specifies the use of a Prometheus observer that collects and reports current transaction status at 5 second intervals.
+
+```
+observer:
+  type: prometheus
+  interval: 5
+```
+
+Use of a Prometheus observer is predicated on the availability and use of a Prometheus monitor. The observer will extract required URL information from the relevant sections under the Prometheus monitor specification.
+
+### Grafana Visualization
+Grafana is an analytics platform that may be used to query and visualize metrics collected by Prometheus. Caliper clients will send the following to the PushGateway:
+ - caliper_tps
+ - caliper_latency
+ - caliper_send_rate
+ - caliper_txn_submitted
+ - caliper_txn_success
+ - caliper_txn_failure
+ - caliper_txn_pending
+
+ Each of the above are sent to the PushGateway, tagged with the following labels: 
+  - instance: the current test label
+  - round: the current test round
+  - client: the client identifier that is sending the information
+
+ We are currently working on a Grafana dashboard to give you immediate access to the metrics published above, but in the interim please feel free to create custom queries to view the above metrics that are accessible in real time.
+
+## Resource Charting
+The data from each monitor is capable of being output in chart form within the generated Caliper report, via an option within the benchmark configuration file for each monitor. In addition to tabulated data for resource monitors, Caliper currently supports rendering of the following charts using `charting.js`:
+ - horizontal bar
+ - polar area
+
+Charting is an option that is available for each resource monitor, and the specification of the charting to be produced is specified under each monitor type within the benchmark configuration file, under a `charting` block. It is possible to specify multiple charting options for a single resource monitor.
+
+A chart will contain data for all items that are being tracked by the monitor; it is only possible to filter on the metrics that are to be charted. The following declares the charting block that is valid for the listed monitors:
+```
+charting:
+  bar:
+  - metrics: [all | <sting list>]
+  polar:
+  - metrics: [all | <sting list>]
+```
+
+If the `all` option is specified, then a chart will be output for each metric and include all monitored items within each chart. It is possible to filter on metrics by providing a comma separated list. The provided list is matched against metrics using a string comparison, and so it is only required to provide the initial part of the required match. The following declares a charting block that specifies a bar chart for all available metrics, and a polar chart for only metric0 and metric1:
+```
+charting:
+  bar:
+  - metrics: [all]
+  polar:
+  - metrics: [metric0, metric1]
+```
+### Process Charting
+The process resource monitor exposes the following metrics: Memory(max), Memory(avg), CPU%(max), CPU%(avg).
+
+The following declares the monitoring of any running processes named `fabricClientWorker.js` and `runBenchmarkCommand.js`, with charting options specified to produce bar charts for `all` available metrics. Charts will be produced containing data from all monitored processes:
+```
+monitor:
+  type:
+  - process
+  process:
+    processes:    
+    - command: node
+      arguments: fabricClientWorker.js
+      multiOutput: avg
+    - command: node
+      arguments: runBenchmarkCommand.js
+      multiOutput: avg
+    charting:
+      bar:
+        metrics: [all]
+```
+### Docker Charting
+The docker resource monitor exposes the following metrics: Memory(max), Memory(avg), CPU%(max), CPU%(avg), Traffic In, Traffic Out, Disc Read, Disc Write.
+
+The following declares the monitoring of all local docker containers, with charting options specified to produce bar charts for `Memory(avg)` and `CPU%(avg)`, and polar charts for `all` metrics. Charts will be produced containing data from all monitored containers:
+```
+monitor:
+  type:
+  - docker
+  docker:  
+    containers:
+    - all
+    charting:
+    bar:
+      metrics: [Memory(avg), CPU%(avg)]
+    polar:
+      metrics: [all]
+```
+
+### Prometheus Charting
+The Prometheus monitor enables user definition of all metrics within the configuration file. 
+
+The following declares the monitoring of two user defined metrics `Endorse Time(s)` and `Max Memory(MB)`. Charting options are specified to produce polar charts filtered on the metric `Max Memory (MB)`, and bar charts of all user defined metrics.
+```
+monitor:
+  type:
+  - prometheus
+  prometheus:
+    push_url: "http://localhost:9091"
+    url: "http://localhost:9090"
+    metrics:
+      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter]
+      include:
+        Endorse Time(s):
+          query: rate(endorser_propsal_duration_sum{chaincode="marbles:v0"}[5m])/rate(endorser_propsal_duration_count{chaincode="marbles:v0"}[5m])
+          step: 1
+          label: instance		
+          statistic: avg
+        Max Memory(MB):
+          query: sum(container_memory_rss{name=~".+"}) by (name)
+          step: 10
+          label: name		
+          statistic: max
+          multiplier: 0.000001
+    charting:
+      polar:
+        metrics: [Max Memory (MB)]
+      bar:
+        metrics: [all]
+```
+
+## License
+The Caliper codebase is released under the [Apache 2.0 license](./LICENSE.md). Any documentation developed by the Caliper Project is licensed under the Creative Commons Attribution 4.0 International License. You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/docs/v0.3.1/Rate_Controllers.md
+++ b/docs/v0.3.1/Rate_Controllers.md
@@ -1,0 +1,399 @@
+---
+layout: v0.3.1
+title:  "Rate Controllers"
+categories: reference
+permalink: /v0.3.1/rate-controllers/
+order: 4
+---
+
+The rate at which transactions are input to the blockchain system is a key factor within performance tests. It may be desired to send transactions at a specified rate or follow a specified profile. Caliper permits the specification of custom rate controllers to enable a user to perform testing under a custom loading mechanism. A user may specify their own rate controller or use one of the default options:
+
+* [Fixed rate](#fixed-rate)
+* [Fixed feedback rate](#fixed-feedback-rate)
+* [Fixed backlog](#fixed-backlog)
+* [Composite rate](#composite-rate)
+* [Linear rate](#linear-rate)
+* [Zero rate](#zero-rate)
+* [Record rate](#record-rate)
+* [Replay rate](#replay-rate)
+
+For implementing your own rate controller, refer to the [Adding Custom Controllers](#adding-custom-controllers) section.
+
+## Fixed Rate
+The fixed rate controller is the most basic controller, and also the default option if no controller is specified. It will send input transactions at a fixed interval that is specified as TPS (transactions per second).
+
+The fixed rate controller, driving at 10 TPS, is specified through the following controller option:
+
+```json
+{
+  "type": "fixed-rate",
+  "opts": {"tps" : 10}
+}
+```
+
+## Fixed Feedback Rate
+The fixed feedback rate controller which is the extension of fixed rate also will originally send input transactions at a fixed interval. When the unfinished transactions exceeds times of the defined unfinished transactions for each client,it will stop sending input transactions temporally by sleeping a long period of time.
+
+The fixed feedback rate controller, driving at 100 TPS, 100 unfinished transactions for each client, is specified through the following controller option:
+
+```json
+{
+  "type": "fixed-feedback-rate",
+  "opts": {"tps" : 100, "unfinished_per_client": 100}
+}
+```
+
+## Fixed Backlog
+The fixed backlog rate controller is a controller for driving the tests at a target loading (backlog transactions). This controller will aim to maintain a defined backlog of transactions within the system by modifying the driven TPS. The result is the maximum possible TPS for the system whilst maintaining the backlog level.
+
+
+The PID rate controller, targeting a backlog of 5 transactions with a starting TPS of 100, is specified through the following controller option:
+
+```json
+{
+  "type": "fixed-backlog",
+  "opts": {
+    "unfinished_per_client": 5,
+    "startingTps": 100
+  }
+}
+```
+
+## Composite Rate
+
+A benchmark round in Caliper is associated with a single rate controller. However, a single rate controller is rarely sufficient to model advanced client behaviors. Moreover, implementing new rate controllers for such behaviors can be cumbersome and error-prone. Most of the time a complex client behavior can be split into several, simpler phases.
+
+Accordingly, the composite rate controller enables the configuration of multiple "simpler" rate controllers _in a single round_, promoting the reusability of existing rate controller implementations. The composite rate controller will automatically switch between the given controllers according to the specified weights (see the configuration details after the example).
+
+For example, the definition of a square wave function (with varying amplitude) as the transaction submission rate is as easy as switching between [fixed rate](#fixed-rate) controllers with different TPS settings:
+
+```json
+{
+  "type": "composite-rate",
+  "opts": {
+    "weights": [2, 1, 2],
+    "rateControllers": [
+      {
+        "type": "fixed-rate",
+        "opts": {"tps" : 100}
+      },
+      {
+        "type": "fixed-rate",
+        "opts": {"tps" : 300}
+      },
+      {
+        "type": "fixed-rate",
+        "opts": {"tps" : 200}
+      }
+    ],  
+    "logChange": true
+  }
+}
+```
+
+The composite rate controller can be specified by setting the rate controller `type` to the `composite-rate` string. The available options (`opts` property) are the following:
+* `weights`: an array of "number-like" values (explicit numbers or numbers as strings) specifying the weights associated with the rate controllers defined in the `rateControllers` property.
+
+    The weights do not necessarily have to sum to `1`, since they will eventually be normalized to a vector of unit length. This means, that the weights can be specified in a manner that is the most intuitive for the given configuration. For example, the weights can correspond to durations, numbers of transactions or ratios.
+
+    In the above example, the weights are corresponding to ratios (2:1:2). The exact meaning of the weights is determined by whether the benchmark round is _duration-based_ or _transaction number-based_. If the above controller definition is used in a round with a duration of 5 minutes, then in the first 2 minutes the transactions will be submitted at 100 TPS, then at 300 TPS for the next minute, and at 200 TPS for the last 2 minutes of the round.
+
+    Note, that 0 weights are also allowed in the array. Setting the weight of one or more controllers to 0 is a convenient way to "remove/disable" those controllers without actually removing them from the configuration file.
+
+* `rateControllers`: an array of arbitrary rate controller specifications. See the documentation of the individual rate controllers on how to configure them. The number of specified rate controllers must equal to the number of specified weights.
+
+    Note, that technically, composite rate controllers can be nested to form a hierarchy. However, using a composite rate controller incurs an additional execution overhead in the rate control logic. Keep this in mind before specifying a deep hierarchy of composite rate controllers, or just flatten the hierarchy to a single level.
+
+* `logChange`: a `boolean` value indicating whether the switches between the specified rate controllers should be logged or not.
+
+**Important!** The existence of the composite rate controller is almost transparent to the specified "sub-controllers." This is achieved by essentially placing the controllers in a "virtualized" round, i.e., "lying" to them about:
+* the duration of the round (for duration-based rounds),
+* the total number of transactions to submit (for transaction number-based rounds),
+* the starting time of the round, and
+* the index of the next transaction to submit.
+
+The results of recently finished transactions are propagated to the sub-controllers as-is, so for the first few call of a newly activated sub-controller it can receive recent results that don't belong to its virtualized round.
+
+This virtualization does not affect the memoryless controllers, i.e., the controllers whose control logic does not depend on global round properties or past transaction results. However, other controllers might exhibit some strange (but hopefully transient) behavior due to this "virtualized" round approach. For example, the logic of the [PID controller](#pid-rate) for example depends on the transaction backlog.
+
+## Linear Rate
+
+Exploring the performance limits of a system usually consists of performing multiple measurements with increasing load intensity. However, finding the tipping point of the system this way is not easy, it is more like a trial-and-error method.
+
+The linear rate controller can gradually (linearly) change the TPS rate between a starting and finishing TPS value (both in increasing and decreasing manner). This makes it easier to find the workload rates that affect the system performance in an interesting way.
+
+The linear rate controller can be used in both duration-based and transaction number-based rounds. The following example specifies a rate controller that gradually changes the transaction load from 25 TPS to 75 TPS during the benchmark round.
+
+```json
+{
+  "type": "linear-rate",
+  "opts": {
+    "startingTps": 25,
+    "finishingTps": 75
+    }
+}
+```
+
+The linear rate controller can be specified by setting the rate controller `type` to the `linear-rate` string. The available options (`opts` property) are the following:
+* `startingTps`: the TPS at the beginning of the round.
+* `finishingTps`: the TPS at the end of the round.
+
+**Note:** similarly to the [fixed rate controller](#fixed-rate), this controller also divides the workload between the available client, so the specified rates in the configuration are cumulative rates, and not the rates of individual clients. Using the above configuration with 5 clients results in clients that start at 5 TPS and finish at 15 TPS. Together they generate a [25-75] TPS load.
+
+## Zero Rate
+
+This controller stops the workload generation for the duration of the round. Using the controller on its own for a round is meaningless. However, it can be used as a building block inside a [composite rate](#composite-rate) controller. **The zero rate controller can be used only in duration-based rounds!**
+
+```json
+{
+  "type": "composite-rate",
+  "opts": {
+    "weights": [30, 10, 10, 30],
+    "rateControllers": [
+      {
+        "type": "fixed-rate",
+        "opts": {"tps" : 100}
+      },
+      {
+        "type": "fixed-rate",
+        "opts": {"tps" : 500}
+      },
+      {
+        "type": "zero-rate",
+        "opts": { }
+      },
+      {
+        "type": "fixed-rate",
+        "opts": {"tps" : 100}
+      }
+    ],  
+    "logChange": true
+  }
+}
+```
+
+Let's assume, that the above example is placed in a round definition with an 80 seconds duration (note the intuitive specification of the weights). In this case, an initial 30 seconds _normal_ workload is followed by a 10 seconds _intensive_ workload, which is followed by a 10 seconds _cooldown_ period, etc.
+
+The controller is identified by the `zero-rate` string as the value of the `type` property and requires no additional configuration.
+
+## Record Rate
+
+This rate controller serves as a decorator around an other (arbitrary) controller. Its purpose is to record the times (relative to the start of the round) when each transaction was submitted, i.e., when the transaction was "enabled" by the "sub-controller."
+
+The following example records the times when the underlying [fixed rate](#fixed-rate) controller enabled the transactions (for details, see the available options below the example):
+
+```json
+{
+  "type": "record-rate",
+  "opts": {
+    "rateController": {
+      "type": "fixed-rate",
+      "opts": {"tps" : 100}
+    },
+    "pathTemplate": "../tx_records_client<C>_round<R>.txt",
+    "outputFormat": "TEXT",
+    "logEnd": true
+  }
+}
+```
+
+The record rate controller can be specified by setting the rate controller `type` to the `record-rate` string. The available options (`opts` property) are the following:
+* `rateController`: the specification of an arbitrary rate controller.
+* `pathTemplate`: the template for the file path where the recorded times will be saved. The path can be either an absolute path or relative to the root Caliper directory.
+
+    The template can (**and should**) contain special "variables/placeholders" that can refer to special environment properties (see the remarks below). The available placeholders are the following:
+    * `<C>`: placeholder for the 1-based index of the current client that uses this rate controller.
+    * `<R>`: placeholder for the 1-based index of the current round that uses this rate controller.
+* `outputFormat`: optional. Determines the format in which the recording will be saved. Defaults to `"TEXT"`. The currently supported formats are the following:
+    * `"TEXT"`: each recorded timing is encoded as text on separate lines.
+    * `"BIN_BE"`: binary format with Big Endian encoding.
+    * `"BIN_LE"`: binary format with Little Endian encoding.
+* `logEnd`: optional. Indicates whether to log that the recordings are written to the file(s). Defaults to `false`.
+
+**Template placeholders:** since Caliper provides a concise way to define multiple rounds and multiple clients with the same behavior, it is essential to differentiate between the recordings of the clients and rounds. Accordingly, the output file paths can contain placeholders for the round and client indices that will be resolved automatically at each client in each round. Otherwise, every client would write the same file, resulting in a serious conflict between timings and transaction IDs.
+
+**Text format:** the rate controller saves the recordings in the following format (assuming a constant 10 TPS rate and ignoring the noise in the actual timings), row `i` corresponding to the `i`th transaction:
+```csv
+100
+200
+300
+...
+```
+
+**Binary format:** Both binary representations encode the `X` number of recordings as a series of `X+1` UInt32 numbers (1 number for the array length, the rest for the array elements), either in Little Endian or Big Endian encoding:
+```
+Offset: |0      |4      |8      |12      |16      |...     
+Data:   |length |1st    |2nd    |3rd     |4th     |...      
+```
+
+## Replay Rate
+
+One of the most important aspect of a good benchmark is its repeatability, i.e., it can be re-executed in a deterministic way whenever necessary. However, some benchmarks define the workload (e.g., user behavior) as a function of probabilistic distribution(s). This presents two problems from a practical point of view:
+
+1. Repeatability: The random sampling of the given probability distribution(s) can differ between benchmark (re-)executions. This makes the comparison of different platforms questionable.
+1. Efficiency: Sampling a complex probability distribution incurs an additional runtime overhead, which can limit the rate of the load, distorting the originally specified workload.
+
+This rate controller aims to mitigate these problems by replaying a fix transaction load profile that was created "offline." This way the profile is generated once, outside of the benchmark execution, and can be replayed any time with the same timing constraints with minimal overhead.
+
+A trivial use case of this controller is to play back a transaction recording created by the [record controller](#record-rate). However, a well-formed trace file is the only requirement for this controller, hence any tool/method can be used to generate the transaction load profile.
+
+The following example specifies a rate controller that replays some client-dependent workload profiles (for details, see the available options below the example):
+
+```json
+{
+  "type": "replay-rate",
+  "opts": {
+    "pathTemplate": "../tx_records_client<C>.txt",
+    "inputFormat": "TEXT",
+    "logWarnings": true,
+    "defaultSleepTime": 50
+    }
+}
+```
+
+The replay rate controller can be specified by setting the rate controller type to the `replay-rate` string. The available options (`opts` property) are the following:
+
+* `pathTemplate`: the template for the file path where the transaction timings will be replayed from. The path can be either an absolute path or relative to the root Caliper directory.
+
+    The template can (**and should**) contain special "variables/placeholders" that can refer to special environment properties (see the remarks at the [record rate controller](#record-rate)). The available placeholders are the following:
+    * `<C>`: placeholder for the 1-based index of the current client that uses this rate controller.
+    * `<R>`: placeholder for the 1-based index of the current round that uses this rate controller.
+* `inputFormat`: optional. Determines the format in which the transaction timings are stored (see the details at the [record rate controller](#record-rate)). Defaults to `"TEXT"`. The currently supported formats are the following:
+    * `"TEXT"`: each recorded timing is encoded as text on separate lines.
+    * `"BIN_BE"`: binary format with Big Endian encoding.
+    * `"BIN_LE"`: binary format with Little Endian encoding.
+* `logWarnings`: optional. Indicates whether to log that there are no more recordings to replay, so the `defaultSleepTime` is used between consecutive transactions. Defaults to `false`.
+* `defaultSleepTime`: optional. Determines the sleep time between transactions for the case when the benchmark execution is longer than the specified recording. Defaults to `20` ms.
+
+**About the recordings:**
+
+Special care must be taken, when using duration-based benchmark execution, as it is possible to issue more transactions than specified in the recording. A safety measure for this case is the `defaultSleepTime` option. This should only occur in the last few moments of the execution, affecting only a few transactions, that can be discarded before performing additional performance analyses on the results.
+
+The recommended approach is to use transaction number-based round configurations, since the number of transactions to replay is known beforehand. Note, that the number of clients affects the actual number of transactions submitted by a client.
+
+## Adding Custom Controllers
+
+It is possible to use rate controllers that are not built-in controllers of Caliper. When you specify the rate controller in the test configuration file (see the [architecture documentation](./Architecture.md)), you must set the `type` and `opts` attributes.
+
+You can set the `type` attribute so that it points to your custom JS file that satisfies the following criteria:
+1. The file/module exports a `createRateController` function that takes the following parameters:
+    1. An `opts` parameter that is the `object` representation of the `opts` attribute set in the configuration file, and contains the custom settings of your rate controller.
+    1. A `clientIdx` parameter of type `number` that is the 0-based index of the client process using this rate controller.
+    1. A `roundIdx` parameter of type `number` that is the 1-based index of the round where the rate controller is used.
+    
+    The function must return an object (i.e., your rate controller instance) that satisfies the next criteria.
+2. The object returned by `createRateController` must implement the `/packages/caliper-core/lib/rate-control/rateInterface.js` interface, i.e., must provide the following async functions:
+    1. `init`, for initializing the rate controller at the beginning of the round.
+    1. `applyRateControl`, for performing the actual rate control by "blocking" the execution (in an async manner) for the desired time.
+    1. `end`, for disposing any acquired resources at the end of a round.
+
+The following example is a complete implementation of a rate control that doesn't perform any control, thus allowing the submitting of transactions as fast as the program execution allows it (warning, this implementation run with many client processes could easily over-load a backend network, so use it with caution).
+
+```js
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const RateInterface = require('path-to-caliper/caliper-core/lib/rate-control/rateInterface.js');
+
+/**
+ * Rate controller for allowing uninterrupted workloadload generation.
+ *
+ * @property {object} options The user-supplied options for the controller. Empty.
+ */
+class MaxRateController extends RateInterface{
+    /**
+     * Creates a new instance of the MaxRateController class.
+     * @constructor
+     * @param {object} opts Options for the rate controller. Empty.
+     */
+    constructor(opts) {
+        // just pass it to the base class
+        super(opts);
+    }
+
+    /**
+     * Initializes the rate controller.
+     *
+     * @param {object} msg Client options with adjusted per-client load settings.
+     * @param {string} msg.type The type of the message. Currently always 'test'
+     * @param {string} msg.label The label of the round.
+     * @param {object} msg.rateControl The rate control to use for the round.
+     * @param {number} msg.trim The number/seconds of transactions to trim from the results.
+     * @param {object} msg.args The user supplied arguments for the round.
+     * @param {string} msg.cb The path of the user's callback module.
+     * @param {string} msg.config The path of the network's configuration file.
+     * @param {number} msg.numb The number of transactions to generate during the round.
+     * @param {number} msg.txDuration The length of the round in SECONDS.
+     * @param {number} msg.totalClients The number of clients executing the round.
+     * @param {number} msg.clients The number of clients executing the round.
+     * @param {object} msg.clientargs Arguments for the client.
+     * @param {number} msg.clientIdx The 0-based index of the current client.
+     * @param {number} msg.roundIdx The 1-based index of the current round.
+     * @async
+     */
+    async init(msg) {
+        // no init is needed
+    }
+
+    /**
+     * Doesn't perform any rate control.
+     * @param {number} start The epoch time at the start of the round (ms precision).
+     * @param {number} idx Sequence number of the current transaction.
+     * @param {object[]} recentResults The list of results of recent transactions.
+     * @param {object[]} resultStats The aggregated stats of previous results.
+     * @async
+     */
+    async applyRateControl(start, idx, recentResults, resultStats) {
+        // no sleeping is needed, allow the transaction invocation immediately
+    }
+
+    /**
+     * Notify the rate controller about the end of the round.
+     * @async
+     */
+    async end() { 
+        // nothing to dispose of
+    }
+}
+
+/**
+ * Creates a new rate controller instance.
+ * @param {object} opts The rate controller options.
+ * @param {number} clientIdx The 0-based index of the client who instantiates the controller.
+ * @param {number} roundIdx The 1-based index of the round the controller is instantiated in.
+ * @return {RateInterface} The rate controller instance.
+ */
+function createRateController(opts, clientIdx, roundIdx) {
+    // no need for the other parameters
+    return new MaxRateController(opts);
+}
+
+module.exports.createRateController = createRateController;
+``` 
+
+Let's say you save this implementation into a file called `maxRateController.js` next to your Caliper directory (so they're on the same level). In the test configuration file you can set this rate controller (at its required place in the configuration hierarchy) the following way:
+
+```yaml
+rateControl:
+  # relative path from the Caliper directory
+- type: ../maxRateController.js
+  # empty options
+  opts: 
+
+```
+
+## License
+The Caliper codebase is released under the [Apache 2.0 license](./LICENSE.md). Any documentation developed by the Caliper Project is licensed under the Creative Commons Attribution 4.0 International License. You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/docs/v0.3.1/Runtime_Configuration.md
+++ b/docs/v0.3.1/Runtime_Configuration.md
@@ -1,0 +1,340 @@
+---
+layout: v0.3.1
+title:  "Runtime Configuration"
+categories: reference
+permalink: /v0.3.1/runtime-config/
+order: 3
+---
+
+## Table of contents
+{:.no_toc}
+
+- TOC
+{:toc}
+
+## Overview
+
+Caliper relies on the [nconf](https://github.com/indexzero/nconf) package to provide a flexible and hierarchical configuration mechanism for runtime-related settings. Hierarchical configuration means that a runtime setting can be set or overridden from multiple sources/locations, and there is a priority order among them.
+
+In general, a setting is a simple `string` key associated with some `value`. However, it is highly recommended to compose the keys in a way that follows the place of the module in the hierarchy that uses the setting. Consider the following key, for example:
+
+`caliper-fabric-timeout-invokeorquery`
+
+The key consists of several parts that makes it easy to identify the purpose of the setting: it is used in Caliper, by the Fabric adapter, it is a timeout-related setting that specifies the timeout to use for transaction invocations or queries. Every setting key in Caliper follows the same convention.
+
+The rule of thumb is to use lowercase letters (maybe numbers), and the hierarchy should be denoted by dashes (`-`) as separator.
+
+Every setting used by Caliper is prefixed with the `caliper-` string. The prefix serves as a namespace for the internal settings of Caliper modules. It also prevents name collisions since the configuration mechanism parses every setting available from the various sources, some intended, for example, to the underlying SDK modules or the user test module.
+
+> For every available runtime setting, refer to the [last section](#available-settings).
+
+## Setting sources
+
+Caliper supports the following sources/locations where runtime settings can be set/overridden, in priority order, starting with the highest priority:
+
+1. [Memory](#in-memory-settings)
+1. [Command line arguments](#command-line-arguments)
+1. [Environment variables](#environment-variables)
+1. [Project-level configuration file](#project-level)
+1. [User-level configuration file](#user-level)
+1. [Machine-level configuration file](#machine-level)
+1. [Fallback/default configuration file](#default-configuration)
+
+For simplicity, you can think of the above order as the following: the "closer" the setting is set to its point of use, the higher the priority of the set value.
+
+### In-memory settings
+
+If some component (Caliper-related, or user provided) sets a setting during runtime (using the configuration API), then that value will have priority over any other source/location that might have also set the same setting.
+
+The simple configuration API is provided by the `ConfigUtil` module of the `@hyperledger/caliper-core` package. It exports a simple `get` and `set` method:
+
+* `get(key:string, fallbackValue:any) => any` 
+
+    Returns the value of the setting associated with the given `key`. If the setting is not set from any sources, then the `fallbackValue` is returned.
+* `set(key:string, value:any)` 
+
+    Sets the `value` for the setting associated with the given `key`. It will overwrite any other value set by other sources.
+
+For example:
+```js
+const { ConfigUtil } = require('@hyperledger/caliper-core');
+
+// retrieves a setting for your module, if not set, use some default
+const shouldBeFast = ConfigUtil.get('mymodule-performance-shoudbefast', /*default:*/ true);
+
+if (shouldBeFast) { /* ... */ } else { /* ... */ }
+```
+
+The above code also shows how a custom user module/code can easily leverage Caliper's configuration mechanism. Since the `mymodule-performance-shoudbefast` setting is queried through the configuration API, setting it from various sources automatically became possible (see the next sections for details). 
+
+> Thus adding a flexible runtime setting to any module requires only to query that setting through the configuration API when you need it (with the desired default/fallback value).
+
+### Command line arguments
+
+If we wish to influence the behavior of a third-party code (e.g., Caliper or a user callback module), we usually can't (or don't want to) overwrite the setting in the source code. A standard way of modifying the behavior of third-party/pre-packaged applications is to provide the settings as commandline arguments.
+
+Starting Caliper through the [CLI](./Installing_Caliper.md#the-caliper-cli), you can override runtime settings the following way:
+
+```bash
+caliper launch master \
+    --caliper-workspace yourworkspace/ \
+    --caliper-benchconfig yourconfig.yaml \
+    --caliper-networkconfig yournetwork.yaml \
+    --mymodule-performance-shoudbefast=true
+```
+
+The arguments will be converted to lower-case letters and every `_` character will be replaced with `-`. So the above command can be written in a more user friendly way:
+
+```bash
+caliper launch master \
+    --caliper-workspace yourworkspace/ \
+    --caliper-benchconfig yourconfig.yaml \
+    --caliper-networkconfig yournetwork.yaml \
+    --MyModule_Performance_ShoudBeFast=true
+```
+
+Both ways will result in the setting key `mymodule-performance-shoudbefast` associated with the `boolean` value `true`.
+
+Note, that `nconf` will automatically parse values of common types, so the `true` and `false` values will be parsed (and returned by `get`) as `boolean` values. This also holds for (both integer and floating point) numbers.
+
+Moreover, `boolean` values can be specified as flags, without explicitly setting the `true` or `false` value (note the `no-` prefix for the second case):
+* Setting a key to `true`:
+    ```bash
+    caliper launch master \
+        --caliper-workspace yourworkspace/ \
+        --caliper-benchconfig yourconfig.yaml \
+        --caliper-networkconfig yournetwork.yaml \
+        --mymodule-performance-shoudbefast
+    ```
+* Setting a key to `false`:
+    ```bash
+    caliper launch master \
+        --caliper-workspace yourworkspace/ \
+        --caliper-benchconfig yourconfig.yaml \
+        --caliper-networkconfig yournetwork.yaml \
+        --no-mymodule-performance-shoudbefast
+    ```
+
+Command line arguments overwrite the settings set in locations of the next sections.
+
+### Environment variables
+
+If Caliper is part of a scripted environment, then it would be cumbersome to modify the script to pass command line arguments to Caliper. The standard approach in these scenarios is to use environment variables.
+
+The example setting can be set the following way using an environment variable:
+
+```bash
+export MYMODULE_PERFORMANCE_SHOULDBEFAST=true
+
+# calling some script containing the following command
+caliper launch master \
+    --caliper-workspace yourworkspace/ \
+    --caliper-benchconfig yourconfig.yaml \
+    --caliper-networkconfig yournetwork.yaml
+```
+
+Note the standard notation of environment variable settings: upper-case letters separated by `_` characters. Caliper performs the same transformation as with command line arguments: the variable names will be converted to lower-case letters and every `_` character will be replaced with `-`. So the above setting will also result in the setting key `mymodule-performance-shoudbefast` associated with the `boolean` value `true`.
+
+### Configuration files
+
+Depending on the scenario, users may want to change multiple runtime settings. Using command line arguments and environment variables to change multiple settings can become cumbersome and hard to read. Moreover, sometimes it is desirable for the configuration to be a separate project artifact (that can be version controlled, for example) rather than just embedded around the place of CLI call.
+
+Using configuration files is a standard way of overriding multiple settings in a manageable way. Caliper provides multiple configuration "locations" where you can insert configuration files into the settings hierarchy. These locations also follow the "closer one wins" semantic of the hierarchical configuration mechanism.
+
+Moreover, YAML-based configuration files allow comments that make your configuration choices self-documenting and self-contained.
+
+Note, that no additional transformation is performed on the key names of a YAML file, they are simply concatenated with `-` to get a flat string key from the object hierarchy. 
+
+So the hierarchical setting
+```yaml
+mymodule:
+  performance:
+    shouldbefast: true
+```
+will be parsed as the `mymodule-performance-shouldbefast` string key associated with the `true` Boolean value.
+
+#### Project-level
+
+If you have a group of settings that are always overridden in your Caliper benchmark project, then it is recommended to define them as a project-level configuration file. This file will usually consist of a subset of settings defined in the default configuration file (and probably your custom settings associated with your custom user module).
+
+The project-level configuration file can be included into the hierarchy in two ways:
+* Define the overridden settings in the `caliper.yaml` file in the **workspace directory**
+* Or set the path of the configuration file explicitly through the `caliper-projectconfig` setting key using one of the higher priority locations above (i.e., command line argument or environment variable):
+
+  * The command line approach: 
+    ```bash
+    caliper launch master \
+        --caliper-workspace yourworkspace/ \
+        --caliper-benchconfig yourconfig.yaml \
+        --caliper-networkconfig yournetwork.yaml \
+        --Caliper-ProjectConfig mypath/project1-config.yaml
+    ```
+  * The environment variable approach: 
+    ```bash
+    export CALIPER_PROJECTCONFIG=mypath/project1-config.yaml
+    caliper launch master \
+        --caliper-workspace yourworkspace/ \
+        --caliper-benchconfig yourconfig.yaml \
+        --caliper-networkconfig yournetwork.yaml
+    ```
+    
+Note that project-level settings will override the settings defined by the locations of the next sections.
+
+#### User-level
+
+If you find yourself overriding the same settings for multiple Caliper benchmark projects, then it is recommended to extract the common settings into a user-level configuration file. To include a user-level configuration file into the hierarchy, specify its path through the `caliper-userconfig` settings key using one of the higher priority locations above (i.e., command line argument, environment variable or the project-level configuration file):
+
+* The command line approach: 
+    ```bash
+    caliper launch master \
+        --caliper-workspace yourworkspace/ \
+        --caliper-benchconfig yourconfig.yaml \
+        --caliper-networkconfig yournetwork.yaml \
+        --Caliper-UserConfig ~/.config/my-caliper-config.yaml
+    ```
+* The environment variable approach: 
+    ```bash
+    export CALIPER_USERCONFIG=~/.config/my-caliper-config.yaml
+    caliper launch master \
+        --caliper-workspace yourworkspace/ \
+        --caliper-benchconfig yourconfig.yaml \
+        --caliper-networkconfig yournetwork.yaml
+    ```
+* The configuration file approach (excerpt from the project-level configuration file): 
+    ```yaml
+    caliper:
+      userconfig: ~/.config/my-caliper-config.yaml
+    # additional settings
+    ```
+
+#### Machine-level
+
+If multiple users use the same workstation and want to share common settings across Caliper projects and users, then a machine-level configuration file can be included into the hierarchy by specifying its path through the `caliper-machineconfig` settings key using one of the higher priority locations above (i.e., command line argument, environment variable, project- or user-level configuration files):
+
+* The command line approach: 
+    ```bash
+    caliper launch master \
+        --caliper-workspace yourworkspace/ \
+        --caliper-benchconfig yourconfig.yaml \
+        --caliper-networkconfig yournetwork.yaml \
+        --Caliper-MachineConfig /etc/config/caliper.yaml
+    ```
+* The environment variable approach: 
+    ```bash
+    export CALIPER_MACHINECONFIG=/etc/config/caliper.yaml
+    caliper launch master \
+        --caliper-workspace yourworkspace/ \
+        --caliper-benchconfig yourconfig.yaml \
+        --caliper-networkconfig yournetwork.yaml
+    ```
+* The configuration file approach (excerpt from the project- or user-level configuration file): 
+    ```yaml
+    caliper:
+      machineconfig: /etc/config/caliper.yaml
+    # additional settings
+    ```
+
+#### Default configuration
+
+A default/fallback configuration file is shipped with the Caliper-related packages that defines sensible fallback values and documentation for each available setting used by the Caliper modules. This configuration file has the lowest priority among the supported setting locations.
+
+## Available settings
+
+> Always refer to the self-documenting [default configuration file](https://github.com/hyperledger/caliper/blob/master/packages/caliper-core/lib/common/config/default.yaml) for the currently supported runtime configuration settings.
+
+### Basic settings
+
+| Key | Description |
+|:----|:------------|
+| caliper-benchconfig | Path to the benchmark configuration file that describes the test worker(s), test rounds and monitors. |
+| caliper-networkconfig | Path to the blockchain configuration file that contains information required to interact with the SUT. |
+| caliper-machineconfig | The file path for the user-level configuration file. Can be relative to the workspace. |
+| caliper-projectconfig | The file path for the project-level configuration file. Can be relative to the workspace. |
+| caliper-txupdatetime | The frequency of the worker's progress report in milliseconds. |
+| caliper-userconfig | The file path for the user-level configuration file. Can be relative to the workspace. |
+| caliper-workspace | Workspace directory that contains all configuration information |
+
+### Binding settings
+
+| Key | Description |
+|:----|:------------|
+| caliper-bind-args | The additional args to pass to the binding (i.e., npm install) command. |
+| caliper-bind-cwd | The CWD to use for the binding (i.e., npm install) command. |
+| caliper-bind-file | The path of a custom binding configuration file that will override the default one. |
+| caliper-bind-sut | The binding specification of the SUT in the <SUT type>:<SDK version> format. |
+
+### Reporting settings
+
+| Key | Description |
+|:----|:------------|
+| caliper-report-charting-hue | The HUE value to construct the chart [color scheme](https://www.npmjs.com/package/color-scheme) from. |
+| caliper-report-charting-scheme | The [color scheme](https://www.npmjs.com/package/color-scheme) method to use for producing chart colors. |
+| caliper-report-charting-transparency | The transparency value [0..1] to use for the charts. |
+| caliper-report-options | The options object to pass to [fs.writeFile](https://nodejs.org/docs/latest-v8.x/api/fs.html#fs_fs_writefile_file_data_options_callback) |
+| caliper-report-path | The absolute or workspace-relative path of the generated report file. |
+| caliper-report-precision | Precision (significant digits) for the numbers in the report. |
+
+### Logging settings
+
+| Key | Description |
+|:----|:------------|
+| caliper-logging-formats-align | Adds a tab delimiter before the messages to align them in the same place. |
+| caliper-logging-formats-attributeformat-\<attribute\> | Specifies the formatting string for the log message attribute `<attribute>`. |
+| caliper-logging-formats-json | Indicates that the logs should be serialized in JSON format. |
+| caliper-logging-formats-label | Adds a specified label to every message. Useful for distributed worker scenario. |
+| caliper-logging-formats-pad | Pads the log level strings to be the same length. |
+| caliper-logging-formats-timestamp | Adds a timestamp to the messages with the specified format. |
+| caliper-logging-formats-colorize-all | Indicates that all log message attributes must be colorized. |
+| caliper-logging-formats-colorize-\<attribute\> | Indicates that log message attribute `<attribute>` must be colorized. |
+| caliper-logging-formats-colorize-colors-\<level\> | Sets the color for the log messages with level `<level>`. |
+| caliper-logging-targets-\<target\>-enabled | Sets whether the target transport `<target>` is enabled or disabled. |
+| caliper-logging-template | Specifies the message structure through placeholders. |
+
+### Worker management settings
+
+| Key | Description |
+|:----|:------------|
+| caliper-worker-communication-method | Indicates the type of the communication between the master and workers. |
+| caliper-worker-communication-address | The address of the MQTT broker used for distributed worker management. |
+| caliper-worker-pollinterval | The interval for polling for new available workers, in milliseconds. |
+| caliper-worker-remote | Indicates whether the workers operate in distributed mode. |
+
+### Benchmark phase settings
+
+| Key | Description |
+|:----|:------------|
+| caliper-flow-only-end | Indicates whether to only perform the end command script in the network configuration file. |
+| caliper-flow-only-init | Indicates whether to only perform the init phase of the benchmark. |
+| caliper-flow-only-install | Indicates whether to only perform the smart contract install phase of the benchmark. |
+| caliper-flow-only-start | Indicates whether to only perform the start command script in the network configuration file. |
+| caliper-flow-only-test | Indicates whether to only perform the test phase of the benchmark. |
+| caliper-flow-skip-end | Indicates whether to skip the end command script in the network configuration file. |
+| caliper-flow-skip-init | Indicates whether to skip the init phase of the benchmark. |
+| caliper-flow-skip-install | Indicates whether to skip the smart contract install phase of the benchmark. |
+| caliper-flow-skip-start | Indicates whether to skip the start command script in the network configuration file. |
+| caliper-flow-skip-test | Indicates whether to skip the test phase of the benchmark. |
+
+### Fabric adapter settings
+
+| Key | Description |
+|:----|:------------|
+| caliper-fabric-countqueryasload | Indicates whether to count queries as workload, i.e., whether the generated report should include them. |
+| caliper-fabric-gateway-discovery | Indicates whether to use the Fabric discovery mechanism (via Gateway API). |
+| caliper-fabric-gateway-eventstrategy | Sets the event strategy to use. |
+| caliper-fabric-gateway-gatewaylocalhost | Indicates whether to use the localhost default within the Fabric Gateway API. |
+| caliper-fabric-gateway-querystrategy | Sets the query strategy to use. |
+| caliper-fabric-gateway-usegateway | Indicates whether to use the gateway-based SDK API. |
+| caliper-fabric-latencythreshold | Determines the reported commit time of a transaction based on the given percentage of event sources. |
+| caliper-fabric-loadbalancing | Determines how automatic load balancing is applied. |
+| caliper-fabric-overwritegopath | Indicates whether to temporarily set the GOPATH environment variable to the workspace directory. |
+| caliper-fabric-sleepafter-createchannel | The time in milliseconds to sleep after creating the channels. |
+| caliper-fabric-sleepafter-joinchannel | The time in milliseconds to sleep after joining the channels. |
+| caliper-fabric-sleepafter-instantiatechaincode | The time in milliseconds to sleep after instantiated the chaincodes. |
+| caliper-fabric-timeout-chaincodeinstantiate | Timeout in milliseconds for the endorsement part of a chaincode instantiation. |
+| caliper-fabric-timeout-chaincodeinstantiateevent | Timeout in milliseconds for receiving the event about the result of a chaincode instantiation. |
+| caliper-fabric-timeout-invokeorquery | The default timeout in milliseconds to use for invoking or querying transactions. |
+| caliper-fabric-verify-proposalresponse | Indicates whether to verify the received proposal responses. |
+| caliper-fabric-verify-readwritesets | Indicates whether to verify that the read-write sets returned by the endorsers match. |
+
+## License
+The Caliper codebase is released under the [Apache 2.0 license](./LICENSE.md). Any documentation developed by the Caliper Project is licensed under the Creative Commons Attribution 4.0 International License. You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/docs/v0.3.1/Sawtooth_Configuration.md
+++ b/docs/v0.3.1/Sawtooth_Configuration.md
@@ -1,0 +1,18 @@
+---
+layout: v0.3.1
+title:  "Sawtooth Configuration"
+categories: config
+permalink: /v0.3.1/sawtooth-config/
+---
+
+> The latest supported version of Hyperledger Sawtooth is v1.0
+
+## Using Alternative Sawtooth Versions
+If you wish to use a specific Sawtooth version, it is necessary to modify the `protocol-buffers` and `sawtooth-sdk` version levels listed as dependancies in `packages/caliper-sawtooth/package.json`, and then rebuild the Caliper project using the following commands issued at the root Caliper project location:
+
+- `npm install`
+- `npm run repoclean`
+- `npm run bootstrap`
+
+## License
+The Caliper codebase is released under the [Apache 2.0 license](./LICENSE.md). Any documentation developed by the Caliper Project is licensed under the Creative Commons Attribution 4.0 International License. You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/docs/v0.3.1/Workload_Module.md
+++ b/docs/v0.3.1/Workload_Module.md
@@ -1,0 +1,109 @@
+---
+layout: v0.3.1
+title:  "Workload Modules"
+categories: docs
+permalink: /v0.3.1/workload-module/
+order: 6
+---
+
+## Table of contents
+{:.no_toc}
+
+- TOC
+{:toc}
+
+## Overview
+
+Workload modules are the essence of a Caliper benchmark since it is their responsibility to construct and submit TXs. Accordingly, workload modules implement the logic pertaining to your business, benchmark or user behavior. Think of the workload modules as the brain of an emulated SUT client, deciding what kind of TX to submit at the given moment.
+
+## Implementing the workload module
+
+Workload modules are Node.JS modules that expose a certain API. There are no further restrictions on the implementation, thus arbitrary logic (using further arbitrary components) can be implemented.
+
+### The API
+
+A workload module must export the following three asynchronous functions:
+
+* `init(blockchain: BlockchainInterface, context: object, args: object)`
+  
+  The `init` function is called before a round is started. It receives:
+  * the SUT adapter instance in the `blockchain` parameter;
+  * the adapter-specific `context` created by the adapter (usually containing additional data about the network);
+  * and the user-provided settings object as `args` which is set in the [benchmark configuration](./BenchmarkConfiguration.md#benchmark-test-settings) file's `test.rounds[i].arguments` attribute (if the workload module is configurable).
+* `run() => Promise<TxResult[]>`
+
+  The `run` function is called every time the set [rate controller](./Rate_Controllers.md) enables the next TX. The function must assemble the content of the next TX (using arbitrary logic) and call the `invokeSmartContract` or `querySmartContract` functions of the `blockchain` adapter instance. See the adapter configuration pages for the exact usage of the mentioned functions.
+  > __At the end, the function must return the result of the invoke/query call!__
+* `end()`
+
+  The `end` function is called after the round has ended. The workload module can perform resource cleanup or any other maintenance activity at this point.
+
+### Example
+
+A complete (albeit simple) example of a workload module implementation:
+
+```js
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const logger = require('@hyperledger/caliper-core').CaliperUtils.getLogger('my-module');
+
+// save the objects during init
+let bc, contx;
+
+/**
+* Initializes the workload module before the start of the round.
+* @param {BlockchainInterface} blockchain The SUT adapter instance.
+* @param {object} context The SUT-specific context for the round.
+* @param {object} args The user-provided arguments for the workload module.
+*/
+module.exports.init = async (blockchain, context, args) => {
+    bc = blockchain;
+    contx = context;
+    logger.debug('Initialized workload module');
+};
+
+module.exports.run = async () => {
+    let txArgs = {
+        // TX arguments for "mycontract"
+    };
+    
+    return bc.invokeSmartContract(contx, 'mycontract', 'v1', txArgs, 30);
+};
+
+module.exports.end = async () => {
+    // Noop
+    logger.debug('Disposed of workload module');
+};
+```
+
+## Configuring the workload module
+
+To use your workload module for a given round, you only need to reference it in the [benchmark configuration](./BenchmarkConfiguration.md#benchmark-test-settings) file:
+1. Set the `test.rounds[i].callback` attribute to the path of your workload module file. The path can be either an absolute path, or a relative path to the configured workspace path.
+2. If your module supports different settings, set the `test.rounds[i].arguments` attribute object accordingly. It will be passed to your module upon initialization.
+
+## Tips & Tricks
+
+The following advices might help you to improve your workload module implementation.
+
+1. You can use (`require`) any Node.JS module in your code (including the core Caliper module). Modularization is important for keeping your implementation clean and manageable.
+2. If you use third-party modules, then it is your responsibility to make them available to your workload module. This usually requires an `npm install` call in your module directory before you start Caliper.
+3. Caliper provides some core utilities that might make your life easier, such as [logging](./Logging_Control.md) and [runtime configuration](./Runtime_Configuration.md). Use them, don't reinvent the wheel! 
+4. The `run` function is on the __hot path__ of the worker workload generation loop. Do computation-intensive tasks with care, it might hurt the scheduling precision of TXs! You can perform expensive pre-processing tasks in the `init` function instead. 
+
+## License
+The Caliper codebase is released under the [Apache 2.0 license](./LICENSE.md). Any documentation developed by the Caliper Project is licensed under the Creative Commons Attribution 4.0 International License. You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/docs/v0.3.1/Writing_Adapters.md
+++ b/docs/v0.3.1/Writing_Adapters.md
@@ -1,0 +1,123 @@
+---
+layout: v0.3.1
+title:  "Writing Adapters"
+categories: reference
+permalink: /v0.3.1/writing-adaptors/
+order: 2
+---
+
+## How to write your own blockchain adapter
+Let's look inside first and learn about how the whole framework interacts with the backend blockchain system.
+When the benchmark engine is running, the master process of benchmark engine will call the user defined blockchian class to complete the blockchain's and chaicodes' installation. Then, after the master process launches the corresponding clients, each client will do the test. During the test, the client will get current blockchain's context, run test scripts, release the blockchain's context in the end, and return the performance statistics. Hence, if users intend to test the blockchain system which Caliper is unable to support, the bellows are what the users would concern about.
+
+* Use Blockchain NBI to write your own blockchain Class: Below is a Blockchain interface implementation example. 
+
+  ```javascript
+    /**
+    * Implements {BlockchainInterface} for a myblockchain backend.
+    */
+    class Myblockchain extends BlockchainInterface{
+
+        /**
+        * Create a new instance of the {Myblockchain} class.
+        * @param {string} config_path The path of  Myblockchain network configuration file.
+        */
+        constructor(config_path) {
+
+        }
+
+        /**
+        * Initialize the {Myblockchain} object.
+        */
+        init() {
+        ...
+        }
+
+        /**
+        * Deploy the chaincode specified in the network configuration file to all peers.
+        * @return {Myblockchain} resolve
+        */
+        installSmartContract() {
+        ...
+        }
+
+        /**
+        * Return the Burrow context associated with the given callback module name.
+        * @param {string} name The name of the callback module as defined in the configuration files.
+        * @param {object} args Unused.
+        * @return {object} The assembled Myblockchain context.
+        * @async
+        */
+        getContext(name, args) {
+            ...
+        }
+
+        /**
+        * Release the given Myblockchain context.
+        * @param {object} context The Myblockchain context to release.
+        * @async
+        */
+        async releaseContext(context) {
+            ...
+        }
+
+        /**
+        * Invoke a smart contract.
+        * @param {Object} context context object
+        * @param {String} contractID identity of the contract
+        * @param {String} contractVer version of the contract
+        * @param {Array} args array of JSON formatted arguments for multiple transactions
+        * @param {Number} timeout request timeout, in seconds
+        * @return {Promise<object>} the promise for the result of the execution.
+        */
+        async invokeSmartContract(context, contractID, contractVer, args, timeout) {
+            ...
+        }
+
+        /**
+        * Query the given chaincode according to the specified options.
+        * @param {object} context The Myblockchain context returned by {getContext}.
+        * @param {string} contractID The name of the chaincode.
+        * @param {string} contractVer The version of the chaincode.
+        * @param {string} key The argument to pass to the chaincode query.
+        * @param {string} [fcn=query] The chaincode query function name.
+        * @return {Promise<object>} The promise for the result of the execution.
+        */
+        async queryState(context, contractID, contractVer, key, fcn = 'query') {
+            ...
+        }
+
+        /**
+        * Get adapter specific transaction statistics.
+        * @param {JSON} stats txStatistics object
+        * @param {Array} results array of txStatus objects.
+        */
+        getDefaultTxStats(stats, results) {
+            ...
+        }
+    }
+  ```
+
+* Add your own blockchain type into the blockchain's constructor function: In the file `caliper-core/lib/blockchain.js`, a new blockchain type should be added into the constructor function.
+  ```js
+    if(config.caliper.blockchain === 'myblockchain') {
+        let myblockchain = require('../adapters/myblockchain/myblockchain.js');
+        this.bcType = 'myblockchain';
+        this.bcObj = new myblockchain(configPath);
+    }
+  ```
+* Add predefined Network files into the dir `network/`:  These files will be useful when Caliper is trying to simulate your blockchain system. Please add all of the related files what a new boot blockchain system needs.
+* Add your own network configuration file into the corresponding network folder: Make sure the files that are necessary to boot your blockchain are specified here.
+* Define your command which will be executed before and after the test
+* Define your own smart contracts: As Caliper has several test cases now, it is necessary to realize your own smart contracts according to current test cases, eg. you could provide your smart contracts about opening an account, querying an account, deleting an account and transfering according to the test case `simple`. Your own smart contracts could be put into the directory `packages/caliper-samples/contract/myblockchain/`.
+* Define the installation script: To facilitate other users, an installation script in the file `package.json` is appreciated. Your packages and  other dependencies should be added.
+  ```json
+    "scripts": {
+        "myblockchain-deps": "npm install --no-save myblockchainpackage"
+    }
+  ```
+
+If you would like to define your test module, please use Blockchain NBI to write your own test script which should include 3 functions(init(), run()and end()) as the files in the directory `bechmark/simple/open.js` and  `bechmark/simple/query.js`, and change the callback property in the test configuration file into current test script's path. The whole flow of Benchmarks is referred to  [Writing Benchmarks](./Writing_Benchmarks.md).
+
+## License
+The Caliper codebase is released under the [Apache 2.0 license](./LICENSE.md). Any documentation developed by the Caliper Project is licensed under the Creative Commons Attribution 4.0 International License. You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/docs/v0.3.1/Writing_Benchmarks.md
+++ b/docs/v0.3.1/Writing_Benchmarks.md
@@ -1,0 +1,27 @@
+---
+layout: v0.3.1
+title:  "Writing Benchmarks"
+categories: reference
+permalink: /v0.3.1/writing-benchmarks/
+order: 1
+---
+## Write your own benchmarks
+Caliper provides a set of nodejs NBIs (North Bound Interfaces) for applications to interact with backend blockchain system. Check the [*packages/caliper-core/lib/blockchain.js*](./packages/caliper-core/lib/blockchain.js) to learn about the NBIs. Multiple *Adaptors* are implemented to translate the NBIs to different blockchain protocols. So developers can write a benchmark once, and run it with different blockchain systems.
+
+Generally speaking, to write a new caliper benchmark, you need to:
+* Write smart contracts for systems you want to test
+* Write a testing flow using caliper NBIs. Caliper provides a default benchmark engine, which is pluggable and configurable to integrate new tests easily. For more details, please refer to [Benchmark Engine](./Architecture.md).
+* Write a configuration file to define the backend network and benchmark arguments.
+
+### Directory Structure
+
+**Directory** | **Description**
+------------------ | --------------
+/benchmark | Samples of the blockchain benchmarks
+/docs | Documents
+/network | Boot configuration files used to deploy some predefined blockchain network under test.
+/src | Souce code of the framework
+/src/contract | Smart contracts for different blockchain systems
+
+## License
+The Caliper codebase is released under the [Apache 2.0 license](./LICENSE.md). Any documentation developed by the Caliper Project is licensed under the Creative Commons Attribution 4.0 International License. You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/docs/v0.3.1/architecture_CH.md
+++ b/docs/v0.3.1/architecture_CH.md
@@ -1,0 +1,143 @@
+---
+layout: v0.3.1
+title:  "Architecture (CH)"
+categories: docs
+permalink: /v0.3.1/architecture-ch/
+order: 6
+---
+
+## Architecture
+<img src="{{ site.baseurl }}/assets/img/architecture.png" alt="architecture">
+
+
+### Adaptation Layer(适配层)
+
+适配层用于将现有的区块链系统集成到Caliper框架中。每个适配器使用相应的区块链SDK或RESTful API实现'Caliper Blockchain NBI'。目前支持Hyperledger Fabric1.0-1.4、Sawtooth、Iroha、和burrow。Caliper后续将实现对以太坊和其他区块链系统的支持。
+
+### Interface&Core Layer（接口及核心层）
+接口和核心层提供 Blockchain NBI、资源监控、性能监控、报告生成模块，并为上层应用提供四种相应的北向接口：
+* *Blockchain operating interfaces:* 包含诸如在后端区块链上部署智能合约、调用合约、从账本查询状态等操作。
+* *Resource Monitor:* 包含启动/停止监视器和获取后端区块链系统资源消耗状态的操作，包括CPU、内存、网络IO等。现在提供两种监视器，一种是监视本地/远程docker容器，另一种则是监控本地进程。未来将实现更多功能。
+* *Performance Analyzer:* 包含读取预定义性能统计信息（包括TPS、延迟、成功交易数等）和打印基准测试结果的操作。在调用区块链北向接口时，每个交易的关键指标（如创建交易的时间、交易提交时间、交易返回结果等）都会被记录下来，并用于生成最终的预定义性能指标统计信息。
+* *Report Generator:* 生成HTML格式测试报告。
+   
+### Application Layer(应用层)
+
+应用程序层包含针对典型区块链方案实施的测试。每次测试都需要设置对应的配置文件，用于定义后端区块链网络信息和测试参数信息。基于这些配置，可以完成区块链系统的性能测试。
+
+我们预置了一个默认的基准测试引擎以帮助开发人员理解框架并快速实施自己的测试。下面将介绍如何使用基准测试引擎。当然，开发人员也可以不使用测试框架，直接使用NBI完成自有区块链系统的测试。
+
+
+## Benchmark Engine
+
+
+<img src="{{ site.baseurl }}/assets/img/test-framework.png" alt="Benchmark Engine">
+
+### Configuration File
+ 
+我们使用两种配置文件。一种是基准配置文件，它定义基准测试参数，如负载量（workload）等。另一种是区块链网络配置文件，它指定了有助于与待测试的系统（SUT）交互的必要信息。 
+
+以下是基准配置文件示例:
+```yaml
+test:
+  name: simple
+  description: This is an example benchmark for caliper
+  clients:
+    type: local
+    number: 5
+  rounds:
+  - label: open
+    txNumber:
+    - 5000
+    - 5000
+    - 5000
+    rateControl:
+    - type: fixed-rate
+      opts: 
+        tps: 100
+    - type: fixed-rate
+      opts:
+        tps: 200
+    - type: fixed-rate
+      opts:
+        tps: 300
+    arguments:
+      money: 10000
+    callback: benchmark/simple/open.js
+  - label: query
+    txNumber:
+    - 5000
+    - 5000
+    rateControl:
+    - type: fixed-rate
+      opts:
+        tps: 300
+    - type: fixed-rate
+      opts:
+        tps: 400
+    callback" : benchmark/simple/query.js
+monitor:
+  type:
+  - docker
+  - process
+  docker:
+    name:
+    - peer0.org1.example.com
+    - http://192.168.1.100:2375/orderer.example.com
+  process:
+  - command: node
+    arguments: local-client.js
+    multiOutput: avg
+  interval: 1
+```
+* **test** - 定义测试的元数据和指定工作负载下的多轮测试。
+  * **name&description** : 测试名及其描述，该信息会被报告生成器使用，并显示在测试报告中。
+  * **clients** : 定义客户端类型和相关参数，其中'type'应该设置为'local'。
+    * local: 此例中，Caliper的主进程将会创建多个子进程，每个子进程将会作为客户端向后端区块链系统发送交易。客户端的数量由'number'定义。
+  * **label** : 当前测试标签名称。例如，可以使用当前交易目的名称（如开户）作为标签名称，来说明当前性能测试的交易类型。该值还可用作blockchain.getContext()中的Context名称。又例如，开发人员可能希望测试不同Fabric通道的性能，在这种情况下，具有不同标签的测试可以绑定到不同的Fabric通道。 
+  * **txNumber** : 定义一个子轮测试数组，每个轮次有不同的交易数量。例如, [5000,400] 表示在第一轮中将生成总共5000个交易，在第二轮中将生成400个交易。
+  * **txDuration** : 定义基于时间测试的子轮数组。例如 [150,400] 表示将进行两次测试，第一次测试将运行150秒，第二次运行将运行400秒。如果当前配置文件中同时指定了txNumber和txDuration，系统将优先根据txDuration设置运行测试。
+  * **rateControl** : 定义每个子轮测试期间使用的速率控制数组。如果未指定，则默认为“固定速率”，将以1TPS速率发送交易开始测试。如果已定义，务必保证所选用的速率控制机制名称正确并且提供对应的发送速率及所需参数。在每一轮测试中,  **txNumber** 或 **txDuration** 在 **rateControl** 中具有相应的速率控制项。有关可用速率控制器以及如何实现自定义速率控制器的更多信息，请参阅 [速率控制部分](./Rate_Controllers.md)。
+  * **trim** : 对客户端结果执行修剪（trim）操作，以消除warm-up和cool-down阶段对于测试结果的影响。如果已指定修剪区间，该设置将被应用于该轮测试结果的修剪中。例如, 在`txNumber`测试模式中，值30表示每个客户端发送的最初和最后的30个交易结果将被修剪掉; 在`txDuration`模式下, 则从每个客户端发送的前30秒和后30秒的交易结果将会被忽略掉。
+  * **arguments** : 用户自定义参数，将被传递到用户自定义的测试模块中。
+  * **callback** : 指明用户在该轮测试中定义的测试模块。请参阅[User defined test module](./Writing_Benchmarks.md) 获取更多信息。
+* **monitor** - 定义资源监视器和受监视对象的类型，以及监视的时间间隔。
+  * docker : docker monitor用于监视本地或远程主机上的指定docker容器。Docker Remote API用于检索远程容器的统计信息。保留的容器名称“all”表示将监视主机上的所有容器。在上面的示例中，监视器将每秒检索两个容器的统计信息，一个是名为“peer0.org1.example.com”的本地容器，另一个是位于主机'192.168.1.100'上的名为“orderer.example.com”的远程容器。2375是该主机上Docker的侦听端口。
+  * process : 进程监视器用于监视指定的本地进程。例如，用户可以使用此监视器来监视模拟区块链客户端的资源消耗。'command'和'arguments'属性用于指定进程。如果找到多个进程，'multiOutput'属性用于定义输出的含义。'avg'表示输出是这些过程的平均资源消耗，而'sum'表示输出是总和消耗。 
+  * others : 待后续补充。
+
+### Master
+
+实现默认测试流程，其中包含三个阶段：
+
+* 准备阶段：在此阶段，主进程使用区块链配置文件创建并初始化内部区块链对象，按照配置中指定的信息部署智能合约，并启动监控对象以监控后端区块链系统的资源消耗。
+
+* 测试阶段: 在此阶段，主进程根据配置文件执行测试，将根据定义的workload生成任务并将其分配给客户端子进程。最后将存储各个客户端返回的性能统计信息以供后续分析。
+
+* 报告阶段: 分析每个测试轮次的所有客户端的统计数据，并自动生成HTML格式报告。报告示例如下:
+
+
+<img src="{{ site.baseurl }}/assets/img/report.png" alt="report example">
+
+### Clients
+
+#### Local Clients
+
+在此模式下，主进程使用Node.js集群模块启动多个本地客户端（子进程）来执行实际的测试工作。由于Node.js本质上是单线程的，因此本地集群可用于提高客户端在多核机器上的性能。
+
+此模式下，总工作负载被平均分配给子进程。每个子进程相当于区块链客户端，子进程拥有临时生成的context，可以和后端区块链系统交互。context通常包含客户端的标识和加密信息，在测试结束后context将被释放。
+
+* 对于Hyperledger Fabric，context也绑定到特定channel，该绑定关系在Fabric配置文件中有相关定义。
+
+测试时客户端将调用用户定义的测试模块，该模块包含了自定义的测试逻辑。测试模块的相关信息后文会给出解释。
+
+本地客户端在第一轮测试时启动，并在完成所有测试后被销毁。
+
+### User Defined Test Module
+
+该模块实现交易生成和提交交易的功能。通过这种方式，开发人员可以实现自己的测试逻辑并将其与基准引擎集成。
+测试模块主要实现3个函数，所有这些函数都应该返回一个Promise对象。 
+
+* `init` - 将在每个测试轮次开始时由客户端调用。所需参数包括当前区块链对象、上下文以及从基准配置文件中读取的用户定义的参数。在该函数内可以保存区块链对象和context供以后使用，其他初始化工作也可在此处实现。
+* `run` - 应使用Caliper的区块链API在此处生成和提交实际的事务。客户端将根据工作负载重复调用此函数。建议每次调用只提交一个事务；如果每次提交多个事务，则实际工作负载可能与配置的工作负载不同。请确保该函数应以异步方式运行。
+* `end` - 将在每轮测试结束时调用，任何结束时需要释放信息的工作都应在此处执行。

--- a/scripts/bump-docs.js
+++ b/scripts/bump-docs.js
@@ -29,8 +29,8 @@ const configFilePath = path.join(__dirname, '../_config.yml');
 const _config = yaml.safeLoad(fs.readFileSync(configFilePath),'utf8');
 if (_config.caliper.current_release.localeCompare(targetRelease) !== 0) {
 	// Need to update config file
-	_config.caliper[targetRelease.replace('.', '_')] = targetRelease;
-	_config.caliper.current_release = targetRelease;
+	_config.caliper[targetRelease.replace(/\./g, '_')] = targetRelease + '/';
+	_config.caliper.current_release = targetRelease + '/';
 
 	const newConfig = yaml.safeDump(_config);
     fs.writeFileSync(configFilePath, newConfig, 'utf8');
@@ -45,7 +45,7 @@ if (_config.caliper.current_release.localeCompare(targetRelease) !== 0) {
 	let replaceTarget = '<option value="/caliper/vNext/getting-started/" selected>vNext</option>';
 	let replaceString = `<option value="/caliper/${targetRelease}/getting-started/" selected>${targetRelease}</option>\n    ` + '<option value="/caliper/vNext/getting-started/">vNext</option>';
 	let newInclude = include.replace(replaceTarget, replaceString);
-	newInclude = newInclude.replace(/next_release/g, `${targetRelease.replace('.','_')}`);
+	newInclude = newInclude.replace(/next_release/g, `${targetRelease.replace(/\./g, '_')}`);
 	fs.writeFileSync(path.join(__dirname, `../_includes/${targetRelease}.html`), newInclude);
 
 	// Need to update other versions to indicate existence of new targetRelease


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

New docs for 0.3.1

Also a fix for bumpdocs
- global replace to enable publish of x.y.z as well as x.y versions
- addition of trailing slash on html matcher to enable "contains" disambiguation for x.y and x.y.z