### PR TITLE
Enable transaction on named channels

### DIFF
--- a/packages/caliper-fabric/lib/connector-versions/v1/fabric-gateway.js
+++ b/packages/caliper-fabric/lib/connector-versions/v1/fabric-gateway.js
@@ -849,7 +849,7 @@ class Fabric extends BlockchainConnector {
             for (const info of walletInfoList) {
                 logger.info(`Retrieving and persisting contract map for identity ${info.label}`);
                 // Retrieve
-                const contractMap = await this._retrieveContractsForIdentity(info.label, orgWallet);
+                const contractMap = await this._retrieveContractMapForIdentity(info.label, orgWallet);
                 // Persist
                 this.userContracts.set(info.label, contractMap);
             }
@@ -863,7 +863,7 @@ class Fabric extends BlockchainConnector {
      * @returns {Map<FabricNetworkAPI.Contract>} A map of all Contracts retrieved from the client Gateway
      * @async
      */
-    async _retrieveContractsForIdentity(identity, wallet) {
+    async _retrieveContractMapForIdentity(identity, wallet) {
 
         // Retrieve the gateway for the passed user. The gateway object is persisted for easier cleanup.
         // - userName must match that created for wallet userId in init phases
@@ -881,7 +881,7 @@ class Fabric extends BlockchainConnector {
             const contracts = this.networkUtil.getContractsOfChannel(channel);
             for (const contract of contracts) {
                 const networkContract = await network.getContract(contract.id);
-                contractMap.set(contract.id, networkContract);
+                contractMap.set(`${channel}_${contract.id}`, networkContract);
             }
         }
 
@@ -1509,16 +1509,35 @@ class Fabric extends BlockchainConnector {
 
     /**
      * Perform a transaction using a Gateway contract
+     * @param {string} contractID The unique contract ID of the target contract.
+     * @param {string} contractVersion The version of the contract. Only used when explicitly naming a channel within the invokeSettings.
      * @param {object} context The context previously created by the Fabric adapter.
      * @param {ContractInvokeSettings | ContractQuerySettings} invokeSettings The settings associated with the transaction submission.
      * @param {boolean} isSubmit boolean flag to indicate if the transaction is a submit or evaluate
      * @return {Promise<TxStatus>} The result and stats of the transaction invocation.
      * @async
      */
-    async _performGatewayTransaction(context, invokeSettings, isSubmit) {
+    async _performGatewayTransaction(contractID, contractVersion, context, invokeSettings, isSubmit) {
+        // Populate the contract details for the invoke
+        if (invokeSettings.hasOwnProperty('channel')) {
+            invokeSettings.contractId = contractID;
+            invokeSettings.contractVersion = contractVersion;
+        } else {
+            const contractDetails = this.networkUtil.getContractDetails(contractID);
+            if (!contractDetails) {
+                throw new Error(`Could not find details for contract ID ${contractID}`);
+            }
+            invokeSettings.channel = contractDetails.channel;
+            invokeSettings.contractId = contractDetails.id;
+            invokeSettings.contractVersion = contractDetails.version;
+        }
+
+        if (!invokeSettings.invokerIdentity) {
+            invokeSettings.invokerIdentity = this.defaultInvoker;
+        }
 
         // Retrieve the existing contract and a client
-        const smartContract = await this._getUserContract(invokeSettings.invokerIdentity, invokeSettings.contractId);
+        const smartContract = await this._getUserContract(invokeSettings.invokerIdentity, invokeSettings.channel, invokeSettings.contractId);
 
         // Create a transaction
         const transaction = smartContract.createTransaction(invokeSettings.contractFunction);
@@ -1584,11 +1603,12 @@ class Fabric extends BlockchainConnector {
     /**
      * Get the named contract for a named user
      * @param {string} invokerIdentity the user identity for interacting with the contract
-     * @param {string} contractName the name of the contract to return
+     * @param {string} channelName the channel name the contract exists on
+     * @param {string} contractId the name of the contract to return
      * @returns {FabricNetworkAPI.Contract} A contract that may be used to submit or evaluate transactions
      * @async
      */
-    async _getUserContract(invokerIdentity, contractName) {
+    async _getUserContract(invokerIdentity, channelName, contractId) {
 
         // Determine the invoking user for this transaction
         let userName;
@@ -1606,11 +1626,11 @@ class Fabric extends BlockchainConnector {
         }
 
         // Retrieve the named Network Contract for the invoking user from the Map
-        const contract = contractSet.get(contractName);
+        const contract = contractSet.get(`${channelName}_${contractId}`);
 
         // If no contract found, there is a user configuration/test specification error, so it should terminate
         if (!contract) {
-            throw Error(`No contract named ${contractName} found!`);
+            throw Error(`Unable to find specified contract ${contractId} on channel ${channelName}!`);
         }
 
         return contract;
@@ -1722,20 +1742,7 @@ class Fabric extends BlockchainConnector {
         }
 
         for (const settings of settingsArray) {
-            const contractDetails = this.networkUtil.getContractDetails(contractID);
-            if (!contractDetails) {
-                throw new Error(`Could not find details for contract ID ${contractID}`);
-            }
-
-            settings.channel = contractDetails.channel;
-            settings.contractId = contractDetails.id;
-            settings.contractVersion = contractDetails.version;
-
-            if (!settings.invokerIdentity) {
-                settings.invokerIdentity = this.defaultInvoker;
-            }
-
-            promises.push(this._performGatewayTransaction(this.context, settings, true));
+            promises.push(this._performGatewayTransaction(contractID, contractVersion, this.context, settings, true));
         }
 
         return await Promise.all(promises);
@@ -1761,20 +1768,7 @@ class Fabric extends BlockchainConnector {
         }
 
         for (const settings of settingsArray) {
-            const contractDetails = this.networkUtil.getContractDetails(contractID);
-            if (!contractDetails) {
-                throw new Error(`Could not find details for contract ID ${contractID}`);
-            }
-
-            settings.channel = contractDetails.channel;
-            settings.contractId = contractDetails.id;
-            settings.contractVersion = contractDetails.version;
-
-            if (!settings.invokerIdentity) {
-                settings.invokerIdentity = this.defaultInvoker;
-            }
-
-            promises.push(this._performGatewayTransaction(this.context, settings, false));
+            promises.push(this._performGatewayTransaction(contractID, contractVersion, this.context, settings, false));
         }
 
         return await Promise.all(promises);

--- a/packages/caliper-fabric/lib/connector-versions/v1/fabric.js
+++ b/packages/caliper-fabric/lib/connector-versions/v1/fabric.js
@@ -2095,14 +2095,18 @@ class Fabric extends BlockchainConnector {
         }
 
         for (const settings of settingsArray) {
-            const contractDetails = this.networkUtil.getContractDetails(contractID);
-            if (!contractDetails) {
-                throw new Error(`Could not find details for contract ID ${contractID}`);
+            if (settings.hasOwnProperty('channel')) {
+                settings.contractId = contractID;
+                settings.contractVersion = contractVersion;
+            } else {
+                const contractDetails = this.networkUtil.getContractDetails(contractID);
+                if (!contractDetails) {
+                    throw new Error(`Could not find details for contract ID ${contractID}`);
+                }
+                settings.channel = contractDetails.channel;
+                settings.contractId = contractDetails.id;
+                settings.contractVersion = contractDetails.version;
             }
-
-            settings.channel = contractDetails.channel;
-            settings.contractId = contractDetails.id;
-            settings.contractVersion = contractDetails.version;
 
             if (!settings.invokerIdentity) {
                 settings.invokerIdentity = this.defaultInvoker;
@@ -2135,14 +2139,18 @@ class Fabric extends BlockchainConnector {
         }
 
         for (const settings of settingsArray) {
-            const contractDetails = this.networkUtil.getContractDetails(contractID);
-            if (!contractDetails) {
-                throw new Error(`Could not find details for contract ID ${contractID}`);
+            if (settings.hasOwnProperty('channel')) {
+                settings.contractId = contractID;
+                settings.contractVersion = contractVersion;
+            } else {
+                const contractDetails = this.networkUtil.getContractDetails(contractID);
+                if (!contractDetails) {
+                    throw new Error(`Could not find details for contract ID ${contractID}`);
+                }
+                settings.channel = contractDetails.channel;
+                settings.contractId = contractDetails.id;
+                settings.contractVersion = contractDetails.version;
             }
-
-            settings.channel = contractDetails.channel;
-            settings.contractId = contractDetails.id;
-            settings.contractVersion = contractDetails.version;
 
             if (!settings.invokerIdentity) {
                 settings.invokerIdentity = this.defaultInvoker;

--- a/packages/caliper-fabric/lib/connector-versions/v2/fabric-gateway.js
+++ b/packages/caliper-fabric/lib/connector-versions/v2/fabric-gateway.js
@@ -309,7 +309,7 @@ class Fabric extends BlockchainConnector {
             for (const identity of walletIdentities) {
                 logger.info(`Retrieving and persisting contract map for identity ${identity}`);
                 // Retrieve
-                const contractMap = await this._retrieveContractsForIdentity(identity, orgWallet);
+                const contractMap = await this._retrieveContractMapForIdentity(identity, orgWallet);
                 // Persist
                 this.userContracts.set(identity, contractMap);
             }
@@ -318,15 +318,15 @@ class Fabric extends BlockchainConnector {
     }
 
     /**
-     * Retrieve all Contracts from the passed client gateway object
+     * Retrieve all Contracts using a passed identity and organization wallet
      * @param {string} identity, the unique client identity name
      * @param {FileSystemWallet | InMemoryWallet} wallet, the wallet that holds the passed identity name
      * @returns {Map<Contract>} A map of all Contracts retrieved from the client Gateway
      * @async
      */
-    async _retrieveContractsForIdentity(identity, wallet) {
+    async _retrieveContractMapForIdentity(identity, wallet) {
         logger.debug('Entering _retrieveContractsForIdentity');
-        // Retrieve the gateway for the passed user. The gateway object is persisted for easier cleanup.
+        // Retrieve the gateway for the passed identity. The gateway object is persisted for easier cleanup.
         // - userName must match that created for wallet userId in init phases
         const gateway = await this._retrieveUserGateway(identity, wallet);
         this.userGateways.set(identity, gateway);
@@ -342,7 +342,7 @@ class Fabric extends BlockchainConnector {
             const contracts = this.networkUtil.getContractsOfChannel(channel);
             for (const contract of contracts) {
                 const networkContract = await network.getContract(contract.id);
-                contractMap.set(contract.id, networkContract);
+                contractMap.set(`${channel}_${contract.id}`, networkContract);
             }
         }
 
@@ -452,16 +452,34 @@ class Fabric extends BlockchainConnector {
 
     /**
      * Perform a transaction using a Gateway contract
-     * @param {object} context The context previously created by the Fabric adapter.
+     * @param {string} contractID The unique contract ID of the target contract.
+     * @param {string} contractVersion The version of the contract. Only used when explicitly naming a channel within the invokeSettings.
      * @param {ContractInvokeSettings} invokeSettings The settings associated with the transaction submission.
      * @param {boolean} isSubmit boolean flag to indicate if the transaction is a submit or evaluate
      * @return {Promise<TxStatus>} The result and stats of the transaction invocation.
      * @async
      */
-    async _performGatewayTransaction(context, invokeSettings, isSubmit) {
+    async _performGatewayTransaction(contractID, contractVersion, invokeSettings, isSubmit) {
+        // Populate the contract details for the invoke
+        if (invokeSettings.hasOwnProperty('channel')) {
+            invokeSettings.contractId = contractID;
+            invokeSettings.contractVersion = contractVersion;
+        } else {
+            const contractDetails = this.networkUtil.getContractDetails(contractID);
+            if (!contractDetails) {
+                throw new Error(`Could not find details for contract ID ${contractID}`);
+            }
+            invokeSettings.channel = contractDetails.channel;
+            invokeSettings.contractId = contractDetails.id;
+            invokeSettings.contractVersion = contractDetails.version;
+        }
 
-        // Retrieve the existing contract and a client
-        const smartContract = await this._getUserContract(invokeSettings.invokerIdentity, invokeSettings.contractId);
+        if (!invokeSettings.invokerIdentity) {
+            invokeSettings.invokerIdentity = this.defaultInvoker;
+        }
+
+        // Retrieve the existing contract for the invokerIdentity
+        const smartContract = await this._getUserContract(invokeSettings.invokerIdentity, invokeSettings.channel, invokeSettings.contractId);
 
         // Create a transaction
         const transaction = smartContract.createTransaction(invokeSettings.contractFunction);
@@ -496,15 +514,15 @@ class Fabric extends BlockchainConnector {
         try {
             let result;
             if (isSubmit) {
-                if (context.engine) {
-                    context.engine.submitCallback(1);
+                if (this.context.engine) {
+                    this.context.engine.submitCallback(1);
                 }
                 invokeStatus.Set('request_type', 'transaction');
                 result = await transaction.submit(...invokeSettings.contractArguments);
             } else {
                 const countAsLoad = invokeSettings.countAsLoad === undefined ? this.configCountQueryAsLoad : invokeSettings.countAsLoad;
-                if (context.engine && countAsLoad) {
-                    context.engine.submitCallback(1);
+                if (this.context.engine && countAsLoad) {
+                    this.context.engine.submitCallback(1);
                 }
                 invokeStatus.Set('request_type', 'query');
                 result = await transaction.evaluate(...invokeSettings.contractArguments);
@@ -526,11 +544,12 @@ class Fabric extends BlockchainConnector {
     /**
      * Get the named contract for a named user
      * @param {string} invokerIdentity the user identity for interacting with the contract
-     * @param {string} contractName the name of the contract to return
+     * @param {string} channelName the channel name the contract exists on
+     * @param {string} contractId the name of the contract to return
      * @returns {FabricNetworkAPI.Contract} A contract that may be used to submit or evaluate transactions
      * @async
      */
-    async _getUserContract(invokerIdentity, contractName) {
+    async _getUserContract(invokerIdentity, channelName, contractId) {
         logger.debug('Entering _getUserContract');
         // Determine the invoking user for this transaction
         let userName;
@@ -548,11 +567,11 @@ class Fabric extends BlockchainConnector {
         }
 
         // Retrieve the named Network Contract for the invoking user from the Map
-        const contract = contractSet.get(contractName);
+        const contract = contractSet.get(`${channelName}_${contractId}`);
 
         // If no contract found, there is a user configuration/test specification error, so it should terminate
         if (!contract) {
-            throw Error(`No contract named ${contractName} found!`);
+            throw Error(`Unable to find specified contract ${contractId} on channel ${channelName}!`);
         }
 
         logger.debug('Exiting _getUserContract');
@@ -635,20 +654,7 @@ class Fabric extends BlockchainConnector {
         }
 
         for (const settings of settingsArray) {
-            const contractDetails = this.networkUtil.getContractDetails(contractID);
-            if (!contractDetails) {
-                throw new Error(`Could not find details for contract ID ${contractID}`);
-            }
-
-            settings.channel = contractDetails.channel;
-            settings.contractId = contractDetails.id;
-            settings.contractVersion = contractDetails.version;
-
-            if (!settings.invokerIdentity) {
-                settings.invokerIdentity = this.defaultInvoker;
-            }
-
-            promises.push(this._performGatewayTransaction(this.context, settings, true));
+            promises.push(this._performGatewayTransaction(contractID, contractVersion, settings, true));
         }
 
         return await Promise.all(promises);
@@ -674,20 +680,7 @@ class Fabric extends BlockchainConnector {
         }
 
         for (const settings of settingsArray) {
-            const contractDetails = this.networkUtil.getContractDetails(contractID);
-            if (!contractDetails) {
-                throw new Error(`Could not find details for contract ID ${contractID}`);
-            }
-
-            settings.channel = contractDetails.channel;
-            settings.contractId = contractDetails.id;
-            settings.contractVersion = contractDetails.version;
-
-            if (!settings.invokerIdentity) {
-                settings.invokerIdentity = this.defaultInvoker;
-            }
-
-            promises.push(this._performGatewayTransaction(this.context, settings, false));
+            promises.push(this._performGatewayTransaction(contractID, contractVersion, settings, false));
         }
 
         return await Promise.all(promises);

--- a/packages/caliper-fabric/lib/connector-versions/v2/fabric.js
+++ b/packages/caliper-fabric/lib/connector-versions/v2/fabric.js
@@ -2095,14 +2095,18 @@ class Fabric extends BlockchainConnector {
         }
 
         for (const settings of settingsArray) {
-            const contractDetails = this.networkUtil.getContractDetails(contractID);
-            if (!contractDetails) {
-                throw new Error(`Could not find details for contract ID ${contractID}`);
+            if (settings.hasOwnProperty('channel')) {
+                settings.contractId = contractID;
+                settings.contractVersion = contractVersion;
+            } else {
+                const contractDetails = this.networkUtil.getContractDetails(contractID);
+                if (!contractDetails) {
+                    throw new Error(`Could not find details for contract ID ${contractID}`);
+                }
+                settings.channel = contractDetails.channel;
+                settings.contractId = contractDetails.id;
+                settings.contractVersion = contractDetails.version;
             }
-
-            settings.channel = contractDetails.channel;
-            settings.contractId = contractDetails.id;
-            settings.contractVersion = contractDetails.version;
 
             if (!settings.invokerIdentity) {
                 settings.invokerIdentity = this.defaultInvoker;
@@ -2135,14 +2139,18 @@ class Fabric extends BlockchainConnector {
         }
 
         for (const settings of settingsArray) {
-            const contractDetails = this.networkUtil.getContractDetails(contractID);
-            if (!contractDetails) {
-                throw new Error(`Could not find details for contract ID ${contractID}`);
+            if (settings.hasOwnProperty('channel')) {
+                settings.contractId = contractID;
+                settings.contractVersion = contractVersion;
+            } else {
+                const contractDetails = this.networkUtil.getContractDetails(contractID);
+                if (!contractDetails) {
+                    throw new Error(`Could not find details for contract ID ${contractID}`);
+                }
+                settings.channel = contractDetails.channel;
+                settings.contractId = contractDetails.id;
+                settings.contractVersion = contractDetails.version;
             }
-
-            settings.channel = contractDetails.channel;
-            settings.contractId = contractDetails.id;
-            settings.contractVersion = contractDetails.version;
 
             if (!settings.invokerIdentity) {
                 settings.invokerIdentity = this.defaultInvoker;

--- a/packages/caliper-tests-integration/fabric_tests/initByChannel.js
+++ b/packages/caliper-tests-integration/fabric_tests/initByChannel.js
@@ -1,0 +1,82 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const { WorkloadModuleBase } = require('@hyperledger/caliper-core');
+
+/**
+ * Workload module for initializing the SUT with various marbles.
+ */
+class MarblesInitByChannelWorkload extends WorkloadModuleBase {
+    /**
+     * Initializes the parameters of the marbles workload.
+     */
+    constructor() {
+        super();
+        this.txIndex = -1;
+        this.colors = ['red', 'blue', 'green', 'black', 'white', 'pink', 'rainbow'];
+        this.owners = ['Alice', 'Bob', 'Claire', 'David'];
+    }
+
+    /**
+     * Initialize the workload module with the given parameters.
+     * @param {number} workerIndex The 0-based index of the worker instantiating the workload module.
+     * @param {number} totalWorkers The total number of workers participating in the round.
+     * @param {number} roundIndex The 0-based index of the currently executing round.
+     * @param {Object} roundArguments The user-provided arguments for the round from the benchmark configuration file.
+     * @param {BlockchainConnector} sutAdapter The adapter of the underlying SUT.
+     * @param {Object} sutContext The custom context object provided by the SUT adapter.
+     * @async
+     */
+    async initializeWorkloadModule(workerIndex, totalWorkers, roundIndex, roundArguments, sutAdapter, sutContext) {
+        await super.initializeWorkloadModule(workerIndex, totalWorkers, roundIndex, roundArguments, sutAdapter, sutContext);
+
+        if (!this.roundArguments.marblePrefix) {
+            throw new Error(`Argument "marblePrefix" is missing from benchmark configuration`);
+        }
+    }
+
+    /**
+     * Assemble TXs for creating new marbles.
+     * @return {Promise<TxStatus[]>}
+     */
+    async submitTransaction() {
+        this.txIndex++;
+
+        const marbleName = `${this.roundArguments.marblePrefix}_${this.roundIndex}_${this.workerIndex}_${this.txIndex}`;
+        let marbleColor = this.colors[this.txIndex % this.colors.length];
+        let marbleSize = (((this.txIndex % 10) + 1) * 10).toString(); // [10, 100]
+        let marbleOwner = this.owners[this.txIndex % this.owners.length];
+
+        let args = {
+            contractFunction: 'initMarble',
+            channel: this.txIndex % 2 === 0 ? 'mychannel' : 'yourchannel',
+            contractArguments: [marbleName, marbleColor, marbleSize, marbleOwner],
+        };
+
+        let targetCC = 'marbles';
+        return this.sutAdapter.invokeSmartContract(targetCC, 'v0', args, 5);
+    }
+}
+
+/**
+ * Create a new instance of the workload module.
+ * @return {WorkloadModuleInterface}
+ */
+function createWorkloadModule() {
+    return new MarblesInitByChannelWorkload();
+}
+
+module.exports.createWorkloadModule = createWorkloadModule;

--- a/packages/caliper-tests-integration/fabric_tests/phase4/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase4/benchconfig.yaml
@@ -25,11 +25,23 @@ test:
           module: ./../init.js
           arguments:
               marblePrefix: marbles_phase_4
-    - label: query
+    - label: query1
       txNumber: 50
       rateControl: { type: 'linear-rate', opts: { startingTps: 5, finishingTps: 10 } }
       workload:
         module: ./../query.js
+    - label: init2
+      txNumber: 50
+      rateControl: { type: 'fixed-rate', opts: { tps: 5 } }
+      workload:
+          module: ./../initByChannel.js
+          arguments:
+              marblePrefix: marbles_phase_4
+    - label: query2
+      txNumber: 50
+      rateControl: { type: 'linear-rate', opts: { startingTps: 5, finishingTps: 10 } }
+      workload:
+        module: ./../queryByChannel.js
 observer:
     interval: 1
     type: prometheus

--- a/packages/caliper-tests-integration/fabric_tests/phase4/networkconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase4/networkconfig.yaml
@@ -55,14 +55,10 @@ channels:
                 eventSource: true
             peer0.org2.example.com:
                 eventSource: true
-
         contracts:
         - id: marbles
           contractID: mymarbles
           version: v0
-          language: node
-          path: src/marbles/node
-          metadataPath: src/marbles/node/metadata
     yourchannel:
         created: true
         orderers:
@@ -73,14 +69,10 @@ channels:
                 eventSource: true
             peer0.org2.example.com:
                 eventSource: true
-
         contracts:
         - id: marbles
           contractID: yourmarbles
           version: v0
-          language: golang
-          path: marbles/go
-          metadataPath: src/marbles/go/metadata
 
 organizations:
     Org1:

--- a/packages/caliper-tests-integration/fabric_tests/phase5/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase5/benchconfig.yaml
@@ -25,11 +25,23 @@ test:
           module: ./../init.js
           arguments:
               marblePrefix: marbles_phase_5
-    - label: query
+    - label: query1
       txNumber: 25
       rateControl: { type: 'linear-rate', opts: { startingTps: 5, finishingTps: 10 } }
       workload:
         module: ./../query.js
+    - label: init2
+      txNumber: 25
+      rateControl: { type: 'fixed-rate', opts: { tps: 5 } }
+      workload:
+          module: ./../initByChannel.js
+          arguments:
+              marblePrefix: marbles_phase_5
+    - label: query2
+      txNumber: 25
+      rateControl: { type: 'linear-rate', opts: { startingTps: 5, finishingTps: 10 } }
+      workload:
+        module: ./../queryByChannel.js
 observer:
     interval: 1
     type: prometheus

--- a/packages/caliper-tests-integration/fabric_tests/phase5/networkconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase5/networkconfig.yaml
@@ -55,14 +55,10 @@ channels:
                 eventSource: true
             peer0.org2.example.com:
                 eventSource: true
-
         contracts:
         - id: marbles
           contractID: mymarbles
           version: v0
-          language: node
-          path: src/marbles/node
-          metadataPath: src/marbles/node/metadata
     yourchannel:
         created: true
         orderers:
@@ -73,14 +69,10 @@ channels:
                 eventSource: true
             peer0.org2.example.com:
                 eventSource: true
-
         contracts:
         - id: marbles
           contractID: yourmarbles
           version: v0
-          language: golang
-          path: marbles/go
-          metadataPath: src/marbles/go/metadata
 
 organizations:
     Org1:

--- a/packages/caliper-tests-integration/fabric_tests/phase6/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase6/benchconfig.yaml
@@ -25,11 +25,23 @@ test:
           module: ./../init.js
           arguments:
               marblePrefix: marbles_phase_6
-    - label: query
+    - label: query1
       txNumber: 25
       rateControl: { type: 'linear-rate', opts: { startingTps: 5, finishingTps: 10 } }
       workload:
         module: ./../query.js
+    - label: init2
+      txNumber: 25
+      rateControl: { type: 'fixed-rate', opts: { tps: 5 } }
+      workload:
+          module: ./../initByChannel.js
+          arguments:
+              marblePrefix: marbles_phase_6
+    - label: query2
+      txNumber: 25
+      rateControl: { type: 'linear-rate', opts: { startingTps: 5, finishingTps: 10 } }
+      workload:
+        module: ./../queryByChannel.js
 observer:
     interval: 1
     type: prometheus

--- a/packages/caliper-tests-integration/fabric_tests/phase6/networkconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase6/networkconfig.yaml
@@ -55,14 +55,10 @@ channels:
                 eventSource: true
             peer0.org2.example.com:
                 eventSource: true
-
         contracts:
         - id: marbles
           contractID: mymarbles
           version: v0
-          language: node
-          path: src/marbles/node
-          metadataPath: src/marbles/node/metadata
     yourchannel:
         created: true
         orderers:
@@ -73,14 +69,10 @@ channels:
                 eventSource: true
             peer0.org2.example.com:
                 eventSource: true
-
         contracts:
         - id: marbles
           contractID: yourmarbles
           version: v0
-          language: golang
-          path: marbles/go
-          metadataPath: src/marbles/go/metadata
 
 organizations:
     Org1:

--- a/packages/caliper-tests-integration/fabric_tests/queryByChannel.js
+++ b/packages/caliper-tests-integration/fabric_tests/queryByChannel.js
@@ -1,0 +1,60 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const { WorkloadModuleBase } = require('@hyperledger/caliper-core');
+
+/**
+ * Workload module for querying the SUT for various marbles.
+ */
+class MarblesQueryByChannelWorkload extends WorkloadModuleBase {
+    /**
+     * Initializes the parameters of the marbles workload.
+     */
+    constructor() {
+        super();
+        this.txIndex = -1;
+        this.owners = ['Alice', 'Bob', 'Claire', 'David'];
+    }
+
+    /**
+     * Assemble TXs for querying existing marbles based on their owners.
+     * @return {Promise<TxStatus[]>}
+     */
+    async submitTransaction() {
+        this.txIndex++;
+        let marbleOwner = this.owners[this.txIndex % this.owners.length];
+
+        let args = {
+            channel: this.txIndex % 2 === 0 ? 'mychannel' : 'yourchannel',
+            contractFunction: 'queryMarblesByOwner',
+            contractArguments: [marbleOwner],
+            targetPeers: ['peer0.org1.example.com']
+        };
+
+        let targetCC = 'marbles';
+        return this.sutAdapter.querySmartContract(targetCC, 'v0', args, 10);
+    }
+}
+
+/**
+ * Create a new instance of the workload module.
+ * @return {WorkloadModuleInterface}
+ */
+function createWorkloadModule() {
+    return new MarblesQueryByChannelWorkload();
+}
+
+module.exports.createWorkloadModule = createWorkloadModule;


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

Closes #898

PR changes within the Fabric connector:

adds the ability to specify channel name in the transaction arguments
modifies the gateway adaptors to enable selection of contracts in different channels