### PR TITLE
Use solc-js library instead of docker to compile contracts in FISCO-BCOS adapter

### DIFF
--- a/packages/caliper-fisco-bcos/package.json
+++ b/packages/caliper-fisco-bcos/package.json
@@ -23,16 +23,17 @@
     },
     "dependencies": {
         "@hyperledger/caliper-core": "0.4.0-unstable",
-        "nconf": "^0.10.0",
-        "isarray": "^2.0.4",
-        "fs-extra": "8.1.0",
         "bn.js": "^4.11.8",
-        "ethereumjs-util": "^6.1.0",
         "crypto-js": "^3.1.9-1",
+        "ethereumjs-util": "^6.1.0",
+        "fs-extra": "8.1.0",
+        "isarray": "^2.0.4",
+        "nconf": "^0.10.0",
         "ora": "^1.2.0",
-        "uuid": "^3.3.2",
+        "request-promise": "^4.2.1",
+        "solc": "^0.4.25",
         "tls": "^0.0.1",
-        "request-promise": "^4.2.1"
+        "uuid": "^3.3.2"
     },
     "devDependencies": {
         "web3": "0.20.7",


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->
This PR addresses the issue that a docker host is needed when using FISCO-BCOS adapter. 

## Checklist
 - [x]  The issue/user story that the pull request relates to
 - [x]  How to recreate the problem without the fix
 - [x]  Design of the fix
 - [x]  How to prove that the fix works
 - [x]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
<!--- What issue / user story is this for -->

Previously, as per the FISCO-BCOS adapter's implementation, a child process is spawned to invoke a `docker run`command for solidity contract compilation. This creates difficulty when running caliper against a remote network (e.g., with `caliper.command.start` and `caliper.command.end` removed and with the node endpoints set to a remote addresses in the network config). The environment (e.g., a container) that runs caliper may or may not have docker available and this requirement is not very necessary as the contract compilation is achievable through the js-based solidity compiler `solc-js`. 

(Someone may argue that [dind](http://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/) is possible but this is simply just not necessary unless there's some other reason other than just compiling the contract.)

With this fix, now the adapter implementation directly uses `solc-js` library (which is also what the image `ethereum/solc:0.4.25` uses internally).

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1. Prepare an environment without docker (a VM or a container)
2. Clone the repo
3. Remove `start` and `end` in `packages/caliper-tests-integration/fisco-bcos_tests/networkconfig.json` as follows

    ```
    {
        "caliper": {
            "blockchain": "fisco-bcos",
            "command": {
            }
        },
    ```
4. Start the integration test `BENCHMARK=fisco-bcos ./.travis/benchmark-integration-test-direct.sh`
3. The integration test will fail at `PHASE 2` when calling `docker` to compile the contract. The output shows `docker: not found` as it's not available here (which is intended).

    ````
    # PHASE 2: init, install, test
    ${CALL_METHOD} launch master --caliper-flow-skip-start --caliper-flow-skip-end
    2020.06.09-09:55:05.616 +0000 debug [blockchain] Constructed a winston logger with the specified settings
    2020.06.09-09:55:05.732 +0000 info  [cli-launch-master] Set workspace path: /home/vagrant/caliper/packages/caliper-tests-integration/fisco-bcos_tests
    2020.06.09-09:55:05.732 +0000 info  [cli-launch-master] Set benchmark configuration path: /home/vagrant/caliper/packages/caliper-tests-integration/fisco-bcos_tests/benchconfig.yaml
    2020.06.09-09:55:05.732 +0000 info  [cli-launch-master] Set network configuration path: /home/vagrant/caliper/packages/caliper-tests-integration/fisco-bcos_tests/networkconfig.json
    2020.06.09-09:55:05.732 +0000 info  [cli-launch-master] Set SUT type: fisco-bcos
    2020.06.09-09:55:05.918 +0000 info  [caliper-engine] Starting benchmark flow
    2020.06.09-09:55:05.927 +0000 info  [caliper-engine] Skipping start commands due to benchmark flow conditioning
    2020.06.09-09:55:05.927 +0000 info  [caliper-engine] Executed "init" step in 0 seconds
    2020.06.09-09:55:05.927 +0000 info  [installSmartContract.js] Deploying smart contracts ...
    2020.06.09-09:55:05.927 +0000 info  [installSmartContract.js] Deploying helloworld ...
    ⠋ Compiling /home/vagrant/caliper/packages/caliper-tests-integration/fisco-bcos_tests/src/helloworld/HelloWorld.sol ..✖ Compiling /home/vagrant/caliper/packages/caliper-tests-integration/    fisco-bcos_tests/src/helloworld/HelloWorld.sol ...
    2020.06.09-09:55:05.946 +0000 error [fiscoBcosApi.js] Compiling error:
    /bin/sh: 1: docker: not found
    
    2020.06.09-09:55:05.946 +0000 error [installSmartContract.js] Depolying error: undefined
    2020.06.09-09:55:05.946 +0000 error [installSmartContract.js] Failed to install smart contract helloworld, path=/home/vagrant/caliper/packages/caliper-tests-integration/fisco-bcos_tests/src/    helloworld/HelloWorld.sol
    2020.06.09-09:55:05.946 +0000 error [caliper-engine] Error while performing "install" step: TypeError: Cannot read property 'stack' of undefined
    2020.06.09-09:55:05.946 +0000 info  [caliper-engine] Executed "install" step in 0.019 seconds
    2020.06.09-09:55:05.947 +0000 info  [caliper-engine] Skipping end command due to benchmark flow conditioning
    2020.06.09-09:55:05.947 +0000 error [cli-launch-master] Benchmark failed with error code 5
    ```

## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-caliper)
- [ ] [GitHub Issues](https://github.com/hyperledger/caliper/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/caliper)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->

It's just simply a swap of the contract compilation from docker-based method to js-based method.

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

The functionality is not compromised while the dependency on docker is removed. The passed integration test proves that.

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->
