### PR TITLE
Make connectors event oriented

### DIFF
--- a/packages/caliper-core/lib/common/core/blockchain-connector.js
+++ b/packages/caliper-core/lib/common/core/blockchain-connector.js
@@ -14,10 +14,13 @@
 
 'use strict';
 
+const { EventEmitter } = require('events');
+const Events = require('./../utils/constants').Events.Connector;
+
 /**
  * Base class for all blockchain connectors
  */
-class BlockchainConnector {
+class BlockchainConnector extends EventEmitter {
 
     /**
      * Constructor
@@ -25,8 +28,27 @@ class BlockchainConnector {
      * @param {string} bcType The target SUT type
      */
     constructor(workerIndex, bcType) {
+        super();
         this.workerIndex = workerIndex;
         this.bcType = bcType;
+    }
+
+    /**
+     * Raises the "txsSubmitted" event.
+     * @param {number} count The number of TXs submitted. Passed to the raised event.
+     * @protected
+     */
+    _onTxsSubmitted(count) {
+        this.emit(Events.TxsSubmitted, count);
+    }
+
+    /**
+     * Raises the "txsFinished" event.
+     * @param {TxStatus|TxStatus[]} txResults The array of TX results. Passed to the raised event.
+     * @protected
+     */
+    _onTxsFinished(txResults) {
+        this.emit(Events.TxsFinished, txResults);
     }
 
     /**

--- a/packages/caliper-core/lib/common/messages/txUpdateMessage.js
+++ b/packages/caliper-core/lib/common/messages/txUpdateMessage.js
@@ -31,6 +31,9 @@ class TxUpdateMessage extends Message {
      */
     constructor(sender, recipients, content, date = undefined, error = undefined) {
         super(sender, recipients, MessageTypes.TxUpdate, content, date, error);
+
+        // the local observers needs this content, deep-deep down
+        this.content.type = MessageTypes.TxUpdate;
     }
 }
 

--- a/packages/caliper-core/lib/common/utils/constants.js
+++ b/packages/caliper-core/lib/common/utils/constants.js
@@ -40,5 +40,11 @@ module.exports = {
         Connector: 'ConnectorFactory',
         WorkerMessenger: 'createWorkerMessenger',
         ManagerMessenger: 'createManagerMessenger'
+    },
+    Events: {
+        Connector: {
+            TxsSubmitted: 'txsSubmitted',
+            TxsFinished: 'txsFinished'
+        }
     }
 };

--- a/packages/caliper-core/lib/manager/orchestrators/worker-orchestrator.js
+++ b/packages/caliper-core/lib/manager/orchestrators/worker-orchestrator.js
@@ -110,7 +110,7 @@ class WorkerOrchestrator {
 
         this.messenger.on(MessageTypes.TxUpdate, async (message) => {
             logger.debug('Dealing with txUpdate message');
-            self.pushUpdate(message.from, message.data);
+            self.pushUpdate(message.getSender(), message.getContent());
         });
 
         this.messenger.on(MessageTypes.TestResult, async (message) => {

--- a/packages/caliper-core/lib/worker/workload/workloadModuleInterface.js
+++ b/packages/caliper-core/lib/worker/workload/workloadModuleInterface.js
@@ -34,7 +34,6 @@ class WorkloadModuleInterface {
 
     /**
      * Assemble the next TX content(s) and submit it to the SUT adapter.
-     * @return {Promise<TxStatus[]>} The promises for the TX results as returned by the SUT adapter.
      * @async
      */
     async submitTransaction() {

--- a/packages/caliper-ethereum/lib/ethereum-connector.js
+++ b/packages/caliper-ethereum/lib/ethereum-connector.js
@@ -198,9 +198,13 @@ class EthereumConnector extends BlockchainConnector {
         }
         let promises = [];
         invocations.forEach((item, index) => {
+            this._onTxsSubmitted(1);
             promises.push(this.sendTransaction(this.context, contractID, contractVer, item, timeout));
         });
-        return Promise.all(promises);
+
+        const results = await Promise.all(promises);
+        this._onTxsFinished(results);
+        return results;
     }
 
     /**
@@ -221,9 +225,13 @@ class EthereumConnector extends BlockchainConnector {
         let promises = [];
         invocations.forEach((item, index) => {
             item.isView = true;
+            this._onTxsSubmitted(1);
             promises.push(this.sendTransaction(this.context, contractID, contractVer, item, timeout));
         });
-        return Promise.all(promises);
+
+        const results = await Promise.all(promises);
+        this._onTxsFinished(results);
+        return results;
     }
 
     /**
@@ -240,7 +248,6 @@ class EthereumConnector extends BlockchainConnector {
         let params = {from: context.fromAddress};
         let contractInfo = context.contracts[contractID];
 
-        context.engine.submitCallback(1);
         let receipt = null;
         let methodType = 'send';
         if (methodCall.isView) {
@@ -315,7 +322,10 @@ class EthereumConnector extends BlockchainConnector {
             args: [key],
             isView: true
         };
-        return this.sendTransaction(this.context, contractID, contractVer, methodCall, 60);
+        this._onTxsSubmitted(1);
+        const result = await this.sendTransaction(this.context, contractID, contractVer, methodCall, 60);
+        this._onTxsFinished(result);
+        return result;
     }
 
     /**

--- a/packages/caliper-fabric/lib/connector-versions/v1/fabric-gateway.js
+++ b/packages/caliper-fabric/lib/connector-versions/v1/fabric-gateway.js
@@ -1511,13 +1511,12 @@ class Fabric extends BlockchainConnector {
      * Perform a transaction using a Gateway contract
      * @param {string} contractID The unique contract ID of the target contract.
      * @param {string} contractVersion The version of the contract. Only used when explicitly naming a channel within the invokeSettings.
-     * @param {object} context The context previously created by the Fabric adapter.
      * @param {ContractInvokeSettings | ContractQuerySettings} invokeSettings The settings associated with the transaction submission.
      * @param {boolean} isSubmit boolean flag to indicate if the transaction is a submit or evaluate
      * @return {Promise<TxStatus>} The result and stats of the transaction invocation.
      * @async
      */
-    async _performGatewayTransaction(contractID, contractVersion, context, invokeSettings, isSubmit) {
+    async _performGatewayTransaction(contractID, contractVersion, invokeSettings, isSubmit) {
         // Populate the contract details for the invoke
         if (invokeSettings.hasOwnProperty('channel')) {
             invokeSettings.contractId = contractID;
@@ -1575,16 +1574,9 @@ class Fabric extends BlockchainConnector {
         try {
             let result;
             if (isSubmit) {
-                if (context.engine) {
-                    context.engine.submitCallback(1);
-                }
                 invokeStatus.Set('request_type', 'transaction');
                 result = await transaction.submit(...invokeSettings.contractArguments);
             } else {
-                const countAsLoad = invokeSettings.countAsLoad === undefined ? this.configCountQueryAsLoad : invokeSettings.countAsLoad;
-                if (context.engine && countAsLoad) {
-                    context.engine.submitCallback(1);
-                }
                 invokeStatus.Set('request_type', 'query');
                 result = await transaction.evaluate(...invokeSettings.contractArguments);
             }
@@ -1742,10 +1734,13 @@ class Fabric extends BlockchainConnector {
         }
 
         for (const settings of settingsArray) {
-            promises.push(this._performGatewayTransaction(contractID, contractVersion, this.context, settings, true));
+            this._onTxsSubmitted(1);
+            promises.push(this._performGatewayTransaction(contractID, contractVersion, settings, true));
         }
 
-        return await Promise.all(promises);
+        const results = await Promise.all(promises);
+        this._onTxsFinished(results);
+        return results;
     }
 
     /**
@@ -1768,10 +1763,13 @@ class Fabric extends BlockchainConnector {
         }
 
         for (const settings of settingsArray) {
-            promises.push(this._performGatewayTransaction(contractID, contractVersion, this.context, settings, false));
+            this._onTxsSubmitted(1);
+            promises.push(this._performGatewayTransaction(contractID, contractVersion, settings, false));
         }
 
-        return await Promise.all(promises);
+        const results = await Promise.all(promises);
+        this._onTxsFinished(results);
+        return results;
     }
 
     /**

--- a/packages/caliper-fabric/lib/fabric-connector.js
+++ b/packages/caliper-fabric/lib/fabric-connector.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const { BlockchainConnector, CaliperUtils, ConfigUtil } = require('@hyperledger/caliper-core');
+const { BlockchainConnector, CaliperUtils, ConfigUtil, Constants } = require('@hyperledger/caliper-core');
 const ConfigValidator = require('./configValidator.js');
 const Logger = CaliperUtils.getLogger('fabric-connector');
 
@@ -80,6 +80,11 @@ const FabricConnector = class extends BlockchainConnector {
 
         const Fabric = require(modulePath);
         this.fabric = new Fabric(networkObject, workerIndex, bcType);
+
+        // propagate inside events through this decorator
+        const self = this;
+        this.fabric.on(Constants.Events.Connector.TxsSubmitted, count => self._onTxsSubmitted(count));
+        this.fabric.on(Constants.Events.Connector.TxsFinished, results => self._onTxsFinished(results));
     }
 
     /**

--- a/packages/caliper-fisco-bcos/lib/generateRawTransactions.js
+++ b/packages/caliper-fisco-bcos/lib/generateRawTransactions.js
@@ -21,11 +21,7 @@ const uuid = require('uuid/v4');
 const fiscoBcosApi = require('./fiscoBcosApi');
 const commLogger = CaliperUtils.getLogger('generateRawTransactions.js');
 
-module.exports.run = async function (fiscoBcosSettings, workspaceRoot, context, contractID, arg, file) {
-    if (context && context.engine) {
-        context.engine.submitCallback(1);
-    }
-
+module.exports.run = async function (fiscoBcosSettings, workspaceRoot, contractID, arg, file) {
     let smartContracts = fiscoBcosSettings.smartContracts;
     let address = findContractAddress(workspaceRoot, smartContracts, contractID);
     let account = fiscoBcosSettings.config.account;

--- a/packages/caliper-fisco-bcos/lib/invokeSmartContract.js
+++ b/packages/caliper-fisco-bcos/lib/invokeSmartContract.js
@@ -22,7 +22,7 @@ const fiscoBcosApi = require('./fiscoBcosApi');
 const { TxErrorEnum, findContractAddress } = require('./common');
 const commLogger = CaliperUtils.getLogger('invokeSmartContract.js');
 
-module.exports.run = async function (context, fiscoBcosSettings, contractID, fcn, args, workspaceRoot, readOnly = false) {
+module.exports.run = async function (fiscoBcosSettings, contractID, fcn, args, workspaceRoot, readOnly = false) {
     let smartContracts = fiscoBcosSettings.smartContracts;
     let address = findContractAddress(workspaceRoot, smartContracts, contractID);
     if (address === null) {
@@ -37,9 +37,6 @@ module.exports.run = async function (context, fiscoBcosSettings, contractID, fcn
     let receipt = null;
 
     try {
-        if (context && context.engine) {
-            context.engine.submitCallback(1);
-        }
 
         if (readOnly) {
             receipt = await fiscoBcosApi.call(networkConfig, account, address, fcn, args);

--- a/packages/caliper-tests-integration/besu_tests/caliper.yaml
+++ b/packages/caliper-tests-integration/besu_tests/caliper.yaml
@@ -15,7 +15,7 @@
 caliper:
     benchconfig: benchconfig.yaml
     networkconfig: networkconfig.json
-    txupdatetime: 1000
+    txupdatetime: 500
     workspace: ./
     report:
         path: ./report/report.html
@@ -43,7 +43,7 @@ caliper:
                 target: console
                 enabled: true
                 options:
-                    level: debug
+                    level: info
             file:
                 target: file
                 enabled: false

--- a/packages/caliper-tests-integration/besu_tests/open.js
+++ b/packages/caliper-tests-integration/besu_tests/open.js
@@ -108,12 +108,11 @@ class SimpleOpenWorkload extends WorkloadModuleBase {
 
     /**
      * Assemble TXs for opening new accounts.
-     * @return {Promise<TxStatus[]>}
      */
     async submitTransaction() {
         let args = this._generateWorkload();
         Logger.debug(`Worker ${this.workerIndex} for TX ${this.txIndex}: ${JSON.stringify(args)}`);
-        return this.sutAdapter.invokeSmartContract('simple', 'v0', args, 100);
+        await this.sutAdapter.invokeSmartContract('simple', 'v0', args, 100);
     }
 }
 

--- a/packages/caliper-tests-integration/besu_tests/query.js
+++ b/packages/caliper-tests-integration/besu_tests/query.js
@@ -89,7 +89,6 @@ class SimpleQueryWorkload extends WorkloadModuleBase {
 
     /**
      * Assemble TXs for querying accounts.
-     * @return {Promise<TxStatus[]>}
      */
     async submitTransaction() {
         const args = {
@@ -98,7 +97,7 @@ class SimpleQueryWorkload extends WorkloadModuleBase {
         };
 
         Logger.debug(`Worker ${this.workerIndex} TX parameters: ${JSON.stringify(args)}`);
-        return this.sutAdapter.querySmartContract('simple', 'v0', args, 100);
+        await this.sutAdapter.querySmartContract('simple', 'v0', args, 100);
     }
 }
 

--- a/packages/caliper-tests-integration/besu_tests/transfer.js
+++ b/packages/caliper-tests-integration/besu_tests/transfer.js
@@ -93,7 +93,6 @@ class SimpleTransferWorkload extends WorkloadModuleBase {
 
     /**
      * Assemble TXs for transferring money.
-     * @return {Promise<TxStatus[]>}
      */
     async submitTransaction() {
         const args = {
@@ -102,7 +101,7 @@ class SimpleTransferWorkload extends WorkloadModuleBase {
         };
 
         Logger.debug(`Worker ${this.workerIndex} TX parameters: ${JSON.stringify(args)}`);
-        return this.sutAdapter.invokeSmartContract('simple', 'v0', args, 100);
+        await this.sutAdapter.invokeSmartContract('simple', 'v0', args, 100);
     }
 }
 

--- a/packages/caliper-tests-integration/ethereum_tests/caliper.yaml
+++ b/packages/caliper-tests-integration/ethereum_tests/caliper.yaml
@@ -15,7 +15,7 @@
 caliper:
     benchconfig: benchconfig.yaml
     networkconfig: networkconfig.json
-    txupdatetime: 1000
+    txupdatetime: 500
     workspace: ./
     report:
         path: report.html
@@ -43,7 +43,7 @@ caliper:
                 target: console
                 enabled: true
                 options:
-                    level: debug
+                    level: info
             file:
                 target: file
                 enabled: false

--- a/packages/caliper-tests-integration/ethereum_tests/open.js
+++ b/packages/caliper-tests-integration/ethereum_tests/open.js
@@ -108,12 +108,11 @@ class SimpleOpenWorkload extends WorkloadModuleBase {
 
     /**
      * Assemble TXs for opening new accounts.
-     * @return {Promise<TxStatus[]>}
      */
     async submitTransaction() {
         let args = this._generateWorkload();
         Logger.debug(`Worker ${this.workerIndex} for TX ${this.txIndex}: ${JSON.stringify(args)}`);
-        return this.sutAdapter.invokeSmartContract('simple', 'v0', args, 100);
+        await this.sutAdapter.invokeSmartContract('simple', 'v0', args, 100);
     }
 }
 

--- a/packages/caliper-tests-integration/ethereum_tests/query.js
+++ b/packages/caliper-tests-integration/ethereum_tests/query.js
@@ -91,7 +91,6 @@ class SimpleQueryWorkload extends WorkloadModuleBase {
 
     /**
      * Assemble TXs for querying accounts.
-     * @return {Promise<TxStatus[]>}
      */
     async submitTransaction() {
         const args = {
@@ -100,7 +99,7 @@ class SimpleQueryWorkload extends WorkloadModuleBase {
         };
 
         Logger.debug(`Worker ${this.workerIndex} TX parameters: ${JSON.stringify(args)}`);
-        return this.sutAdapter.querySmartContract('simple', 'v0', args, 100);
+        await this.sutAdapter.querySmartContract('simple', 'v0', args, 100);
     }
 }
 

--- a/packages/caliper-tests-integration/ethereum_tests/transfer.js
+++ b/packages/caliper-tests-integration/ethereum_tests/transfer.js
@@ -93,7 +93,6 @@ class SimpleTransferWorkload extends WorkloadModuleBase {
 
     /**
      * Assemble TXs for transferring money.
-     * @return {Promise<TxStatus[]>}
      */
     async submitTransaction() {
         const args = {
@@ -102,7 +101,7 @@ class SimpleTransferWorkload extends WorkloadModuleBase {
         };
 
         Logger.debug(`Worker ${this.workerIndex} TX parameters: ${JSON.stringify(args)}`);
-        return this.sutAdapter.invokeSmartContract('simple', 'v0', args, 100);
+        await this.sutAdapter.invokeSmartContract('simple', 'v0', args, 100);
     }
 }
 

--- a/packages/caliper-tests-integration/fabric_docker_distributed_tests/init.js
+++ b/packages/caliper-tests-integration/fabric_docker_distributed_tests/init.js
@@ -32,7 +32,6 @@ class MarblesInitWorkload extends WorkloadModuleBase {
 
     /**
      * Assemble TXs for creating new marbles.
-     * @return {Promise<TxStatus[]>}
      */
     async submitTransaction() {
         this.txIndex++;
@@ -48,7 +47,7 @@ class MarblesInitWorkload extends WorkloadModuleBase {
         };
 
         let targetCC = this.txIndex % 2 === 0 ? 'mymarbles' : 'yourmarbles';
-        return this.sutAdapter.invokeSmartContract(targetCC, 'v0', args, 5);
+        await this.sutAdapter.invokeSmartContract(targetCC, 'v0', args, 5);
     }
 }
 

--- a/packages/caliper-tests-integration/fabric_docker_distributed_tests/query.js
+++ b/packages/caliper-tests-integration/fabric_docker_distributed_tests/query.js
@@ -31,7 +31,6 @@ class MarblesQueryWorkload extends WorkloadModuleBase {
 
     /**
      * Assemble TXs for querying existing marbles based on their owners.
-     * @return {Promise<TxStatus[]>}
      */
     async submitTransaction() {
         this.txIndex++;
@@ -43,7 +42,7 @@ class MarblesQueryWorkload extends WorkloadModuleBase {
         };
 
         let targetCC = this.txIndex % 2 === 0 ? 'mymarbles' : 'yourmarbles';
-        return this.sutAdapter.querySmartContract(targetCC, 'v0', args, 10);
+        await this.sutAdapter.querySmartContract(targetCC, 'v0', args, 10);
     }
 }
 

--- a/packages/caliper-tests-integration/fabric_docker_local_tests/init.js
+++ b/packages/caliper-tests-integration/fabric_docker_local_tests/init.js
@@ -48,7 +48,7 @@ class MarblesInitWorkload extends WorkloadModuleBase {
         };
 
         let targetCC = this.txIndex % 2 === 0 ? 'mymarbles' : 'yourmarbles';
-        return this.sutAdapter.invokeSmartContract(targetCC, 'v0', args, 5);
+        await this.sutAdapter.invokeSmartContract(targetCC, 'v0', args, 5);
     }
 }
 

--- a/packages/caliper-tests-integration/fabric_docker_local_tests/query.js
+++ b/packages/caliper-tests-integration/fabric_docker_local_tests/query.js
@@ -43,7 +43,7 @@ class MarblesQueryWorkload extends WorkloadModuleBase {
         };
 
         let targetCC = this.txIndex % 2 === 0 ? 'mymarbles' : 'yourmarbles';
-        return this.sutAdapter.querySmartContract(targetCC, 'v0', args, 10);
+        await this.sutAdapter.querySmartContract(targetCC, 'v0', args, 10);
     }
 }
 

--- a/packages/caliper-tests-integration/fabric_tests/caliper.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/caliper.yaml
@@ -15,7 +15,7 @@
 caliper:
     benchconfig: benchconfig.yaml
     networkconfig: networkconfig.yaml
-    txupdatetime: 1000
+    txupdatetime: 500
     report:
         path: ../report.html
     logging:

--- a/packages/caliper-tests-integration/fabric_tests/init.js
+++ b/packages/caliper-tests-integration/fabric_tests/init.js
@@ -66,7 +66,7 @@ class MarblesInitWorkload extends WorkloadModuleBase {
         };
 
         let targetCC = this.txIndex % 2 === 0 ? 'mymarbles' : 'yourmarbles';
-        return this.sutAdapter.invokeSmartContract(targetCC, 'v0', args, 5);
+        await this.sutAdapter.invokeSmartContract(targetCC, 'v0', args, 5);
     }
 }
 

--- a/packages/caliper-tests-integration/fabric_tests/initByChannel.js
+++ b/packages/caliper-tests-integration/fabric_tests/initByChannel.js
@@ -67,7 +67,7 @@ class MarblesInitByChannelWorkload extends WorkloadModuleBase {
         };
 
         let targetCC = 'marbles';
-        return this.sutAdapter.invokeSmartContract(targetCC, 'v0', args, 5);
+        await this.sutAdapter.invokeSmartContract(targetCC, 'v0', args, 5);
     }
 }
 

--- a/packages/caliper-tests-integration/fabric_tests/phase4/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase4/benchconfig.yaml
@@ -44,29 +44,4 @@ test:
         module: ./../queryByChannel.js
 observer:
     interval: 1
-    type: prometheus
-monitor:
-    interval: 1
-    type: ['prometheus']
-    prometheus:
-        url: "http://localhost:9090"
-        push_url: "http://localhost:9091"
-        metrics:
-            ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter]
-            include:
-                Endorse Time (s):
-                    query: rate(endorser_propsal_duration_sum{chaincode="marbles:v0"}[1m])/rate(endorser_propsal_duration_count{chaincode="marbles:v0"}[1m])
-                    step: 1
-                    label: instance
-                    statistic: avg
-                Max Memory (MB):
-                    query: sum(container_memory_rss{name=~".+"}) by (name)
-                    step: 10
-                    label: name
-                    statistic: max
-                    multiplier: 0.000001
-        charting:
-            polar:
-                metrics: [Max Memory (MB)]
-            bar:
-                metrics: [all]
+    type: local

--- a/packages/caliper-tests-integration/fabric_tests/query.js
+++ b/packages/caliper-tests-integration/fabric_tests/query.js
@@ -44,7 +44,7 @@ class MarblesQueryWorkload extends WorkloadModuleBase {
         };
 
         let targetCC = this.txIndex % 2 === 0 ? 'mymarbles' : 'yourmarbles';
-        return this.sutAdapter.querySmartContract(targetCC, 'v0', args, 10);
+        await this.sutAdapter.querySmartContract(targetCC, 'v0', args, 10);
     }
 }
 

--- a/packages/caliper-tests-integration/fabric_tests/queryByChannel.js
+++ b/packages/caliper-tests-integration/fabric_tests/queryByChannel.js
@@ -45,7 +45,7 @@ class MarblesQueryByChannelWorkload extends WorkloadModuleBase {
         };
 
         let targetCC = 'marbles';
-        return this.sutAdapter.querySmartContract(targetCC, 'v0', args, 10);
+        await this.sutAdapter.querySmartContract(targetCC, 'v0', args, 10);
     }
 }
 

--- a/packages/caliper-tests-integration/fisco-bcos_tests/caliper.yaml
+++ b/packages/caliper-tests-integration/fisco-bcos_tests/caliper.yaml
@@ -16,6 +16,7 @@ caliper:
     benchconfig: benchconfig.yaml
     networkconfig: networkconfig.json
     workspace: ./
+    txupdatetime: 500
     report:
         path: report.html
     logging:
@@ -42,7 +43,7 @@ caliper:
                 target: console
                 enabled: true
                 options:
-                    level: debug
+                    level: info
             file:
                 target: file
                 enabled: false

--- a/packages/caliper-tests-integration/fisco-bcos_tests/get.js
+++ b/packages/caliper-tests-integration/fisco-bcos_tests/get.js
@@ -25,7 +25,7 @@ class HelloGetWorkload extends WorkloadModuleBase {
      * @return {Promise<TxStatus[]>}
      */
     async submitTransaction() {
-        return this.sutAdapter.queryState('helloworld', 'v0', null, 'get()');
+        await this.sutAdapter.queryState('helloworld', 'v0', null, 'get()');
     }
 }
 

--- a/packages/caliper-tests-integration/fisco-bcos_tests/set.js
+++ b/packages/caliper-tests-integration/fisco-bcos_tests/set.js
@@ -29,7 +29,7 @@ class HelloSetWorkload extends WorkloadModuleBase {
             'transaction_type': 'set(string)',
             'name': 'hello! - from ' + this.workerIndex.toString(),
         };
-        return this.sutAdapter.invokeSmartContract('helloworld', 'v0', args, null);
+        await this.sutAdapter.invokeSmartContract('helloworld', 'v0', args, null);
     }
 }
 

--- a/packages/caliper-tests-integration/iroha_tests/caliper.yaml
+++ b/packages/caliper-tests-integration/iroha_tests/caliper.yaml
@@ -16,6 +16,7 @@ caliper:
     benchconfig: benchconfig.yaml
     networkconfig: networkconfig.json
     workspace: ./
+    txupdatetime: 500
     report:
         path: report.html
     logging:
@@ -42,7 +43,7 @@ caliper:
                 target: console
                 enabled: true
                 options:
-                    level: debug
+                    level: info
             file:
                 target: file
                 enabled: false

--- a/packages/caliper-tests-integration/iroha_tests/create.js
+++ b/packages/caliper-tests-integration/iroha_tests/create.js
@@ -105,7 +105,7 @@ class SimpleCreateWorkload extends WorkloadModuleBase {
     async submitTransaction() {
         let args = this._generateWorkload();
         Logger.debug(`Worker ${this.workerIndex} for TX ${this.txIndex}: ${JSON.stringify(args)}`);
-        return this.sutAdapter.invokeSmartContract('simple', 'v0', args, 100);
+        await this.sutAdapter.invokeSmartContract('simple', 'v0', args, 100);
     }
 }
 

--- a/packages/caliper-tests-integration/iroha_tests/query.js
+++ b/packages/caliper-tests-integration/iroha_tests/query.js
@@ -88,7 +88,7 @@ class SimpleQueryWorkload extends WorkloadModuleBase {
     async submitTransaction() {
         const account = this._generateAccount();
         Logger.debug(`Worker ${this.workerIndex} TX parameters: ${account}`);
-        return this.sutAdapter.queryState('simple', 'v0', account);
+        await this.sutAdapter.queryState('simple', 'v0', account);
     }
 }
 

--- a/packages/caliper-tests-integration/iroha_tests/transfer.js
+++ b/packages/caliper-tests-integration/iroha_tests/transfer.js
@@ -97,7 +97,7 @@ class SimpleTransferWorkload extends WorkloadModuleBase {
         };
 
         Logger.debug(`Worker ${this.workerIndex} TX parameters: ${JSON.stringify(args)}`);
-        return this.sutAdapter.invokeSmartContract('simple', 'v0', args, 10);
+        await this.sutAdapter.invokeSmartContract('simple', 'v0', args, 10);
     }
 }
 

--- a/packages/caliper-tests-integration/sawtooth_tests/caliper.yaml
+++ b/packages/caliper-tests-integration/sawtooth_tests/caliper.yaml
@@ -16,6 +16,7 @@ caliper:
     benchconfig: benchconfig.yaml
     networkconfig: networkconfig.json
     workspace: ./
+    txupdatetime: 500
     report:
         path: report.html
     logging:
@@ -42,7 +43,7 @@ caliper:
                 target: console
                 enabled: true
                 options:
-                    level: debug
+                    level: info
             file:
                 target: file
                 enabled: false

--- a/packages/caliper-tests-integration/sawtooth_tests/query.js
+++ b/packages/caliper-tests-integration/sawtooth_tests/query.js
@@ -66,7 +66,7 @@ class SmallbankQueryWorkload extends WorkloadModuleBase {
         const account  = this._getAccount();
         Logger.debug(`Worker ${this.workerIndex} TX args: ${account}`);
         // NOTE: the query API is inconsistent with the invoke API
-        return this.sutAdapter.queryState('smallbank', '1.0', account);
+        await this.sutAdapter.queryState('smallbank', '1.0', account);
     }
 }
 

--- a/packages/caliper-tests-integration/sawtooth_tests/smallbankOperations.js
+++ b/packages/caliper-tests-integration/sawtooth_tests/smallbankOperations.js
@@ -175,7 +175,7 @@ class SmallbankWorkload extends WorkloadModuleBase {
     async submitTransaction() {
         let args = this._generateWorkload();
         Logger.debug(`Worker ${this.workerIndex} TX args: ${JSON.stringify(args)}`);
-        return this.sutAdapter.invokeSmartContract('smallbank', '1.0', args, 30);
+        await this.sutAdapter.invokeSmartContract('smallbank', '1.0', args, 30);
     }
 }
 


### PR DESCRIPTION
Connectors now provide `txsSubmitted` and `txsFinished` events. The CaliperWorker subscribes to these events, making the data flow a bit more readable, and taking some pressure off from workload modules.

Signed-off-by: Attila Klenik <a.klenik@gmail.com>

