### PR TITLE
Honour monitor getStatistics return requirement

### DIFF
--- a/packages/caliper-core/lib/manager/monitors/monitor-docker.js
+++ b/packages/caliper-core/lib/manager/monitors/monitor-docker.js
@@ -335,9 +335,10 @@ class MonitorDocker extends MonitorInterface {
      * @async
      */
     async getStatistics(testLabel) {
-        try {
-            const resourceStats = [];
 
+        const resourceStats = [];
+        let chartStats = [];
+        try {
             // Build a statistic for each monitored container and push into watchItems array
             for (const container of this.containers) {
                 if (container.hasOwnProperty('id')) {
@@ -378,16 +379,13 @@ class MonitorDocker extends MonitorInterface {
 
             // Retrieve Chart data
             const chartTypes = this.options.charting;
-            let chartStats = [];
             if (chartTypes) {
                 chartStats = ChartBuilder.retrieveChartStats(this.constructor.name, chartTypes, testLabel, resourceStats);
             }
-
-            return { resourceStats, chartStats };
         } catch (error) {
             Logger.error('Failed to read monitoring data, ' + (error.stack ? error.stack : error));
-            return [];
         }
+        return { resourceStats, chartStats };
     }
 
     /**

--- a/packages/caliper-core/lib/manager/monitors/monitor-process.js
+++ b/packages/caliper-core/lib/manager/monitors/monitor-process.js
@@ -262,8 +262,10 @@ class MonitorProcess extends MonitorInterface {
      * @async
      */
     async getStatistics(testLabel) {
+
+        const resourceStats = [];
+        let chartStats = [];
         try {
-            const resourceStats = [];
             for (const watchItem of this.watchItems) {
                 const key = this.getId(watchItem);
 
@@ -293,16 +295,14 @@ class MonitorProcess extends MonitorInterface {
 
             // Retrieve Chart data
             const chartTypes = this.options.charting;
-            let chartStats = [];
             if (chartTypes) {
                 chartStats = ChartBuilder.retrieveChartStats(this.constructor.name, chartTypes, testLabel, resourceStats);
             }
 
-            return { resourceStats, chartStats };
         } catch (error) {
             Logger.error('Failed to read monitoring data, ' + (error.stack ? error.stack : error));
-            return [];
         }
+        return { resourceStats, chartStats };
     }
 
     /**


### PR DESCRIPTION
Bug found while updating the caliper-benchmarks to add a travis build stage:
- with incorrectly specified monitor configuration files, or in cases of failure during `getStatistics`, the return object was incorrect and not able to be destructured into the required `{ resourceStats, chartStats }` shape as needed by the `report.buildRoundResourceStatistics()`; call
- This PR updates the monitor `getStatistics` methods to ensure compliance


Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>
