### PR TITLE
Simplify connector invoke/query API

### DIFF
--- a/packages/caliper-core/lib/common/core/blockchain-connector.js
+++ b/packages/caliper-core/lib/common/core/blockchain-connector.js
@@ -86,7 +86,7 @@ class BlockchainConnector extends EventEmitter {
      * Retrieve required arguments for test workers, e.g. retrieve information from the connector that is generated during an admin phase such as contract installation.
      * Information returned here is passed to the worker through the messaging protocol on test.
      * @param {Number} number total count of test workers
-     * @return {Promise} array of obtained material for each test worker
+     * @return {Promise<object[]>} array of obtained material for each test worker
      * @async
      */
     async prepareWorkerArguments(number) {
@@ -121,27 +121,21 @@ class BlockchainConnector extends EventEmitter {
 
     /**
      * Invoke a smart contract
-     * @param {String} contractID identity of the contract
-     * @param {String} contractVer version of the contract
-     * @param {Object[]} args array of JSON formatted arguments for multiple transactions
-     * @param {Number} timeout request timeout, in seconds
+     * @param {object|object[]} requests The object(s) containing the arguments of the call.
      * @return {Promise<TxStatus[]>} The array of data about the executed transactions.
      * @async
      */
-    async invokeSmartContract(contractID, contractVer, args, timeout) {
+    async invokeSmartContract(requests) {
         throw new Error('invokeSmartContract is not implemented for this blockchain connector');
     }
 
     /**
      * Query state from the ledger using a smart contract
-     * @param {String} contractID identity of the contract
-     * @param {String} contractVer version of the contract
-     * @param {Object[]} args array of JSON formatted arguments
-     * @param {Number} timeout request timeout, in seconds
+     * @param {object|object[]} requests The object(s) containing the arguments for the call.
      * @return {Promise<TxStatus[]>} The array of data about the executed queries.
      * @async
      */
-    async querySmartContract(contractID, contractVer, args, timeout) {
+    async querySmartContract(requests) {
         throw new Error('querySmartContract is not implemented for this blockchain connector');
     }
 }

--- a/packages/caliper-fabric/lib/connector-versions/v1/fabric.js
+++ b/packages/caliper-fabric/lib/connector-versions/v1/fabric.js
@@ -2109,43 +2109,36 @@ class Fabric extends BlockchainConnector {
     /**
      * Invokes the specified contract according to the provided settings.
      *
-     * @param {string} contractID The unique contract ID of the target contract.
-     * @param {string} contractVersion Unused.
-     * @param {ContractInvokeSettings|ContractInvokeSettings[]} invokeSettings The settings (collection) associated with the (batch of) transactions to submit.
-     * @param {number} timeout The timeout for the whole transaction life-cycle in seconds.
+     * @param {ContractInvokeSettings|ContractInvokeSettings[]} requests The settings (collection) associated with the (batch of) transactions to submit.
      * @return {Promise<TxStatus[]>} The result and stats of the transaction invocation.
      */
-    async invokeSmartContract(contractID, contractVersion, invokeSettings, timeout) {
-        timeout = timeout || this.configDefaultTimeout;
+    async invokeSmartContract(requests) {
         const promises = [];
-        let settingsArray;
+        let requestArray;
 
-        if (!Array.isArray(invokeSettings)) {
-            settingsArray = [invokeSettings];
+        if (!Array.isArray(requests)) {
+            requestArray = [requests];
         } else {
-            settingsArray = invokeSettings;
+            requestArray = requests;
         }
 
-        for (const settings of settingsArray) {
-            if (settings.hasOwnProperty('channel')) {
-                settings.contractId = contractID;
-                settings.contractVersion = contractVersion;
-            } else {
-                const contractDetails = this.networkUtil.getContractDetails(contractID);
+        for (const request of requestArray) {
+            if (!request.hasOwnProperty('channel')) {
+                const contractDetails = this.networkUtil.getContractDetails(request.contractId);
                 if (!contractDetails) {
-                    throw new Error(`Could not find details for contract ID ${contractID}`);
+                    throw new Error(`Could not find details for contract ID ${request.contractId}`);
                 }
-                settings.channel = contractDetails.channel;
-                settings.contractId = contractDetails.id;
-                settings.contractVersion = contractDetails.version;
+                request.channel = contractDetails.channel;
+                request.contractId = contractDetails.id;
+                request.contractVersion = contractDetails.version;
             }
 
-            if (!settings.invokerIdentity) {
-                settings.invokerIdentity = this.defaultInvoker;
+            if (!request.invokerIdentity) {
+                request.invokerIdentity = this.defaultInvoker;
             }
 
             this._onTxsSubmitted(1);
-            promises.push(this._submitSingleTransaction(settings, timeout * 1000));
+            promises.push(this._submitSingleTransaction(request, (request.timeout || this.configDefaultTimeout) * 1000));
         }
 
         const results = await Promise.all(promises);
@@ -2156,43 +2149,36 @@ class Fabric extends BlockchainConnector {
     /**
      * Queries the specified contract according to the provided settings.
      *
-     * @param {string} contractID The unique contract ID of the target contract.
-     * @param {string} contractVersion Unused.
-     * @param {ContractQuerySettings|ContractQuerySettings[]} querySettings The settings (collection) associated with the (batch of) query to submit.
-     * @param {number} timeout The timeout for the call in seconds.
+     * @param {ContractQuerySettings|ContractQuerySettings[]} requests The settings (collection) associated with the (batch of) query to submit.
      * @return {Promise<TxStatus[]>} The result and stats of the transaction query.
      */
-    async querySmartContract(contractID, contractVersion, querySettings, timeout) {
-        timeout = timeout || this.configDefaultTimeout;
+    async querySmartContract(requests) {
         const promises = [];
-        let settingsArray;
+        let requestArray;
 
-        if (!Array.isArray(querySettings)) {
-            settingsArray = [querySettings];
+        if (!Array.isArray(requests)) {
+            requestArray = [requests];
         } else {
-            settingsArray = querySettings;
+            requestArray = requests;
         }
 
-        for (const settings of settingsArray) {
-            if (settings.hasOwnProperty('channel')) {
-                settings.contractId = contractID;
-                settings.contractVersion = contractVersion;
-            } else {
-                const contractDetails = this.networkUtil.getContractDetails(contractID);
+        for (const request of requestArray) {
+            if (!request.hasOwnProperty('channel')) {
+                const contractDetails = this.networkUtil.getContractDetails(request.contractId);
                 if (!contractDetails) {
-                    throw new Error(`Could not find details for contract ID ${contractID}`);
+                    throw new Error(`Could not find details for contract ID ${request.contractId}`);
                 }
-                settings.channel = contractDetails.channel;
-                settings.contractId = contractDetails.id;
-                settings.contractVersion = contractDetails.version;
+                request.channel = contractDetails.channel;
+                request.contractId = contractDetails.id;
+                request.contractVersion = contractDetails.version;
             }
 
-            if (!settings.invokerIdentity) {
-                settings.invokerIdentity = this.defaultInvoker;
+            if (!request.invokerIdentity) {
+                request.invokerIdentity = this.defaultInvoker;
             }
 
             this._onTxsSubmitted(1);
-            promises.push(this._submitSingleQuery(settings, timeout * 1000));
+            promises.push(this._submitSingleQuery(request, (request.timeout || this.configDefaultTimeout) * 1000));
         }
 
         const results = await Promise.all(promises);

--- a/packages/caliper-fabric/lib/connector-versions/v2/fabric-gateway.js
+++ b/packages/caliper-fabric/lib/connector-versions/v2/fabric-gateway.js
@@ -451,32 +451,12 @@ class Fabric extends BlockchainConnector {
 
     /**
      * Perform a transaction using a Gateway contract
-     * @param {string} contractID The unique contract ID of the target contract.
-     * @param {string} contractVersion The version of the contract. Only used when explicitly naming a channel within the invokeSettings.
      * @param {ContractInvokeSettings|ContractQuerySettings} invokeSettings The settings associated with the transaction submission.
      * @param {boolean} isSubmit boolean flag to indicate if the transaction is a submit or evaluate
      * @return {Promise<TxStatus>} The result and stats of the transaction invocation.
      * @async
      */
-    async _performGatewayTransaction(contractID, contractVersion, invokeSettings, isSubmit) {
-        // Populate the contract details for the invoke
-        if (invokeSettings.hasOwnProperty('channel')) {
-            invokeSettings.contractId = contractID;
-            invokeSettings.contractVersion = contractVersion;
-        } else {
-            const contractDetails = this.networkUtil.getContractDetails(contractID);
-            if (!contractDetails) {
-                throw new Error(`Could not find details for contract ID ${contractID}`);
-            }
-            invokeSettings.channel = contractDetails.channel;
-            invokeSettings.contractId = contractDetails.id;
-            invokeSettings.contractVersion = contractDetails.version;
-        }
-
-        if (!invokeSettings.invokerIdentity) {
-            invokeSettings.invokerIdentity = this.defaultInvoker;
-        }
-
+    async _performGatewayTransaction(invokeSettings, isSubmit) {
         // Retrieve the existing contract for the invokerIdentity
         const smartContract = await this._getUserContract(invokeSettings.invokerIdentity, invokeSettings.channel, invokeSettings.contractId);
 
@@ -642,27 +622,41 @@ class Fabric extends BlockchainConnector {
     }
 
     /**
-     * Invokes the specified contract according to the provided settings.
+     * Invokes/queries the specified contract according to the provided settings.
      *
-     * @param {string} contractID The unique contract ID of the target contract.
-     * @param {string} contractVersion Unused.
-     * @param {ContractInvokeSettings|ContractInvokeSettings[]} invokeSettings The settings (collection) associated with the (batch of) transactions to submit.
-     * @param {number} timeout The timeout override for the whole transaction life-cycle in seconds.
+     * @param {ContractInvokeSettings|ContractInvokeSettings[]|ContractQuerySettings|ContractQuerySettings[]} requests The settings (collection) associated with the (batch of) transactions to submit.
+     * @param {boolean} isSubmit Indicates whether the TX is read-write, or read-only.
      * @return {Promise<TxStatus[]>} The result and stats of the transaction invocation.
      */
-    async invokeSmartContract(contractID, contractVersion, invokeSettings, timeout) {
+    async _sendRequests(requests, isSubmit) {
         const promises = [];
-        let settingsArray;
+        let requestsArray;
 
-        if (!Array.isArray(invokeSettings)) {
-            settingsArray = [invokeSettings];
+        if (!Array.isArray(requests)) {
+            requestsArray = [requests];
         } else {
-            settingsArray = invokeSettings;
+            requestsArray = requests;
         }
 
-        for (const settings of settingsArray) {
+        for (const request of requestsArray) {
             this._onTxsSubmitted(1);
-            promises.push(this._performGatewayTransaction(contractID, contractVersion, settings, true));
+
+            // Populate the contract details for the invoke
+            if (!request.hasOwnProperty('channel')) {
+                const contractDetails = this.networkUtil.getContractDetails(request.contractId);
+                if (!contractDetails) {
+                    throw new Error(`Could not find details for contract ID ${request.contractId}`);
+                }
+                request.channel = contractDetails.channel;
+                request.contractId = contractDetails.id;
+                request.contractVersion = contractDetails.version;
+            }
+
+            if (!request.invokerIdentity) {
+                request.invokerIdentity = this.defaultInvoker;
+            }
+
+            promises.push(this._performGatewayTransaction(request, isSubmit));
         }
 
         const results = await Promise.all(promises);
@@ -671,32 +665,23 @@ class Fabric extends BlockchainConnector {
     }
 
     /**
+     * Invokes the specified contract according to the provided settings.
+     *
+     * @param {ContractInvokeSettings|ContractInvokeSettings[]} requests The settings (collection) associated with the (batch of) transactions to submit.
+     * @return {Promise<TxStatus[]>} The result and stats of the transaction invocation.
+     */
+    async invokeSmartContract(requests) {
+        return this._sendRequests(requests, true);
+    }
+
+    /**
      * Queries the specified contract according to the provided settings.
      *
-     * @param {string} contractID The unique contract ID of the target contract.
-     * @param {string} contractVersion Unused.
-     * @param {ContractQuerySettings|ContractQuerySettings[]} querySettings The settings (collection) associated with the (batch of) query to submit.
-     * @param {number} timeout Unused - timeouts are set using globally defined values in the gateway construction phase.
+     * @param {ContractQuerySettings|ContractQuerySettings[]} requests The settings (collection) associated with the (batch of) query to submit.
      * @return {Promise<TxStatus[]>} The result and stats of the transaction query.
      */
-    async querySmartContract(contractID, contractVersion, querySettings, timeout) {
-        const promises = [];
-        let settingsArray;
-
-        if (!Array.isArray(querySettings)) {
-            settingsArray = [querySettings];
-        } else {
-            settingsArray = querySettings;
-        }
-
-        for (const settings of settingsArray) {
-            this._onTxsSubmitted(1);
-            promises.push(this._performGatewayTransaction(contractID, contractVersion, settings, false));
-        }
-
-        const results = await Promise.all(promises);
-        this._onTxsFinished(results);
-        return results;
+    async querySmartContract(requests) {
+        return this._sendRequests(requests, false);
     }
 
     /**

--- a/packages/caliper-fabric/lib/fabric-connector.js
+++ b/packages/caliper-fabric/lib/fabric-connector.js
@@ -121,27 +121,21 @@ const FabricConnector = class extends BlockchainConnector {
     /**
      * Invokes the specified contract according to the provided settings.
      *
-     * @param {string} contractID The unique contract ID of the target contract.
-     * @param {string} contractVersion Unused.
-     * @param {ContractInvokeSettings|ContractInvokeSettings[]} invokeSettings The settings (collection) associated with the (batch of) transactions to submit.
-     * @param {number} timeout The timeout for the whole transaction life-cycle in seconds.
+     * @param {ContractInvokeSettings|ContractInvokeSettings[]} requests The settings (collection) associated with the (batch of) transactions to submit.
      * @return {Promise<TxStatus[]>} The result and stats of the transaction invocation.
      */
-    async invokeSmartContract(contractID, contractVersion, invokeSettings, timeout) {
-        return await this.fabric.invokeSmartContract(contractID, contractVersion, invokeSettings, timeout);
+    async invokeSmartContract(requests) {
+        return await this.fabric.invokeSmartContract(requests);
     }
 
     /**
      * Queries the specified contract according to the provided settings.
      *
-     * @param {string} contractID The unique contract ID of the target contract.
-     * @param {string} contractVersion Unused.
-     * @param {ContractQuerySettings|ContractQuerySettings[]} querySettings The settings (collection) associated with the (batch of) query to submit.
-     * @param {number} timeout The timeout for the call in seconds.
+     * @param {ContractQuerySettings|ContractQuerySettings[]} requests The settings (collection) associated with the (batch of) query to submit.
      * @return {Promise<TxStatus[]>} The result and stats of the transaction query.
      */
-    async querySmartContract(contractID, contractVersion, querySettings, timeout) {
-        return await this.fabric.querySmartContract(contractID, contractVersion, querySettings, timeout);
+    async querySmartContract(requests) {
+        return await this.fabric.querySmartContract(requests);
     }
 
     /**

--- a/packages/caliper-tests-integration/besu_tests/open.js
+++ b/packages/caliper-tests-integration/besu_tests/open.js
@@ -71,6 +71,7 @@ class SimpleOpenWorkload extends WorkloadModuleBase {
             let accountId = this._generateAccount();
 
             workload.push({
+                contract: 'simple',
                 verb: 'open',
                 args: [accountId, this.roundArguments.money]
             });
@@ -112,7 +113,7 @@ class SimpleOpenWorkload extends WorkloadModuleBase {
     async submitTransaction() {
         let args = this._generateWorkload();
         Logger.debug(`Worker ${this.workerIndex} for TX ${this.txIndex}: ${JSON.stringify(args)}`);
-        await this.sutAdapter.invokeSmartContract('simple', 'v0', args, 100);
+        await this.sutAdapter.invokeSmartContract(args);
     }
 }
 

--- a/packages/caliper-tests-integration/besu_tests/query.js
+++ b/packages/caliper-tests-integration/besu_tests/query.js
@@ -92,12 +92,13 @@ class SimpleQueryWorkload extends WorkloadModuleBase {
      */
     async submitTransaction() {
         const args = {
+            contract: 'simple',
             verb: 'query',
             args: [this._generateAccount()]
         };
 
         Logger.debug(`Worker ${this.workerIndex} TX parameters: ${JSON.stringify(args)}`);
-        await this.sutAdapter.querySmartContract('simple', 'v0', args, 100);
+        await this.sutAdapter.querySmartContract(args);
     }
 }
 

--- a/packages/caliper-tests-integration/besu_tests/transfer.js
+++ b/packages/caliper-tests-integration/besu_tests/transfer.js
@@ -96,12 +96,13 @@ class SimpleTransferWorkload extends WorkloadModuleBase {
      */
     async submitTransaction() {
         const args = {
+            contract: 'simple',
             verb: 'transfer',
             args: [this._generateAccount(), this._generateAccount(), this.roundArguments.money.toString()]
         };
 
         Logger.debug(`Worker ${this.workerIndex} TX parameters: ${JSON.stringify(args)}`);
-        await this.sutAdapter.invokeSmartContract('simple', 'v0', args, 100);
+        await this.sutAdapter.invokeSmartContract(args);
     }
 }
 

--- a/packages/caliper-tests-integration/ethereum_tests/open.js
+++ b/packages/caliper-tests-integration/ethereum_tests/open.js
@@ -71,6 +71,7 @@ class SimpleOpenWorkload extends WorkloadModuleBase {
             let accountId = this._generateAccount();
 
             workload.push({
+                contract: 'simple',
                 verb: 'open',
                 args: [accountId, this.roundArguments.money]
             });
@@ -112,7 +113,7 @@ class SimpleOpenWorkload extends WorkloadModuleBase {
     async submitTransaction() {
         let args = this._generateWorkload();
         Logger.debug(`Worker ${this.workerIndex} for TX ${this.txIndex}: ${JSON.stringify(args)}`);
-        await this.sutAdapter.invokeSmartContract('simple', 'v0', args, 100);
+        await this.sutAdapter.invokeSmartContract(args);
     }
 }
 

--- a/packages/caliper-tests-integration/ethereum_tests/query.js
+++ b/packages/caliper-tests-integration/ethereum_tests/query.js
@@ -94,12 +94,13 @@ class SimpleQueryWorkload extends WorkloadModuleBase {
      */
     async submitTransaction() {
         const args = {
+            contract: 'simple',
             verb: 'query',
             args: [this._generateAccount()]
         };
 
         Logger.debug(`Worker ${this.workerIndex} TX parameters: ${JSON.stringify(args)}`);
-        await this.sutAdapter.querySmartContract('simple', 'v0', args, 100);
+        await this.sutAdapter.querySmartContract(args);
     }
 }
 

--- a/packages/caliper-tests-integration/ethereum_tests/transfer.js
+++ b/packages/caliper-tests-integration/ethereum_tests/transfer.js
@@ -96,12 +96,13 @@ class SimpleTransferWorkload extends WorkloadModuleBase {
      */
     async submitTransaction() {
         const args = {
+            contract: 'simple',
             verb: 'transfer',
             args: [this._generateAccount(), this._generateAccount(), this.roundArguments.money.toString()]
         };
 
         Logger.debug(`Worker ${this.workerIndex} TX parameters: ${JSON.stringify(args)}`);
-        await this.sutAdapter.invokeSmartContract('simple', 'v0', args, 100);
+        await this.sutAdapter.invokeSmartContract(args);
     }
 }
 

--- a/packages/caliper-tests-integration/fabric_docker_distributed_tests/init.js
+++ b/packages/caliper-tests-integration/fabric_docker_distributed_tests/init.js
@@ -42,12 +42,13 @@ class MarblesInitWorkload extends WorkloadModuleBase {
         let marbleOwner = this.owners[this.txIndex % this.owners.length];
 
         let args = {
+            contractId: this.txIndex % 2 === 0 ? 'mymarbles' : 'yourmarbles',
             contractFunction: 'initMarble',
             contractArguments: [marbleName, marbleColor, marbleSize, marbleOwner],
+            timeout: 5
         };
 
-        let targetCC = this.txIndex % 2 === 0 ? 'mymarbles' : 'yourmarbles';
-        await this.sutAdapter.invokeSmartContract(targetCC, 'v0', args, 5);
+        await this.sutAdapter.invokeSmartContract(args);
     }
 }
 

--- a/packages/caliper-tests-integration/fabric_docker_distributed_tests/query.js
+++ b/packages/caliper-tests-integration/fabric_docker_distributed_tests/query.js
@@ -37,12 +37,13 @@ class MarblesQueryWorkload extends WorkloadModuleBase {
         let marbleOwner = this.owners[this.txIndex % this.owners.length];
 
         let args = {
+            contractId: this.txIndex % 2 === 0 ? 'mymarbles' : 'yourmarbles',
             contractFunction: 'queryMarblesByOwner',
             contractArguments: [marbleOwner],
+            timeout: 10
         };
 
-        let targetCC = this.txIndex % 2 === 0 ? 'mymarbles' : 'yourmarbles';
-        await this.sutAdapter.querySmartContract(targetCC, 'v0', args, 10);
+        await this.sutAdapter.querySmartContract(args);
     }
 }
 

--- a/packages/caliper-tests-integration/fabric_docker_local_tests/init.js
+++ b/packages/caliper-tests-integration/fabric_docker_local_tests/init.js
@@ -43,12 +43,13 @@ class MarblesInitWorkload extends WorkloadModuleBase {
         let marbleOwner = this.owners[this.txIndex % this.owners.length];
 
         let args = {
+            contractId: this.txIndex % 2 === 0 ? 'mymarbles' : 'yourmarbles',
             contractFunction: 'initMarble',
             contractArguments: [marbleName, marbleColor, marbleSize, marbleOwner],
+            timeout: 5
         };
 
-        let targetCC = this.txIndex % 2 === 0 ? 'mymarbles' : 'yourmarbles';
-        await this.sutAdapter.invokeSmartContract(targetCC, 'v0', args, 5);
+        await this.sutAdapter.invokeSmartContract(args);
     }
 }
 

--- a/packages/caliper-tests-integration/fabric_docker_local_tests/query.js
+++ b/packages/caliper-tests-integration/fabric_docker_local_tests/query.js
@@ -38,12 +38,13 @@ class MarblesQueryWorkload extends WorkloadModuleBase {
         let marbleOwner = this.owners[this.txIndex % this.owners.length];
 
         let args = {
+            contractId: this.txIndex % 2 === 0 ? 'mymarbles' : 'yourmarbles',
             contractFunction: 'queryMarblesByOwner',
             contractArguments: [marbleOwner],
+            timeout: 10
         };
 
-        let targetCC = this.txIndex % 2 === 0 ? 'mymarbles' : 'yourmarbles';
-        await this.sutAdapter.querySmartContract(targetCC, 'v0', args, 10);
+        await this.sutAdapter.querySmartContract(args);
     }
 }
 

--- a/packages/caliper-tests-integration/fabric_tests/init.js
+++ b/packages/caliper-tests-integration/fabric_tests/init.js
@@ -61,12 +61,13 @@ class MarblesInitWorkload extends WorkloadModuleBase {
         let marbleOwner = this.owners[this.txIndex % this.owners.length];
 
         let args = {
+            contractId: this.txIndex % 2 === 0 ? 'mymarbles' : 'yourmarbles',
             contractFunction: 'initMarble',
             contractArguments: [marbleName, marbleColor, marbleSize, marbleOwner],
+            timeout: 5
         };
 
-        let targetCC = this.txIndex % 2 === 0 ? 'mymarbles' : 'yourmarbles';
-        await this.sutAdapter.invokeSmartContract(targetCC, 'v0', args, 5);
+        await this.sutAdapter.invokeSmartContract(args);
     }
 }
 

--- a/packages/caliper-tests-integration/fabric_tests/initByChannel.js
+++ b/packages/caliper-tests-integration/fabric_tests/initByChannel.js
@@ -61,13 +61,15 @@ class MarblesInitByChannelWorkload extends WorkloadModuleBase {
         let marbleOwner = this.owners[this.txIndex % this.owners.length];
 
         let args = {
+            contractId: 'marbles',
+            contractVersion: 'v0',
             contractFunction: 'initMarble',
             channel: this.txIndex % 2 === 0 ? 'mychannel' : 'yourchannel',
             contractArguments: [marbleName, marbleColor, marbleSize, marbleOwner],
+            timeout: 5
         };
 
-        let targetCC = 'marbles';
-        await this.sutAdapter.invokeSmartContract(targetCC, 'v0', args, 5);
+        await this.sutAdapter.invokeSmartContract(args);
     }
 }
 

--- a/packages/caliper-tests-integration/fabric_tests/query.js
+++ b/packages/caliper-tests-integration/fabric_tests/query.js
@@ -38,13 +38,14 @@ class MarblesQueryWorkload extends WorkloadModuleBase {
         let marbleOwner = this.owners[this.txIndex % this.owners.length];
 
         let args = {
+            contractId: this.txIndex % 2 === 0 ? 'mymarbles' : 'yourmarbles',
             contractFunction: 'queryMarblesByOwner',
             contractArguments: [marbleOwner],
-            targetPeers: ['peer0.org1.example.com']
+            targetPeers: ['peer0.org1.example.com'],
+            timeout: 10
         };
 
-        let targetCC = this.txIndex % 2 === 0 ? 'mymarbles' : 'yourmarbles';
-        await this.sutAdapter.querySmartContract(targetCC, 'v0', args, 10);
+        await this.sutAdapter.querySmartContract(args);
     }
 }
 

--- a/packages/caliper-tests-integration/fabric_tests/queryByChannel.js
+++ b/packages/caliper-tests-integration/fabric_tests/queryByChannel.js
@@ -38,14 +38,16 @@ class MarblesQueryByChannelWorkload extends WorkloadModuleBase {
         let marbleOwner = this.owners[this.txIndex % this.owners.length];
 
         let args = {
+            contractId: 'marbles',
+            contractVersion: 'v0',
             channel: this.txIndex % 2 === 0 ? 'mychannel' : 'yourchannel',
             contractFunction: 'queryMarblesByOwner',
             contractArguments: [marbleOwner],
-            targetPeers: ['peer0.org1.example.com']
+            targetPeers: ['peer0.org1.example.com'],
+            timeout: 10
         };
 
-        let targetCC = 'marbles';
-        await this.sutAdapter.querySmartContract(targetCC, 'v0', args, 10);
+        await this.sutAdapter.querySmartContract(args);
     }
 }
 

--- a/packages/caliper-tests-integration/fisco-bcos_tests/get.js
+++ b/packages/caliper-tests-integration/fisco-bcos_tests/get.js
@@ -26,9 +26,12 @@ class HelloGetWorkload extends WorkloadModuleBase {
      */
     async submitTransaction() {
         const args = {
-            'transaction_type': 'get()'
+            contractId: 'helloworld',
+            args: {
+                transaction_type: 'get()'
+            }
         };
-        await this.sutAdapter.querySmartContract('helloworld', 'v0', args, undefined);
+        await this.sutAdapter.querySmartContract(args);
     }
 }
 

--- a/packages/caliper-tests-integration/fisco-bcos_tests/set.js
+++ b/packages/caliper-tests-integration/fisco-bcos_tests/set.js
@@ -26,10 +26,13 @@ class HelloSetWorkload extends WorkloadModuleBase {
      */
     async submitTransaction() {
         const args = {
-            'transaction_type': 'set(string)',
-            'name': 'hello! - from ' + this.workerIndex.toString(),
+            contractId: 'helloworld',
+            args: {
+                transaction_type: 'set(string)',
+                name: 'hello! - from ' + this.workerIndex.toString()
+            }
         };
-        await this.sutAdapter.invokeSmartContract('helloworld', 'v0', args, null);
+        await this.sutAdapter.invokeSmartContract(args);
     }
 }
 

--- a/packages/generator-caliper/generators/benchmark/templates/workload.js
+++ b/packages/generator-caliper/generators/benchmark/templates/workload.js
@@ -54,10 +54,11 @@ class <%= pascalCase %>Workload extends WorkloadModuleBase {
      */
     async submitTransaction() {
         const myArgs = {
+            contractId: this.contractId,
             contractFunction: '<%= contractFunction %>',
             contractArguments: <%- contractArguments %>
         };
-        return this.sutAdapter.invokeSmartContract(this.contractId, this.contractVersion, myArgs);
+        return this.sutAdapter.invokeSmartContract(myArgs);
     }
 }
 

--- a/packages/generator-caliper/test/benchmark/workload.js
+++ b/packages/generator-caliper/test/benchmark/workload.js
@@ -115,10 +115,11 @@ describe('', () => {
         '     */\n' +
         '    async submitTransaction() {\n' +
         '        const myArgs = {\n' +
+        '            contractId: this.contractId,\n' +
         '            contractFunction: \'penguin\',\n' +
         '            contractArguments: ["args1", "args2", "args3"]\n' +
         '        };\n' +
-        '        return this.sutAdapter.invokeSmartContract(this.contractId, this.contractVersion, myArgs);\n' +
+        '        return this.sutAdapter.invokeSmartContract(myArgs);\n' +
         '    }\n' +
         '}\n' +
         '\n' +


### PR DESCRIPTION
- Merge the parameters into a single object, or array of objects
- Use platform-neutral naming, e.g. request and read-only
- Extract common invoke/query code where possible
- Update CI workload modules
- Update generator template

Contributes to #888 

Signed-off-by: Attila Klenik <a.klenik@gmail.com>