### PR TITLE
change client -> worker in code

### DIFF
--- a/packages/caliper-core/index.js
+++ b/packages/caliper-core/index.js
@@ -15,12 +15,12 @@
 'use strict';
 
 module.exports.BlockchainInterface = require('./lib/common/core/blockchain-interface');
-module.exports.CaliperLocalClient = require('./lib/worker/client/caliper-local-client');
+module.exports.CaliperWorker = require('./lib/worker/caliper-worker');
 module.exports.TxStatus = require('./lib/common/core/transaction-status');
 module.exports.CaliperUtils = require('./lib/common/utils/caliper-utils');
 module.exports.Version = require('./lib/common/utils/version');
 module.exports.ConfigUtil = require('./lib/common/config/config-util');
-module.exports.MessageHandler = require('./lib/worker/client/message-handler');
+module.exports.MessageHandler = require('./lib/worker/message-handler');
 module.exports.Messenger = require('./lib/common/messaging/messenger');
 module.exports.CaliperEngine = require('./lib/master/caliper-engine');
 module.exports.MonitorOrchestrator = require('./lib/master/orchestrators/monitor-orchestrator');

--- a/packages/caliper-core/lib/common/messaging/mqtt-worker.js
+++ b/packages/caliper-core/lib/common/messaging/mqtt-worker.js
@@ -17,7 +17,7 @@
 const MessengerInterface = require('./messenger-interface');
 const Logger = require('../utils/caliper-utils').getLogger('mqtt-worker-messenger');
 const ConfigUtil = require('../config/config-util');
-const MessageHandler = require('../../worker/client/message-handler');
+const MessageHandler = require('../../worker/message-handler');
 
 const mqtt = require('mqtt');
 

--- a/packages/caliper-core/lib/common/messaging/process-worker.js
+++ b/packages/caliper-core/lib/common/messaging/process-worker.js
@@ -16,7 +16,7 @@
 
 const MessengerInterface = require('./messenger-interface');
 const Logger = require('../utils/caliper-utils').getLogger('mqtt-worker-messenger');
-const MessageHandler = require('../../worker/client/message-handler');
+const MessageHandler = require('../../worker/message-handler');
 
 /**
  * Messenger that is based on a process

--- a/packages/caliper-core/lib/master/orchestrators/worker-orchestrator.js
+++ b/packages/caliper-core/lib/master/orchestrators/worker-orchestrator.js
@@ -19,9 +19,9 @@ const childProcess = require('child_process');
 
 const CaliperUtils = require('../../common/utils/caliper-utils');
 const ConfigUtils = require('../../common/config/config-util');
-const logger = CaliperUtils.getLogger('worker-orchestrator');
 const Messenger = require('../../common/messaging/messenger');
 
+const logger = CaliperUtils.getLogger('worker-orchestrator');
 
 // Orchestrator message typings
 const TYPES = {


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

contributes to #871 

base on current naming convention in other folders, changed `caliper-local-client` to `caliper-worker` and removed unrequired folder nesting.

This now sits alongside `mqtt-worker`, `process-worker` quite neatly
