### PR TITLE
update engine versions for node and npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- "10"
+- "14"
 
 services:
 - docker

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
         "force-clean": "./scripts/force-clean.sh"
     },
     "engines": {
-        "node": ">=8.10.0",
-        "npm": ">=5.6.0"
+        "node": ">=14.9.0",
+        "npm": ">=6.14.6"
     },
     "dependencies": {},
     "devDependencies": {

--- a/packages/caliper-burrow/package.json
+++ b/packages/caliper-burrow/package.json
@@ -18,8 +18,8 @@
         "nyc": "nyc mocha --recursive -t 10000"
     },
     "engines": {
-        "node": ">=8.10.0",
-        "npm": ">=5.6.0"
+        "node": ">=14.9.0",
+        "npm": ">=6.14.6"
     },
     "dependencies": {
         "@hyperledger/caliper-core": "0.4.0-unstable",

--- a/packages/caliper-cli/lib/lib/config.yaml
+++ b/packages/caliper-cli/lib/lib/config.yaml
@@ -43,7 +43,7 @@ sut:
             settings:
             - *new-node-old-grpc
         1.4.11: &fabric-latest
-            packages: ['fabric-client@1.4.11', 'fabric-protos@2.0.0-snapshot.1', 'fabric-network@1.4.11']
+            packages: ['grpc@1.24.2', 'fabric-client@1.4.11', 'fabric-protos@2.0.0', 'fabric-network@1.4.11']
         1.4: *fabric-latest
         2.1.0:
             packages: ['fabric-common@2.1.0', 'fabric-protos@2.1.0', 'fabric-network@2.1.0', 'fabric-ca-client@2.1.0']

--- a/packages/caliper-cli/package.json
+++ b/packages/caliper-cli/package.json
@@ -22,8 +22,8 @@
         "nyc": "nyc mocha --recursive -t 10000"
     },
     "engines": {
-        "node": ">=8.10.0",
-        "npm": ">=5.6.0"
+        "node": ">=14.9.0",
+        "npm": ">=6.14.6"
     },
     "dependencies": {
         "@hyperledger/caliper-core": "0.4.0-unstable",

--- a/packages/caliper-core/package.json
+++ b/packages/caliper-core/package.json
@@ -18,8 +18,8 @@
         "nyc": "nyc mocha --recursive -t 10000"
     },
     "engines": {
-        "node": ">=8.10.0",
-        "npm": ">=5.6.0"
+        "node": ">=14.9.0",
+        "npm": ">=6.14.6"
     },
     "dependencies": {
         "color-scheme": "^1.0.1",

--- a/packages/caliper-ethereum/package.json
+++ b/packages/caliper-ethereum/package.json
@@ -18,8 +18,8 @@
         "nyc": "nyc mocha --recursive -t 10000"
     },
     "engines": {
-        "node": ">=8.10.0",
-        "npm": ">=5.6.0"
+        "node": ">=14.9.0",
+        "npm": ">=6.14.6"
     },
     "dependencies": {
         "@hyperledger/caliper-core": "0.4.0-unstable",

--- a/packages/caliper-fabric/package.json
+++ b/packages/caliper-fabric/package.json
@@ -18,8 +18,8 @@
         "nyc": "nyc mocha --recursive -t 10000"
     },
     "engines": {
-        "node": ">=8.10.0",
-        "npm": ">=5.6.0"
+        "node": ">=14.9.0",
+        "npm": ">=6.14.6"
     },
     "dependencies": {
         "@hapi/joi": "^15.1.1",
@@ -27,10 +27,10 @@
         "semver": "7.1.1"
     },
     "devDependencies": {
-        "fabric-ca-client": "^1.4.7",
-        "fabric-client": "^1.4.7",
-        "fabric-network": "^1.4.7",
-        "fabric-protos": "2.0.0-snapshot.1",
+        "fabric-ca-client": "1.4.11",
+        "fabric-client": "1.4.11",
+        "fabric-network": "1.4.11",
+        "fabric-protos": "2.2.2",
         "chai": "^3.5.0",
         "eslint": "^5.16.0",
         "mocha": "3.4.2",

--- a/packages/caliper-fisco-bcos/package.json
+++ b/packages/caliper-fisco-bcos/package.json
@@ -18,8 +18,8 @@
         "nyc": "nyc mocha --recursive -t 10000"
     },
     "engines": {
-        "node": ">=8.10.0",
-        "npm": ">=5.6.0"
+        "node": ">=14.9.0",
+        "npm": ">=6.14.6"
     },
     "dependencies": {
         "@hyperledger/caliper-core": "0.4.0-unstable",

--- a/packages/caliper-gui-dashboard/package.json
+++ b/packages/caliper-gui-dashboard/package.json
@@ -23,8 +23,8 @@
         "map-sass": "node-sass src/assets/scss/paper-dashboard.scss src/assets/css/paper-dashboard.css --source-map true"
     },
     "engines": {
-        "node": ">=8.10.0",
-        "npm": ">=5.6.0"
+        "node": ">=14.9.0",
+        "npm": ">=6.14.6"
     },
     "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.27",

--- a/packages/caliper-gui-server/package.json
+++ b/packages/caliper-gui-server/package.json
@@ -18,8 +18,8 @@
         "start": "node app.js"
     },
     "engines": {
-        "node": ">=8.10.0",
-        "npm": ">=5.6.0"
+        "node": ">=14.9.0",
+        "npm": ">=6.14.6"
     },
     "dependencies": {
         "@hyperledger/caliper-burrow": "0.4.0-unstable",

--- a/packages/caliper-iroha/package.json
+++ b/packages/caliper-iroha/package.json
@@ -18,8 +18,8 @@
         "nyc": "nyc mocha --recursive -t 10000"
     },
     "engines": {
-        "node": ">=8.10.0",
-        "npm": ">=5.6.0"
+        "node": ">=14.9.0",
+        "npm": ">=6.14.6"
     },
     "dependencies": {
         "@hyperledger/caliper-core": "0.4.0-unstable"

--- a/packages/caliper-publish/caliper.Dockerfile
+++ b/packages/caliper-publish/caliper.Dockerfile
@@ -12,7 +12,7 @@
 # limitations under the License.
 #
 
-FROM node:10.16-alpine
+FROM node:12.18-alpine
 
 # require to set these explicitly to avoid mistakes
 ARG npm_registry

--- a/packages/caliper-publish/package.json
+++ b/packages/caliper-publish/package.json
@@ -17,8 +17,8 @@
         "nyc": "nyc mocha --recursive -t 10000"
     },
     "engines": {
-        "node": ">=8.10.0",
-        "npm": ">=5.6.0"
+        "node": ">=14.9.0",
+        "npm": ">=6.14.6"
     },
     "dependencies": {
         "yargs": "15.3.1"

--- a/packages/caliper-sawtooth/package.json
+++ b/packages/caliper-sawtooth/package.json
@@ -18,8 +18,8 @@
         "nyc": "nyc mocha --recursive -t 10000"
     },
     "engines": {
-        "node": ">=8.10.0",
-        "npm": ">=5.6.0"
+        "node": ">=14.9.0",
+        "npm": ">=6.14.6"
     },
     "dependencies": {
         "@hyperledger/caliper-core": "0.4.0-unstable",
@@ -27,7 +27,6 @@
         "protocol-buffers": "^4.1.0"
     },
     "devDependencies": {
-        "sawtooth-sdk": "^1.0.5",
         "chai": "^3.5.0",
         "eslint": "^5.16.0",
         "mocha": "3.4.2",

--- a/packages/caliper-tests-integration/package.json
+++ b/packages/caliper-tests-integration/package.json
@@ -3,6 +3,10 @@
     "version": "0.4.0-unstable",
     "private": true,
     "description": "Integration tests for Hyperledger Caliper",
+    "engines": {
+        "node": ">=14.9.0",
+        "npm": ">=6.14.6"
+    },
     "scripts": {
         "cleanup": "./scripts/cleanup.sh",
         "start_verdaccio": "npm run cleanup && ./scripts/start-verdaccio.sh",

--- a/packages/generator-caliper/package.json
+++ b/packages/generator-caliper/package.json
@@ -22,8 +22,8 @@
         "nyc": "nyc mocha --recursive -t 10000"
     },
     "engines": {
-        "node": ">=8.10.0",
-        "npm": ">=5.6.0"
+        "node": ">=14.9.0",
+        "npm": ">=6.14.6"
     },
     "files": [
         "generators"


### PR DESCRIPTION
Closes #965 

bump node to LTS (12.18.3)
bump npm to 6.14.6


Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>
