### PR TITLE
Ensure detection of contracts in benchmark from worker arguments

### DIFF
--- a/packages/caliper-core/lib/common/config/default.yaml
+++ b/packages/caliper-core/lib/common/config/default.yaml
@@ -54,7 +54,7 @@ caliper:
     userconfig:
     # The file path for the user-level configuration file. Can be relative to the workspace.
     machineconfig:
-    # Path to the benchmark workload file that describes the test client(s), test rounds and monitor
+    # Path to the benchmark workload file that describes the test workers(s), test rounds and monitor
     benchconfig:
     # Path to the blockchain configuration file that contains information required to interact with the SUT
     networkconfig:
@@ -81,7 +81,7 @@ caliper:
         formats:
             # Adds a timestamp to the messages with the following format
             timestamp: 'YYYY.MM.DD-HH:mm:ss.SSS'
-            # Adds a specified label to every message. Useful for distributed client scenario
+            # Adds a specified label to every message. Useful for distributed workers scenario
             label: caliper
             # serializes the log messages as JSON
             json: false
@@ -188,7 +188,7 @@ caliper:
             proposalresponse: false
             # Indicates whether to verify that the read-write sets returned by the endorsers match
             readwritesets: true
-        # Contains client-side timeouts related to the initialization part of the adapter
+        # Contains worker-side timeouts related to the initialization part of the adapter
         timeout:
             # Timeout in milliseconds for the endorsement part of a contract instantiation
             contractinstantiate: 300000
@@ -196,8 +196,8 @@ caliper:
             contractinstantiateevent: 100000
             # The default timeout in milliseconds to use for invoking or querying transactions (applied for the entire life-cycle)
             invokeorquery: 60000
-        # Determines how automatic load balancing is applied if the client callback module doesn’t provide explicit targets.
-        # Use the value 'client' to perform client-based load balancing, meaning that each client process will have fix target peers and target orderer.
+        # Determines how automatic load balancing is applied if the worker callback module doesn’t provide explicit targets.
+        # Use the value 'worker' to perform worker-based load balancing, meaning that each worker process will have fix target peers and target orderer.
         # Use the value 'tx' to perform transaction-based load balancing, meaning that the peer and orderer targets change for every submitted transaction or query.
         loadbalancing: tx
         # Indicates whether to temporarily set the GOPATH environment variable to the Caliper root directory

--- a/packages/caliper-core/lib/common/messages/prepareMessage.js
+++ b/packages/caliper-core/lib/common/messages/prepareMessage.js
@@ -39,7 +39,7 @@ class PrepareMessage extends Message {
      * @return {object} The worker arguments.
      */
     getWorkerArguments() {
-        return this.content.clientArgs;
+        return this.content.workerArgs;
     }
 
     /**
@@ -47,7 +47,7 @@ class PrepareMessage extends Message {
      * @return {number} The number of workers.
      */
     getWorkersNumber() {
-        return this.content.totalClients;
+        return this.content.totalWorkers;
     }
 
     /**

--- a/packages/caliper-core/lib/common/messages/testMessage.js
+++ b/packages/caliper-core/lib/common/messages/testMessage.js
@@ -39,7 +39,7 @@ class TestMessage extends Message {
      * @return {object} The worker arguments.
      */
     getWorkerArguments() {
-        return this.content.clientArgs;
+        return this.content.workerArgs;
     }
 
     /**
@@ -47,7 +47,7 @@ class TestMessage extends Message {
      * @return {number} The number of workers.
      */
     getWorkersNumber() {
-        return this.content.totalClients;
+        return this.content.totalWorkers;
     }
 
     /**

--- a/packages/caliper-core/lib/manager/test-observers/null-observer.js
+++ b/packages/caliper-core/lib/manager/test-observers/null-observer.js
@@ -41,9 +41,9 @@ class NullObserver extends TestObserverInterface {
 
     /**
      * Start observing the test output
-     * @param {ClientOrchestrator} clientOrchestrator  the client orchestrator
+     * @param {WorkerOrchestrator} workerOrchestrator  the worker orchestrator
      */
-    startWatch(clientOrchestrator) {
+    startWatch(workerOrchestrator) {
         Logger.debug('No action taken by NullObserver on startWatch');
     }
 

--- a/packages/caliper-core/lib/manager/test-observers/observer-interface.js
+++ b/packages/caliper-core/lib/manager/test-observers/observer-interface.js
@@ -49,9 +49,9 @@ class TestObserverInterface {
 
     /**
      * Start watching the test output from the orchestrator
-     * @param {ClientOrchestrator} clientOrchestrator  the client orchestrator
+     * @param {WorkerOrchestrator} workerOrchestrator  the worker orchestrator
      */
-    startWatch(clientOrchestrator) {
+    startWatch(workerOrchestrator) {
         this._throwNotImplementedError('startWatch');
     }
 

--- a/packages/caliper-core/lib/manager/test-observers/test-observer.js
+++ b/packages/caliper-core/lib/manager/test-observers/test-observer.js
@@ -55,10 +55,10 @@ const TestObserver = class {
 
     /**
      * Start watching the test output from the orchestrator
-     * @param {ClientOrchestrator} clientOrchestrator  the client orchestrator
+     * @param {WorkerOrchestrator} workerOrchestrator  the worker orchestrator
      */
-    startWatch(clientOrchestrator) {
-        this.observer.startWatch(clientOrchestrator);
+    startWatch(workerOrchestrator) {
+        this.observer.startWatch(workerOrchestrator);
     }
 
     /**

--- a/packages/caliper-core/lib/worker/caliper-worker.js
+++ b/packages/caliper-core/lib/worker/caliper-worker.js
@@ -182,7 +182,7 @@ class CaliperWorker {
 
         try {
             Logger.debug(`Worker #${this.workerIndex} initializing adapter context`);
-            let context = await this.connector.getContext(testMessage.getRoundLabel(), workerArguments, this.workerIndex);
+            let context = await this.connector.getContext(roundIndex, workerArguments);
 
             // Activate dispatcher
             Logger.debug(`Worker #${this.workerIndex} activating TX observer dispatch`);

--- a/packages/caliper-core/lib/worker/rate-control/fixedFeedbackRate.js
+++ b/packages/caliper-core/lib/worker/rate-control/fixedFeedbackRate.js
@@ -44,9 +44,9 @@ class FixedFeedbackRateController extends RateInterface {
         super(testMessage, stats, workerIndex);
 
         const tps = this.options.tps ? parseInt(this.options.tps) : 10;
-        const tpsPerClient = tps / this.numberOfWorkers;
+        const tpsPerWorker = tps / this.numberOfWorkers;
 
-        this.generalSleepTime = (tpsPerClient > 0) ? 1000 / tpsPerClient : 0;
+        this.generalSleepTime = (tpsPerWorker > 0) ? 1000 / tpsPerWorker : 0;
         this.backOffTime = this.options.sleepTime || 100;
 
         const transactionLoad = this.options.transactionLoad ? this.options.transactionLoad : 10;

--- a/packages/caliper-core/lib/worker/rate-control/fixedLoad.js
+++ b/packages/caliper-core/lib/worker/rate-control/fixedLoad.js
@@ -39,8 +39,8 @@ class FixedLoad extends RateInterface {
         super(testMessage, stats, workerIndex);
 
         const tps = this.options.startTps ? parseInt(this.options.startTps) : 5;
-        const tpsPerClient = tps / this.numberOfWorkers;
-        this.sleepTime = 1000 / tpsPerClient;
+        const tpsPerWorker = tps / this.numberOfWorkers;
+        this.sleepTime = 1000 / tpsPerWorker;
         const transactionLoad = this.options.transactionLoad ? parseInt(this.options.transactionLoad) : 10;
         this.targetLoad = transactionLoad / this.numberOfWorkers;
     }

--- a/packages/caliper-core/lib/worker/rate-control/fixedRate.js
+++ b/packages/caliper-core/lib/worker/rate-control/fixedRate.js
@@ -37,8 +37,8 @@ class FixedRate extends RateInterface {
         super(testMessage, stats, workerIndex);
 
         const tps = this.options.tps ? this.options.tps : 10;
-        const tpsPerClient = tps / this.numberOfWorkers;
-        this.sleepTime = (tpsPerClient > 0) ? 1000/tpsPerClient : 0;
+        const tpsPerWorker = tps / this.numberOfWorkers;
+        this.sleepTime = (tpsPerWorker > 0) ? 1000/tpsPerWorker : 0;
     }
 
     /**

--- a/packages/caliper-core/lib/worker/rate-control/linearRate.js
+++ b/packages/caliper-core/lib/worker/rate-control/linearRate.js
@@ -39,7 +39,7 @@ class LinearRateController extends RateInterface {
     constructor(testMessage, stats, workerIndex) {
         super(testMessage, stats, workerIndex);
 
-        // distributing TPS among clients
+        // distributing TPS among workers
         let startingTps = Number(this.options.startingTps) / this.numberOfWorkers;
         let finishingTps = Number(this.options.finishingTps) / this.numberOfWorkers;
         this.startingSleepTime = 1000 / startingTps;

--- a/packages/caliper-core/lib/worker/rate-control/maxRate.js
+++ b/packages/caliper-core/lib/worker/rate-control/maxRate.js
@@ -48,11 +48,11 @@ class MaxRate extends RateInterface {
         // Include failed transactions in TPS
         this.includeFailed = this.options.includeFailed ? this.options.includeFailed : true;
 
-        // Client TPS
+        // Worker TPS
         const startTps = this.options.tps ? this.options.tps : 5;
-        const startTpsPerClient = startTps / this.numberOfWorkers;
+        const startTpsPerWorker = startTps / this.numberOfWorkers;
 
-        // Client TPS Step
+        // Worker TPS Step
         const tpsStep = this.options.step ? this.options.step : 5;
         this.step = tpsStep / this.numberOfWorkers;
 
@@ -64,8 +64,8 @@ class MaxRate extends RateInterface {
 
         // Object for TPS settings
         this.tpsSettings = {
-            previous: startTpsPerClient,
-            current: startTpsPerClient
+            previous: startTpsPerWorker,
+            current: startTpsPerWorker
         };
 
         // Object for observed stats

--- a/packages/caliper-core/test/worker/rate-control/fixedFeedbackRate.js
+++ b/packages/caliper-core/test/worker/rate-control/fixedFeedbackRate.js
@@ -40,13 +40,13 @@ describe('fixedFeedbackRate controller implementation', () => {
                 },
                 testRound:0,
                 txDuration:250,
-                totalClients:2
+                totalWorkers:2
             };
             testMessage = new TestMessage('test', [], msgContent);
         });
 
-        it('should set the sleepTime for a single client if no options are specified', () => {
-            testMessage.content.totalClients = 1;
+        it('should set the sleepTime for a single worker if no options are specified', () => {
+            testMessage.content.totalWorkers = 1;
             controller = new FixedFeedbackRate.createRateController(testMessage, {}, 0);
             controller.generalSleepTime.should.equal(100);
         });
@@ -92,7 +92,7 @@ describe('fixedFeedbackRate controller implementation', () => {
                 },
                 testRound:0,
                 txDuration:250,
-                totalClients:2
+                totalWorkers:2
             };
 
             clock = sinon.useFakeTimers();

--- a/packages/caliper-core/test/worker/rate-control/fixedLoad.js
+++ b/packages/caliper-core/test/worker/rate-control/fixedLoad.js
@@ -44,46 +44,46 @@ describe('fixedLoad controller implementation', () => {
                 },
                 testRound:0,
                 txDuration:250,
-                totalClients:2
+                totalWorkers:2
             };
             testMessage = new TestMessage('test', [], msgContent);
         });
 
-        it('should set the sleep time for a single client if a single worker is specified and the startingTps is not specified', () => {
+        it('should set the sleep time for a single worker if a single worker is specified and the startingTps is not specified', () => {
             testMessage.content.rateControl.opts = {};
-            testMessage.content.totalClients = 1;
+            testMessage.content.totalWorkers = 1;
             controller = new FixedLoad.createRateController(testMessage, {}, 0);
             controller.sleepTime.should.equal(200);
         });
 
-        it('should set the sleep time for a single client if no clients are specified and the startingTps is specified', () => {
+        it('should set the sleep time for a single worker if no workers are specified and the startingTps is specified', () => {
             testMessage.content.rateControl.opts = { startTps: 50 };
-            testMessage.content.totalClients = 1;
+            testMessage.content.totalWorkers = 1;
             controller = new FixedLoad.createRateController(testMessage, {}, 0);
             controller.sleepTime.should.equal(20);
         });
 
         it('should set the sleep time for a multiple workers it the startingTps is not specified', () => {
             testMessage.content.rateControl.opts = {};
-            testMessage.content.totalClients = 2;
+            testMessage.content.totalWorkers = 2;
             controller = new FixedLoad.createRateController(testMessage, {}, 0);
             controller.sleepTime.should.equal(400);
         });
 
         it('should set the sleep time for a multiple workers if the startingTps is specified', () => {
             testMessage.content.rateControl.opts = { startTps: 50 };
-            testMessage.content.totalClients = 2;
+            testMessage.content.totalWorkers = 2;
             controller = new FixedLoad.createRateController(testMessage, {}, 0);
             controller.sleepTime.should.equal(40);
         });
 
-        it('should set a default transaction backlog for multiple clients if not specified', () => {
+        it('should set a default transaction backlog for multiple workers if not specified', () => {
             testMessage.content.rateControl.opts = { startTps: 50 };
             controller = new FixedLoad.createRateController(testMessage, {}, 0);
             controller.targetLoad.should.equal(5);
         });
 
-        it('should set the transaction backlog for multiple clients if specified', () => {
+        it('should set the transaction backlog for multiple workers if specified', () => {
             controller = new FixedLoad.createRateController(testMessage, {}, 0);
             controller.targetLoad.should.equal(10);
         });
@@ -114,7 +114,7 @@ describe('fixedLoad controller implementation', () => {
                 },
                 testRound:0,
                 txDuration:250,
-                totalClients:2
+                totalWorkers:2
             };
             const testMessage = new TestMessage('test', [], msgContent);
             txnStats = new TransactionStatisticsCollector();

--- a/packages/caliper-core/test/worker/rate-control/fixedRate.js
+++ b/packages/caliper-core/test/worker/rate-control/fixedRate.js
@@ -41,26 +41,26 @@ describe('fixedRate controller implementation', () => {
                 },
                 testRound:0,
                 txDuration:250,
-                totalClients:2
+                totalWorkers:2
             };
             testMessage = new TestMessage('test', [], msgContent);
         });
 
         it('should set a default sleep time if no options passed', () => {
-            testMessage.content.totalClients = 1;
+            testMessage.content.totalWorkers = 1;
             controller = new FixedRate.createRateController(testMessage, {}, 0);
             controller.sleepTime.should.equal(100);
         });
 
-        it('should set the sleep time for a single client', () => {
-            testMessage.content.totalClients = 1;
+        it('should set the sleep time for a single worker', () => {
+            testMessage.content.totalWorkers = 1;
             testMessage.content.rateControl.opts = { tps: 50 };
             controller = new FixedRate.createRateController(testMessage, {}, 0);
             controller.sleepTime.should.equal(20);
         });
 
-        it('should set the sleep time for multiple clients', () => {
-            testMessage.content.totalClients = 2;
+        it('should set the sleep time for multiple workers', () => {
+            testMessage.content.totalWorkers = 2;
             testMessage.content.rateControl.opts = { tps: 50 };
             controller = new FixedRate.createRateController(testMessage, {}, 0);
             controller.sleepTime.should.equal(40);
@@ -83,7 +83,7 @@ describe('fixedRate controller implementation', () => {
                 },
                 testRound:0,
                 txDuration:250,
-                totalClients:2
+                totalWorkers:2
             };
 
             clock = sinon.useFakeTimers();

--- a/packages/caliper-core/test/worker/rate-control/linearRate.js
+++ b/packages/caliper-core/test/worker/rate-control/linearRate.js
@@ -41,7 +41,7 @@ describe('linearRate controller implementation', () => {
                 },
                 testRound:0,
                 txDuration:250,
-                totalClients:2
+                totalWorkers:2
             };
             testMessage = new TestMessage('test', [], msgContent);
         });
@@ -74,7 +74,7 @@ describe('linearRate controller implementation', () => {
                 },
                 testRound:0,
                 txDuration:250,
-                totalClients:2
+                totalWorkers:2
             };
             testMessage = new TestMessage('test', [], msgContent);
         });
@@ -113,7 +113,7 @@ describe('linearRate controller implementation', () => {
                 },
                 testRound:0,
                 txDuration:250,
-                totalClients:2
+                totalWorkers:2
             };
             testMessage = new TestMessage('test', [], msgContent);
         });
@@ -122,39 +122,39 @@ describe('linearRate controller implementation', () => {
             clock.restore();
         });
 
-        it('should set the starting sleep time based on starting tps and total number of clients', () => {
-            testMessage.content.totalClients = 6;
+        it('should set the starting sleep time based on starting tps and total number of workers', () => {
+            testMessage.content.totalWorkers = 6;
             testMessage.content.rateControl.opts = { startingTps: 20 };
             controller = new LinearRate.createRateController(testMessage, {}, 0);
 
-            // If there are 6 clients with an initial 20 TPS goal, the starting sleep time should be (1000/(20/6)) = 300ms
+            // If there are 6 workers with an initial 20 TPS goal, the starting sleep time should be (1000/(20/6)) = 300ms
             controller.startingSleepTime.should.equal(300);
         });
 
         it('should set the gradient based on linear interpolation between two points separated based on a txn count', () => {
-            testMessage.content.totalClients = 6;
+            testMessage.content.totalWorkers = 6;
             testMessage.content.rateControl.opts = { startingTps: 20, finishingTps: 80 };
             testMessage.content.numb = 5;
             controller = new LinearRate.createRateController(testMessage, {}, 0);
 
-            // if there are 6 clients with a starting sleep time of (1000/(20/6) = 300, a finishing sleep time of (1000/(80/6)) = 75, and a duration of 5,
+            // if there are 6 workers with a starting sleep time of (1000/(20/6) = 300, a finishing sleep time of (1000/(80/6)) = 75, and a duration of 5,
             // the gradient should be ((75 - 300) / 5) = -45
             controller.gradient.should.equal(-45);
         });
 
         it('should set the gradient based on linear interpolation between two points separated based on a duration count', () => {
-            testMessage.content.totalClients = 6;
+            testMessage.content.totalWorkers = 6;
             testMessage.content.rateControl.opts = { startingTps: 20, finishingTps: 80 };
             testMessage.content.txDuration = 5;
             controller = new LinearRate.createRateController(testMessage, {}, 0);
 
-            // If there are 6 clients with a starting sleep time of (1000/(20/6) = 300, a finishing sleep time of (1000/(80/6)) = 75, and a duration of (5*1000) = 5000,
+            // If there are 6 workers with a starting sleep time of (1000/(20/6) = 300, a finishing sleep time of (1000/(80/6)) = 75, and a duration of (5*1000) = 5000,
             // the gradient should be ((75 - 300) / 5000) = -0.045
             controller.gradient.should.equal(-0.045);
         });
 
         it('should assign _interpolateFromIndex to _interpolate if txCount based', () => {
-            testMessage.content.totalClients = 6;
+            testMessage.content.totalWorkers = 6;
             testMessage.content.rateControl.opts = { startingTps: 20, finishingTps: 80 };
             testMessage.content.numb = 5;
 
@@ -167,7 +167,7 @@ describe('linearRate controller implementation', () => {
         });
 
         it('should assign _interpolateFromTime to _interpolate if txCount based', () => {
-            testMessage.content.totalClients = 6;
+            testMessage.content.totalWorkers = 6;
             testMessage.content.rateControl.opts = { startingTps: 20, finishingTps: 80 };
             testMessage.content.txDuration = 5;
 
@@ -197,7 +197,7 @@ describe('linearRate controller implementation', () => {
                 },
                 testRound:0,
                 txDuration:250,
-                totalClients:2
+                totalWorkers:2
             };
 
             clock = sinon.useFakeTimers();

--- a/packages/caliper-core/test/worker/rate-control/maxRate.js
+++ b/packages/caliper-core/test/worker/rate-control/maxRate.js
@@ -42,7 +42,7 @@ describe('maxRate controller implementation', () => {
                 },
                 testRound:0,
                 txDuration:250,
-                totalClients:1
+                totalWorkers:1
             };
             testMessage = new TestMessage('test', [], msgContent);
         });
@@ -56,7 +56,7 @@ describe('maxRate controller implementation', () => {
             controller = new MaxRate.createRateController(testMessage, {}, 0);
             controller.tpsSettings.current.should.equal(5);
 
-            testMessage.content.totalClients = 2;
+            testMessage.content.totalWorkers = 2;
             controller = new MaxRate.createRateController(testMessage, {}, 0);
             controller.tpsSettings.current.should.equal(2.5);
         });
@@ -68,7 +68,7 @@ describe('maxRate controller implementation', () => {
             controller = new MaxRate.createRateController(testMessage, {}, 0);
             controller.tpsSettings.current.should.equal(10);
 
-            testMessage.content.totalClients = 2;
+            testMessage.content.totalWorkers = 2;
             controller = new MaxRate.createRateController(testMessage, {}, 0);
             controller.tpsSettings.current.should.equal(5);
         });
@@ -77,7 +77,7 @@ describe('maxRate controller implementation', () => {
             controller = new MaxRate.createRateController(testMessage, {}, 0);
             controller.step.should.equal(5);
 
-            testMessage.content.totalClients = 2;
+            testMessage.content.totalWorkers = 2;
             controller = new MaxRate.createRateController(testMessage, {}, 0);
             controller.step.should.equal(2.5);
         });
@@ -89,7 +89,7 @@ describe('maxRate controller implementation', () => {
             controller = new MaxRate.createRateController(testMessage, {}, 0);
             controller.step.should.equal(10);
 
-            testMessage.content.totalClients = 2;
+            testMessage.content.totalWorkers = 2;
             controller = new MaxRate.createRateController(testMessage, {}, 0);
             controller.step.should.equal(5);
         });
@@ -98,7 +98,7 @@ describe('maxRate controller implementation', () => {
             controller = new MaxRate.createRateController(testMessage, {}, 0);
             controller.sampleInterval.should.equal(10000);
 
-            testMessage.content.totalClients = 2;
+            testMessage.content.totalWorkers = 2;
             controller = new MaxRate.createRateController(testMessage, {}, 0);
             controller.sampleInterval.should.equal(10000);
         });
@@ -110,7 +110,7 @@ describe('maxRate controller implementation', () => {
             controller = new MaxRate.createRateController(testMessage, {}, 0);
             controller.sampleInterval.should.equal(20000);
 
-            testMessage.content.totalClients = 2;
+            testMessage.content.totalWorkers = 2;
             controller = new MaxRate.createRateController(testMessage, {}, 0);
             controller.sampleInterval.should.equal(20000);
         });
@@ -139,7 +139,7 @@ describe('maxRate controller implementation', () => {
                 },
                 testRound:0,
                 txDuration:250,
-                totalClients: 1
+                totalWorkers: 1
             };
 
             sleepStub = sinon.stub();
@@ -278,7 +278,7 @@ describe('maxRate controller implementation', () => {
                 },
                 testRound:0,
                 txDuration:250,
-                totalClients: 1
+                totalWorkers: 1
             };
 
             const testMessage = new TestMessage('test', [], msgContent);
@@ -326,7 +326,7 @@ describe('maxRate controller implementation', () => {
                 },
                 testRound:0,
                 txDuration:250,
-                totalClients: 1
+                totalWorkers: 1
             };
 
             const testMessage = new TestMessage('test', [], msgContent);
@@ -368,7 +368,7 @@ describe('maxRate controller implementation', () => {
                 },
                 testRound:0,
                 txDuration:250,
-                totalClients: 1
+                totalWorkers: 1
             };
 
             sleepStub = sinon.stub();

--- a/packages/caliper-core/test/worker/rate-control/noRate.js
+++ b/packages/caliper-core/test/worker/rate-control/noRate.js
@@ -41,7 +41,7 @@ describe('noRate controller implementation', () => {
                 },
                 testRound:0,
                 txDuration:250,
-                totalClients:2
+                totalWorkers:2
             };
             testMessage = new TestMessage('test', [], msgContent);
         });
@@ -84,7 +84,7 @@ describe('noRate controller implementation', () => {
                 },
                 testRound:0,
                 txDuration:250,
-                totalClients:2
+                totalWorkers:2
             };
 
             clock = sinon.useFakeTimers();


### PR DESCRIPTION
While inspecting integration test logs noticed that the ethereum connector was throwing errors due to missing arguments. 

The offending line ended up being in the worker orchestrator, with an invalid index being used to specify workerArguments

Additional changes present in this PR from searching the error via removal of all "client" references

Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>
