### PR TITLE
added getter for contract definitions

### DIFF
--- a/packages/caliper-fabric/lib/ConnectorConfiguration.js
+++ b/packages/caliper-fabric/lib/ConnectorConfiguration.js
@@ -86,6 +86,17 @@ class ConnectorConfiguration {
 
         return null;
     }
+    /**
+     * return array of contract definitions for specific channel
+     * @param {string} channelPassed channel wanted
+     * @returns {Array} all of contract definitions for channel
+    */
+    getContractDefinitionsForChannelName(channelPassed) {
+        const channelList = this.adapterConfiguration.channels;
+        const channelWanted = channelList.filter(channelContracts => channelContracts.channelName === channelPassed);
+        const contractDefinitions = channelWanted[0].contracts;
+        return contractDefinitions;
+    }
 }
 
 module.exports = ConnectorConfiguration;

--- a/packages/caliper-fabric/lib/ConnectorConfiguration.js
+++ b/packages/caliper-fabric/lib/ConnectorConfiguration.js
@@ -88,14 +88,19 @@ class ConnectorConfiguration {
     }
     /**
      * return array of contract definitions for specific channel
-     * @param {string} channelPassed channel wanted
+     * @param {string} channelName channel name wanted
      * @returns {Array} all of contract definitions for channel
     */
-    getContractDefinitionsForChannelName(channelPassed) {
+    getContractDefinitionsForChannelName(channelName) {
         const channelList = this.adapterConfiguration.channels;
-        const channelWanted = channelList.filter(channelContracts => channelContracts.channelName === channelPassed);
-        const contractDefinitions = channelWanted[0].contracts;
-        return contractDefinitions;
+
+        if (channelList && Array.isArray(channelList)){
+            const channelWanted = channelList.filter(channelContracts => channelContracts.channelName === channelName);
+            const contractDefinitions = channelWanted[0].contracts;
+            return contractDefinitions;
+        }
+
+        return [];
     }
 }
 

--- a/packages/caliper-fabric/lib/ConnectorConfiguration.js
+++ b/packages/caliper-fabric/lib/ConnectorConfiguration.js
@@ -97,9 +97,10 @@ class ConnectorConfiguration {
         if (channelList && Array.isArray(channelList)){
             const channelWanted = channelList.filter(channelContracts => channelContracts.channelName === channelName);
             const contractDefinitions = channelWanted[0].contracts;
-            return contractDefinitions;
+            if (contractDefinitions && Array.isArray(contractDefinitions)) {
+                return contractDefinitions;
+            }
         }
-
         return [];
     }
 }

--- a/packages/caliper-fabric/test/ConnectorConfiguration.js
+++ b/packages/caliper-fabric/test/ConnectorConfiguration.js
@@ -249,5 +249,14 @@ describe('A valid Adapter Configuration', () => {
             const contractDef = connectorConfiguration.getContractDefinitionsForChannelName('my-channel');
             contractDef.length.should.equal(0);
         });
+        it('should return an empty array if there are no channels', () => {
+            const configFile = new GenerateConfiguration('./test/sampleConfigs/BasicConfig.yaml').generateConfigurationFileWithSpecifics(
+                {
+                    channels: {}
+                });
+            const connectorConfiguration = new ConnectorConfigurationFactory().create(configFile);
+            const contractDef = connectorConfiguration.getContractDefinitionsForChannelName('my-channel');
+            contractDef.length.should.equal(0);
+        });
     });
 });

--- a/packages/caliper-fabric/test/ConnectorConfiguration.js
+++ b/packages/caliper-fabric/test/ConnectorConfiguration.js
@@ -258,5 +258,17 @@ describe('A valid Adapter Configuration', () => {
             const contractDef = connectorConfiguration.getContractDefinitionsForChannelName('my-channel');
             contractDef.length.should.equal(0);
         });
+
+        it('should return an empty array if there is not contract property', () => {
+            const configFile = new GenerateConfiguration('./test/sampleConfigs/BasicConfig.yaml').generateConfigurationFileWithSpecifics(
+                {
+                    channels: [{
+                        channelName: 'my-channel',
+                    }]
+                });
+            const connectorConfiguration = new ConnectorConfigurationFactory().create(configFile);
+            const contractDef = connectorConfiguration.getContractDefinitionsForChannelName('my-channel');
+            contractDef.should.deep.equal([]);
+        });
     });
 });

--- a/packages/caliper-fabric/test/ConnectorConfiguration.js
+++ b/packages/caliper-fabric/test/ConnectorConfiguration.js
@@ -222,4 +222,32 @@ describe('A valid Adapter Configuration', () => {
             should.equal(channelDefinition, null);
         });
     });
+
+    describe('for finding the Contract Definitions For a Channel Name', ()=> {
+        it('should return the contract definitions for the specified channel if there are contracts', () => {
+            const connectorConfiguration = new ConnectorConfigurationFactory().create('./test/sampleConfigs/BasicConfig.yaml');
+            const result=[{
+                id: 'marbles',
+                contractID: 'myMarbles',
+                version: 'v0',
+                language: 'golang',
+                path: 'marbles/go',
+                metadataPath: 'src/marbles/go/metadata'}];
+            const contractDef =connectorConfiguration.getContractDefinitionsForChannelName('my-channel');
+            contractDef.should.deep.equal(result);
+        });
+
+        it('should return an empty array if there are no contracts for the specified channel', () => {
+            const configFile = new GenerateConfiguration('./test/sampleConfigs/BasicConfig.yaml').generateConfigurationFileWithSpecifics(
+                {
+                    channels: [{
+                        channelName: 'my-channel',
+                        contracts: []
+                    }]
+                });
+            const connectorConfiguration = new ConnectorConfigurationFactory().create(configFile);
+            const contractDef = connectorConfiguration.getContractDefinitionsForChannelName('my-channel');
+            contractDef.length.should.equal(0);
+        });
+    });
 });


### PR DESCRIPTION
Signed-off-by: RosieMurphy0 <rosie.murphy@ibm.com>

Adds a function that returns the array that holds the contracts for a specified channel from the config file. 

Contributes to #940 
