### PR TITLE
Update web3 for ethereum sut to 1.2.2

### DIFF
--- a/packages/caliper-cli/lib/lib/config.yaml
+++ b/packages/caliper-cli/lib/lib/config.yaml
@@ -99,7 +99,7 @@ sut:
 
     ethereum:
         1.2.1: &ethereum-latest
-            packages: ['web3@1.2.0']
+            packages: ['web3@1.2.2']
         latest: *ethereum-latest
 
     besu:


### PR DESCRIPTION
Caliper 0.3.1 uses the new Ethereum SUT 1.2.1 adapter, which itself depends on web3 APIs that came became available with web3 1.2.2 such as `eth.getChainId` (see https://github.com/ethereum/web3.js/pull/3147).

However, the bind sut command for ethereum:1.2.1 still used to install web3 1.2.0.

This PR fixes the web3 version for the bind command accordingly.
