### PR TITLE
Besu integration test: Update docker-compose file

### DIFF
--- a/packages/caliper-tests-integration/besu_tests/config/docker-compose.yml
+++ b/packages/caliper-tests-integration/besu_tests/config/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     container_name: besu_clique
     volumes:
       - ./keys:/root/.ethereum/keystore
+      - ./data:/root
     ports:
       - 8545-8547:8545-8547
     command: --revert-reason-enabled --rpc-ws-enabled --rpc-ws-host 0.0.0.0 --host-whitelist=* --rpc-ws-apis admin,eth,miner,web3,net --graphql-http-enabled --discovery-enabled=false

--- a/packages/caliper-tests-integration/besu_tests/run.sh
+++ b/packages/caliper-tests-integration/besu_tests/run.sh
@@ -30,6 +30,7 @@ fi
 export CALIPER_PROJECTCONFIG=../caliper.yaml
 
 dispose () {
+    docker ps -a
     ${CALL_METHOD} launch manager --caliper-workspace phase1 --caliper-flow-only-end
 }
 

--- a/packages/caliper-tests-integration/ethereum_tests/run.sh
+++ b/packages/caliper-tests-integration/ethereum_tests/run.sh
@@ -30,6 +30,7 @@ fi
 export CALIPER_PROJECTCONFIG=caliper.yaml
 
 dispose () {
+    docker ps -a
     ${CALL_METHOD} launch manager --caliper-flow-only-end
 }
 

--- a/packages/caliper-tests-integration/fabric_tests/run.sh
+++ b/packages/caliper-tests-integration/fabric_tests/run.sh
@@ -37,6 +37,7 @@ fi
 export CALIPER_PROJECTCONFIG=../caliper.yaml
 
 dispose () {
+    docker ps -a
     ${CALL_METHOD} launch manager --caliper-workspace phase7 --caliper-flow-only-end --caliper-fabric-gateway-enabled
 }
 

--- a/packages/caliper-tests-integration/fisco-bcos_tests/run.sh
+++ b/packages/caliper-tests-integration/fisco-bcos_tests/run.sh
@@ -30,6 +30,7 @@ fi
 export CALIPER_PROJECTCONFIG=caliper.yaml
 
 dispose () {
+    docker ps -a
     ${CALL_METHOD} launch manager --caliper-flow-only-end
 }
 

--- a/packages/caliper-tests-integration/iroha_tests/run.sh
+++ b/packages/caliper-tests-integration/iroha_tests/run.sh
@@ -26,6 +26,7 @@ cd "${DIR}"
 export CALIPER_PROJECTCONFIG=caliper.yaml
 
 dispose () {
+    docker ps -a
     ${CALL_METHOD} launch manager --caliper-flow-only-end
 }
 

--- a/packages/caliper-tests-integration/sawtooth_tests/run.sh
+++ b/packages/caliper-tests-integration/sawtooth_tests/run.sh
@@ -30,6 +30,7 @@ fi
 export CALIPER_PROJECTCONFIG=caliper.yaml
 
 dispose () {
+    docker ps -a
     ${CALL_METHOD} launch manager --caliper-flow-only-end
 }
 


### PR DESCRIPTION
Besu integration test was failing due to a missing volume mount

This PR fixes the docker compose file, and moves the test to fail at the same point as the ethereum tests, which is fixed with #979

Also adds a `docker ps -a` in the dispose stage which was the command used to discover the failed `docker-compose up` step

Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>
