### PR TITLE
Channel transaction

### DIFF
--- a/packages/caliper-fabric/lib/connector-versions/v1/fabric.js
+++ b/packages/caliper-fabric/lib/connector-versions/v1/fabric.js
@@ -2078,7 +2078,7 @@ class Fabric extends BlockchainConnector {
      * Invokes the specified contract according to the provided settings.
      *
      * @param {string} contractID The unique contract ID of the target contract.
-     * @param {string} contractVersion Unused.
+     * @param {string} contractVersion The version of the contract. Only used when explicitly naming a channel within the invokeSettings.
      * @param {ContractInvokeSettings|ContractInvokeSettings[]} invokeSettings The settings (collection) associated with the (batch of) transactions to submit.
      * @param {number} timeout The timeout for the whole transaction life-cycle in seconds.
      * @return {Promise<TxStatus[]>} The result and stats of the transaction invocation.
@@ -2095,14 +2095,18 @@ class Fabric extends BlockchainConnector {
         }
 
         for (const settings of settingsArray) {
-            const contractDetails = this.networkUtil.getContractDetails(contractID);
-            if (!contractDetails) {
-                throw new Error(`Could not find details for contract ID ${contractID}`);
+            if (settings.hasOwnProperty('channel')) {
+                settings.contractId = contractID;
+                settings.contractVersion = contractVersion;
+            } else {
+                const contractDetails = this.networkUtil.getContractDetails(contractID);
+                if (!contractDetails) {
+                    throw new Error(`Could not find details for contract ID ${contractID}`);
+                }
+                settings.channel = contractDetails.channel;
+                settings.contractId = contractDetails.id;
+                settings.contractVersion = contractDetails.version;
             }
-
-            settings.channel = contractDetails.channel;
-            settings.contractId = contractDetails.id;
-            settings.contractVersion = contractDetails.version;
 
             if (!settings.invokerIdentity) {
                 settings.invokerIdentity = this.defaultInvoker;
@@ -2118,7 +2122,7 @@ class Fabric extends BlockchainConnector {
      * Queries the specified contract according to the provided settings.
      *
      * @param {string} contractID The unique contract ID of the target contract.
-     * @param {string} contractVersion Unused.
+     * @param {string} contractVersion The version of the contract. Only used when explicitly naming a channel within the invokeSettings.
      * @param {ContractQuerySettings|ContractQuerySettings[]} querySettings The settings (collection) associated with the (batch of) query to submit.
      * @param {number} timeout The timeout for the call in seconds.
      * @return {Promise<TxStatus[]>} The result and stats of the transaction query.
@@ -2135,14 +2139,18 @@ class Fabric extends BlockchainConnector {
         }
 
         for (const settings of settingsArray) {
-            const contractDetails = this.networkUtil.getContractDetails(contractID);
-            if (!contractDetails) {
-                throw new Error(`Could not find details for contract ID ${contractID}`);
+            if (settings.hasOwnProperty('channel')) {
+                settings.contractId = contractID;
+                settings.contractVersion = contractVersion;
+            } else {
+                const contractDetails = this.networkUtil.getContractDetails(contractID);
+                if (!contractDetails) {
+                    throw new Error(`Could not find details for contract ID ${contractID}`);
+                }
+                settings.channel = contractDetails.channel;
+                settings.contractId = contractDetails.id;
+                settings.contractVersion = contractDetails.version;
             }
-
-            settings.channel = contractDetails.channel;
-            settings.contractId = contractDetails.id;
-            settings.contractVersion = contractDetails.version;
 
             if (!settings.invokerIdentity) {
                 settings.invokerIdentity = this.defaultInvoker;

--- a/packages/caliper-fabric/lib/fabricNetwork.js
+++ b/packages/caliper-fabric/lib/fabricNetwork.js
@@ -39,7 +39,7 @@ class FabricNetwork {
 
         this.network = undefined;
         if (typeof networkConfig === 'string') {
-            // resolve path will by default use the known workspace root
+            // resolvePath() will by default use the known workspace root
             const configPath = CaliperUtils.resolvePath(networkConfig);
             this.network = CaliperUtils.parseYaml(configPath);
         } else if (typeof networkConfig === 'object' && networkConfig !== null) {
@@ -914,8 +914,8 @@ class FabricNetwork {
 
 
     /**
-     * Return the name of the first client in the named organisation
-     * @param {string} org the organisation name
+     * Return the name of the first client in the named organization
+     * @param {string} org the organization name
      * @returns {string} the client name
      */
     getFirstClientInOrg(org) {

--- a/packages/caliper-fabric/test/configValidator.js
+++ b/packages/caliper-fabric/test/configValidator.js
@@ -432,7 +432,7 @@ describe('Class: ConfigValidator', () => {
         });
     });
 
-    describe('Function: _validateTopLevel', () => {
+    describe.only('Function: _validateTopLevel', () => {
         // good practice for auto complete and easy backup
         let config = {
             name: 'Fabric',
@@ -2375,7 +2375,7 @@ describe('Class: ConfigValidator', () => {
                     hasOrgWallet = true;
                     delete config.client.credentialStore;
                     config.client.affiliation = 'aff';
-                    call.should.throw(err);
+                    call(false).should.throw(err);
                 });
 
                 it('should not throw for setting it without client materials', () => {

--- a/packages/caliper-tests-integration/fabric_tests/initByChannel.js
+++ b/packages/caliper-tests-integration/fabric_tests/initByChannel.js
@@ -1,0 +1,82 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const { WorkloadModuleBase } = require('@hyperledger/caliper-core');
+
+/**
+ * Workload module for initializing the SUT with various marbles.
+ */
+class MarblesInitByChannelWorkload extends WorkloadModuleBase {
+    /**
+     * Initializes the parameters of the marbles workload.
+     */
+    constructor() {
+        super();
+        this.txIndex = -1;
+        this.colors = ['red', 'blue', 'green', 'black', 'white', 'pink', 'rainbow'];
+        this.owners = ['Alice', 'Bob', 'Claire', 'David'];
+    }
+
+    /**
+     * Initialize the workload module with the given parameters.
+     * @param {number} workerIndex The 0-based index of the worker instantiating the workload module.
+     * @param {number} totalWorkers The total number of workers participating in the round.
+     * @param {number} roundIndex The 0-based index of the currently executing round.
+     * @param {Object} roundArguments The user-provided arguments for the round from the benchmark configuration file.
+     * @param {BlockchainConnector} sutAdapter The adapter of the underlying SUT.
+     * @param {Object} sutContext The custom context object provided by the SUT adapter.
+     * @async
+     */
+    async initializeWorkloadModule(workerIndex, totalWorkers, roundIndex, roundArguments, sutAdapter, sutContext) {
+        await super.initializeWorkloadModule(workerIndex, totalWorkers, roundIndex, roundArguments, sutAdapter, sutContext);
+
+        if (!this.roundArguments.marblePrefix) {
+            throw new Error(`Argument "marblePrefix" is missing from benchmark configuration`);
+        }
+    }
+
+    /**
+     * Assemble TXs for creating new marbles.
+     * @return {Promise<TxStatus[]>}
+     */
+    async submitTransaction() {
+        this.txIndex++;
+
+        const marbleName = `${this.roundArguments.marblePrefix}_${this.roundIndex}_${this.workerIndex}_${this.txIndex}`;
+        let marbleColor = this.colors[this.txIndex % this.colors.length];
+        let marbleSize = (((this.txIndex % 10) + 1) * 10).toString(); // [10, 100]
+        let marbleOwner = this.owners[this.txIndex % this.owners.length];
+
+        let args = {
+            contractFunction: 'initMarble',
+            channel: this.txIndex % 2 === 0 ? 'mychannel' : 'yourchannel',
+            contractArguments: [marbleName, marbleColor, marbleSize, marbleOwner],
+        };
+
+        let targetCC = 'marbles';
+        return this.sutAdapter.invokeSmartContract(targetCC, 'v0', args, 5);
+    }
+}
+
+/**
+ * Create a new instance of the workload module.
+ * @return {WorkloadModuleInterface}
+ */
+function createWorkloadModule() {
+    return new MarblesInitByChannelWorkload();
+}
+
+module.exports.createWorkloadModule = createWorkloadModule;

--- a/packages/caliper-tests-integration/fabric_tests/phase4/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase4/benchconfig.yaml
@@ -25,11 +25,23 @@ test:
           module: ./../init.js
           arguments:
               marblePrefix: marbles_phase_4
-    - label: query
+    - label: query1
       txNumber: 50
       rateControl: { type: 'linear-rate', opts: { startingTps: 5, finishingTps: 10 } }
       workload:
         module: ./../query.js
+    - label: init2
+      txNumber: 50
+      rateControl: { type: 'fixed-rate', opts: { tps: 5 } }
+      workload:
+          module: ./../initByChannel.js
+          arguments:
+              marblePrefix: marbles_phase_4
+    - label: query2
+      txNumber: 50
+      rateControl: { type: 'linear-rate', opts: { startingTps: 5, finishingTps: 10 } }
+      workload:
+        module: ./../queryByChannel.js
 observer:
     interval: 1
     type: prometheus

--- a/packages/caliper-tests-integration/fabric_tests/phase4/networkconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase4/networkconfig.yaml
@@ -60,9 +60,6 @@ channels:
         - id: marbles
           contractID: mymarbles
           version: v0
-          language: node
-          path: src/marbles/node
-          metadataPath: src/marbles/node/metadata
     yourchannel:
         created: true
         orderers:
@@ -78,9 +75,6 @@ channels:
         - id: marbles
           contractID: yourmarbles
           version: v0
-          language: golang
-          path: marbles/go
-          metadataPath: src/marbles/go/metadata
 
 organizations:
     Org1:

--- a/packages/caliper-tests-integration/fabric_tests/phase5/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase5/benchconfig.yaml
@@ -25,11 +25,23 @@ test:
           module: ./../init.js
           arguments:
               marblePrefix: marbles_phase_5
-    - label: query
+    - label: query1
       txNumber: 25
       rateControl: { type: 'linear-rate', opts: { startingTps: 5, finishingTps: 10 } }
       workload:
         module: ./../query.js
+    - label: init2
+      txNumber: 25
+      rateControl: { type: 'fixed-rate', opts: { tps: 5 } }
+      workload:
+          module: ./../initByChannel.js
+          arguments:
+              marblePrefix: marbles_phase_5
+    - label: query2
+      txNumber: 25
+      rateControl: { type: 'linear-rate', opts: { startingTps: 5, finishingTps: 10 } }
+      workload:
+        module: ./../queryByChannel.js
 observer:
     interval: 1
     type: prometheus

--- a/packages/caliper-tests-integration/fabric_tests/phase5/networkconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase5/networkconfig.yaml
@@ -60,9 +60,6 @@ channels:
         - id: marbles
           contractID: mymarbles
           version: v0
-          language: node
-          path: src/marbles/node
-          metadataPath: src/marbles/node/metadata
     yourchannel:
         created: true
         orderers:
@@ -78,9 +75,6 @@ channels:
         - id: marbles
           contractID: yourmarbles
           version: v0
-          language: golang
-          path: marbles/go
-          metadataPath: src/marbles/go/metadata
 
 organizations:
     Org1:

--- a/packages/caliper-tests-integration/fabric_tests/phase6/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase6/benchconfig.yaml
@@ -25,11 +25,23 @@ test:
           module: ./../init.js
           arguments:
               marblePrefix: marbles_phase_6
-    - label: query
+    - label: query1
       txNumber: 25
       rateControl: { type: 'linear-rate', opts: { startingTps: 5, finishingTps: 10 } }
       workload:
         module: ./../query.js
+    - label: init2
+      txNumber: 25
+      rateControl: { type: 'fixed-rate', opts: { tps: 5 } }
+      workload:
+          module: ./../initByChannel.js
+          arguments:
+              marblePrefix: marbles_phase_6
+    - label: query2
+      txNumber: 25
+      rateControl: { type: 'linear-rate', opts: { startingTps: 5, finishingTps: 10 } }
+      workload:
+        module: ./../queryByChannel.js
 observer:
     interval: 1
     type: prometheus

--- a/packages/caliper-tests-integration/fabric_tests/phase6/networkconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase6/networkconfig.yaml
@@ -60,9 +60,6 @@ channels:
         - id: marbles
           contractID: mymarbles
           version: v0
-          language: node
-          path: src/marbles/node
-          metadataPath: src/marbles/node/metadata
     yourchannel:
         created: true
         orderers:
@@ -78,9 +75,6 @@ channels:
         - id: marbles
           contractID: yourmarbles
           version: v0
-          language: golang
-          path: marbles/go
-          metadataPath: src/marbles/go/metadata
 
 organizations:
     Org1:

--- a/packages/caliper-tests-integration/fabric_tests/phase7/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase7/benchconfig.yaml
@@ -24,14 +24,14 @@ test:
       workload:
           module: ./../init.js
           arguments:
-              marblePrefix: marbles_phase_5
+              marblePrefix: marbles_phase_7
     - label: init2
       txNumber: 200
       rateControl: { type: 'fixed-feedback-rate', opts: { tps: 20, maximum_transaction_load: 5 } }
       workload:
           module: ./../init.js
           arguments:
-              marblePrefix: marbles_phase_5
+              marblePrefix: marbles_phase_7
     - label: query
       txNumber: 100
       rateControl: { type: 'linear-rate', opts: { startingTps: 10, finishingTps: 20 } }

--- a/packages/caliper-tests-integration/fabric_tests/queryByChannel.js
+++ b/packages/caliper-tests-integration/fabric_tests/queryByChannel.js
@@ -1,0 +1,60 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const { WorkloadModuleBase } = require('@hyperledger/caliper-core');
+
+/**
+ * Workload module for querying the SUT for various marbles.
+ */
+class MarblesQueryByChannelWorkload extends WorkloadModuleBase {
+    /**
+     * Initializes the parameters of the marbles workload.
+     */
+    constructor() {
+        super();
+        this.txIndex = -1;
+        this.owners = ['Alice', 'Bob', 'Claire', 'David'];
+    }
+
+    /**
+     * Assemble TXs for querying existing marbles based on their owners.
+     * @return {Promise<TxStatus[]>}
+     */
+    async submitTransaction() {
+        this.txIndex++;
+        let marbleOwner = this.owners[this.txIndex % this.owners.length];
+
+        let args = {
+            channel: this.txIndex % 2 === 0 ? 'mychannel' : 'yourchannel',
+            contractFunction: 'queryMarblesByOwner',
+            contractArguments: [marbleOwner],
+            targetPeers: ['peer0.org1.example.com']
+        };
+
+        let targetCC = 'marbles';
+        return this.sutAdapter.querySmartContract(targetCC, 'v0', args, 10);
+    }
+}
+
+/**
+ * Create a new instance of the workload module.
+ * @return {WorkloadModuleInterface}
+ */
+function createWorkloadModule() {
+    return new MarblesQueryByChannelWorkload();
+}
+
+module.exports.createWorkloadModule = createWorkloadModule;


### PR DESCRIPTION
Based on top of changes in #916

Closes #898 

PR changes within the Fabric connector:
- adds the ability to specify channel name in the transaction arguments
- modifies the gateway adaptors to enable selection of contracts in different channels