### PR TITLE
Update local module path detection

### DIFF
--- a/packages/caliper-core/lib/common/utils/caliper-utils.js
+++ b/packages/caliper-core/lib/common/utils/caliper-utils.js
@@ -135,7 +135,7 @@ class CaliperUtils {
         // get correct module path
         if (builtInModules.has(moduleName)) {
             modulePath = builtInModules.get(moduleName);
-        } else if (moduleName.startsWith('./') || moduleName.startsWith('/')) {
+        } else if (moduleName.startsWith('./') || moduleName.startsWith('/') || moduleName.endsWith('.js')) {
             // treat it as an external module, but resolve the path, so it's absolute
             modulePath = CaliperUtils.resolvePath(moduleName);
         } else {


### PR DESCRIPTION
Signed-off-by: Attila Klenik <a.klenik@gmail.com>

Now paths like `benchmarks/.../init.js` are also identified as local modules
