### PR TITLE
Align backlog controllers with other rate controllers

### DIFF
--- a/packages/caliper-core/test/worker/rate-control/fixedBacklog.js
+++ b/packages/caliper-core/test/worker/rate-control/fixedBacklog.js
@@ -29,7 +29,7 @@ describe('fixedBacklog controller implementation', () => {
 
         let msg = {totalClients: 1};
         let opts = {
-            unfinished_per_client: 30,
+            transaction_load: 30,
             startingTps: 10
         };
 
@@ -43,7 +43,7 @@ describe('fixedBacklog controller implementation', () => {
         it('should set the sleep time for a single client if no clients are specified and the startingTps is not specified', () => {
             let msg = {};
             let opts = {
-                unfinished_per_client: 30
+                transaction_load: 90
             };
             controller = new FixedBacklog.createRateController(opts);
             controller.init(msg);
@@ -58,7 +58,7 @@ describe('fixedBacklog controller implementation', () => {
 
         it('should set the sleep time for a multiple clients it the startingTps is not specified', () => {
             let opts = {
-                unfinished_per_client: 30
+                transaction_load: 30
             };
             controller = new FixedBacklog.createRateController(opts);
             controller.init(msg);
@@ -68,13 +68,13 @@ describe('fixedBacklog controller implementation', () => {
         it('should set a default transaction backlog for multiple clients if not specified', () => {
             controller = new FixedBacklog.createRateController({});
             controller.init(msg);
-            controller.unfinished_per_client.should.equal(10);
+            controller.unfinished_per_worker.should.equal(10);
         });
 
         it('should set the transaction backlog for multiple clients if specified', () => {
             controller = new FixedBacklog.createRateController(opts);
             controller.init(msg);
-            controller.unfinished_per_client.should.equal(30);
+            controller.unfinished_per_worker.should.equal(30);
         });
 
     });
@@ -83,7 +83,7 @@ describe('fixedBacklog controller implementation', () => {
 
         let sleepStub;
         let opts = {
-            unfinished_per_client: 30,
+            transaction_load: 30,
             startingTps: 10
         };
 
@@ -93,7 +93,7 @@ describe('fixedBacklog controller implementation', () => {
 
             controller = new FixedBacklog.createRateController(opts);
             controller.sleepTime = 1000;
-            controller.unfinished_per_client = 30;
+            controller.unfinished_per_worker = 30;
         });
 
         it('should sleep if resultStats.length < 2', async () => {

--- a/packages/caliper-core/test/worker/rate-control/fixedFeedbackRate.js
+++ b/packages/caliper-core/test/worker/rate-control/fixedFeedbackRate.js
@@ -27,7 +27,7 @@ describe('fixedFeedbackRate controller implementation', () => {
         let controller;
         let opts = {
             tps: 100,
-            unfinished_per_client: 100
+            maximum_transaction_load: 100
         };
 
         beforeEach(() => {
@@ -46,7 +46,7 @@ describe('fixedFeedbackRate controller implementation', () => {
             let msg = {};
             let opts = {
                 tps: 0,
-                unfinished_per_client: 100
+                maximum_transaction_load: 100
             };
             controller = new FixedFeedbackRate.createRateController(opts);
 
@@ -82,17 +82,17 @@ describe('fixedFeedbackRate controller implementation', () => {
             controller.sleep_time.should.equal(100);
         });
 
-        it ('should set the transaction backlog for multiple clients if specified', () => {
-            let msg = {totalClients: 1};
+        it ('should set the transaction backlog for multiple workers if specified', () => {
+            let msg = {totalClients: 2};
             controller.init(msg);
-            controller.unfinished_per_client.should.equal(100);
+            controller.unfinished_per_worker.should.equal(50);
         });
 
-        it ('should set a default transaction backlog for multiple clients if not specified', () => {
+        it ('should set a default transaction backlog for multiple workers if not specified', () => {
             controller = new FixedFeedbackRate.createRateController({});
             let msg = {totalClients: 1};
             controller.init(msg);
-            controller.unfinished_per_client.should.equal(7000);
+            controller.unfinished_per_worker.should.equal(100);
         });
 
         it ('should set zero_succ_count to 0', () => {
@@ -114,8 +114,8 @@ describe('fixedFeedbackRate controller implementation', () => {
 
         let opts = {
             tps: 100,
-            unfinished_per_client: 100
-        }
+            maximum_transaction_load: 100
+        };
 
         beforeEach(() => {
             clock = sinon.useFakeTimers();
@@ -123,7 +123,7 @@ describe('fixedFeedbackRate controller implementation', () => {
             FixedFeedbackRate.__set__('util.sleep', sleepStub);
 
             controller = new FixedFeedbackRate.createRateController(opts);
-            controller.unfinished_per_client = 100;
+            controller.maximum_transaction_load = 100;
             controller.sleepTime = 50;
             controller.sleep_time = 100;
             controller.zero_succ_count = 0;
@@ -145,7 +145,7 @@ describe('fixedFeedbackRate controller implementation', () => {
             sinon.assert.notCalled(sleepStub);
         });
 
-        it ('should not sleep if id < unfinished_per_client', () => {
+        it ('should not sleep if id < maximum_transaction_load', () => {
             let start = 0;
             let idx = 50;
             let resultStats = [
@@ -212,7 +212,7 @@ describe('fixedFeedbackRate controller implementation', () => {
                     succ: 0, fail: 1
                 }
             ];
-            controller.unfinished_per_client = 2;
+            controller.maximum_transaction_load = 2;
             controller.sleepTime = 1;
             controller.total_sleep_time = 2;
 
@@ -235,7 +235,7 @@ describe('fixedFeedbackRate controller implementation', () => {
                 }
             ];
 
-            controller.unfinished_per_client = 2;
+            controller.unfinished_per_worker = 2;
             controller.sleepTime = 1;
             controller.total_sleep_time = 2;
 

--- a/packages/caliper-tests-integration/besu_tests/phase2/benchconfig.yaml
+++ b/packages/caliper-tests-integration/besu_tests/phase2/benchconfig.yaml
@@ -32,7 +32,7 @@ test:
               money: 10000
     - label: query
       txNumber: 200
-      rateControl: { type: 'fixed-feedback-rate', opts: { tps: 10, unfinished_per_client: 5 } }
+      rateControl: { type: 'fixed-feedback-rate', opts: { tps: 10, maximum_transaction_load: 5 } }
       workload:
           module: ./../query.js
           arguments:

--- a/packages/caliper-tests-integration/besu_tests/phase3/benchconfig.yaml
+++ b/packages/caliper-tests-integration/besu_tests/phase3/benchconfig.yaml
@@ -32,7 +32,7 @@ test:
               money: 10000
     - label: query
       txNumber: 200
-      rateControl: { type: 'fixed-feedback-rate', opts: { tps: 10, unfinished_per_client: 5 } }
+      rateControl: { type: 'fixed-feedback-rate', opts: { tps: 10, maximum_transaction_load: 5 } }
       workload:
           module: ./../query.js
           arguments:

--- a/packages/caliper-tests-integration/ethereum_tests/benchconfig.yaml
+++ b/packages/caliper-tests-integration/ethereum_tests/benchconfig.yaml
@@ -32,7 +32,7 @@ test:
               money: 10000
     - label: query
       txNumber: 200
-      rateControl: { type: 'fixed-feedback-rate', opts: { tps: 10, unfinished_per_client: 5 } }
+      rateControl: { type: 'fixed-feedback-rate', opts: { tps: 10, maximum_transaction_load: 5 } }
       workload:
           module: ./query.js
           arguments:

--- a/packages/caliper-tests-integration/fabric_tests/phase1/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase1/benchconfig.yaml
@@ -25,7 +25,7 @@ test:
         module: ./../init.js
     - label: init2
       txNumber: 200
-      rateControl: { type: 'fixed-feedback-rate', opts: { tps: 20, unfinished_per_client: 5 } }
+      rateControl: { type: 'fixed-feedback-rate', opts: { tps: 20, maximum_transaction_load: 5 } }
       workload:
         module: ./../init.js
     - label: query

--- a/packages/caliper-tests-integration/fabric_tests/phase2/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase2/benchconfig.yaml
@@ -25,7 +25,7 @@ test:
         module: ./../init.js
     - label: init2
       txNumber: 200
-      rateControl: { type: 'fixed-feedback-rate', opts: { tps: 20, unfinished_per_client: 5 } }
+      rateControl: { type: 'fixed-feedback-rate', opts: { tps: 20, maximum_transaction_load: 5 } }
       workload:
         module: ./../init.js
     - label: query

--- a/packages/caliper-tests-integration/fabric_tests/phase3/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase3/benchconfig.yaml
@@ -25,7 +25,7 @@ test:
         module: ./../init.js
     - label: init2
       txNumber: 200
-      rateControl: { type: 'fixed-feedback-rate', opts: { tps: 20, unfinished_per_client: 5 } }
+      rateControl: { type: 'fixed-feedback-rate', opts: { tps: 20, maximum_transaction_load: 5 } }
       workload:
         module: ./../init.js
     - label: query

--- a/packages/caliper-tests-integration/fabric_tests/phase7/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase7/benchconfig.yaml
@@ -27,7 +27,7 @@ test:
               marblePrefix: marbles_phase_5
     - label: init2
       txNumber: 200
-      rateControl: { type: 'fixed-feedback-rate', opts: { tps: 20, unfinished_per_client: 5 } }
+      rateControl: { type: 'fixed-feedback-rate', opts: { tps: 20, maximum_transaction_load: 5 } }
       workload:
           module: ./../init.js
           arguments:

--- a/packages/caliper-tests-integration/iroha_tests/benchconfig.yaml
+++ b/packages/caliper-tests-integration/iroha_tests/benchconfig.yaml
@@ -30,7 +30,7 @@ test:
               txnPerBatch: 10
     - label: query
       txNumber: 200
-      rateControl: { type: 'fixed-feedback-rate', opts: { tps: 10, unfinished_per_client: 5 } }
+      rateControl: { type: 'fixed-feedback-rate', opts: { tps: 10, maximum_transaction_load: 5 } }
       workload:
           module: ./query.js
           arguments:


### PR DESCRIPTION
Rate controllers should be from the perspective of the SUT, with workers figuring out what loading they should supply.

This PR aligns the backlog controllers (fixed-backlog, fixed-feedback-rate) to this convention.

Question: Should `fixed-backlog` be renamed to something more appropriate, such as `fixed-transaction-load` or `fixed-load` ?

Docs change to accompany in #910 

Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>
