### PR TITLE
Adding docs link back to header so returning users can access docs easily

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -17,6 +17,7 @@
         </label>
 
         <div class="trigger">
+          <a class="page-link" href="{{ site.baseurl }}/{{ site.caliper.current_release }}/getting-started">Documentation</a> 
           <a class="page-link" href="https://github.com/hyperledger/caliper" target="_blank">Github</a>
           <a class="page-link" href="https://www.linuxfoundation.org/privacy" target="_blank">Privacy Policy</a>
         </div>


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->

This PR adds the useful "documentation" link back to the header bar, it uses the same logic as the main "getting started" button on the homepage so will not require editing the link every time a new release is produced.

**_Before_**
![image](https://user-images.githubusercontent.com/13980028/83403736-24f24080-a401-11ea-8b9e-d97c237223f5.png)

**_After_**
![image](https://user-images.githubusercontent.com/13980028/83403758-2e7ba880-a401-11ea-8eb1-56a602c34a1e.png)

