### PR TITLE
Drop _logHandling log level

### DIFF
--- a/packages/caliper-core/lib/worker/worker-message-handler.js
+++ b/packages/caliper-core/lib/worker/worker-message-handler.js
@@ -108,7 +108,7 @@ class WorkerMessageHandler {
             ? `Worker#${this.workerIndex} (${this.messenger.getUUID()})`
             : `Worker (${this.messenger.getUUID()})`;
 
-        logger.info(`Handling "${message.getType()}" message for ${workerID}: ${message.stringify()}`);
+        logger.debug(`Handling "${message.getType()}" message for ${workerID}: ${message.stringify()}`);
     }
 
     /**


### PR DESCRIPTION
When benchmarking, the `__logHandling` method spams the console log somewhat, and distracts from the actual process.

This PR drops the level to `debug` which is more appropriate

Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>
