### PR TITLE
remove ability to bind to broken fabric sdks

### DIFF
--- a/packages/caliper-cli/lib/lib/config.yaml
+++ b/packages/caliper-cli/lib/lib/config.yaml
@@ -45,15 +45,9 @@ sut:
         1.4.11: &fabric-latest
             packages: ['fabric-client@1.4.11', 'fabric-protos@2.0.0-snapshot.1', 'fabric-network@1.4.11']
         1.4: *fabric-latest
-        2.1.0:
+        2.1.0: &fabric-latest-v2
             packages: ['fabric-common@2.1.0', 'fabric-protos@2.1.0', 'fabric-network@2.1.0', 'fabric-ca-client@2.1.0']
-        2.2.0:
-            packages: ['fabric-network@2.2.0', 'fabric-ca-client@2.2.0']
-        2.2.1:
-            packages: ['fabric-network@2.2.1', 'fabric-ca-client@2.2.1']
-        2.2.2: &fabric-latest-v2
-            packages: ['fabric-network@2.2.2', 'fabric-ca-client@2.2.2']
-        2.2: *fabric-latest-v2
+        2.1: *fabric-latest-v2
         latest: *fabric-latest
         latest-v2: *fabric-latest-v2
 


### PR DESCRIPTION
2.2.2 sdk has shown to have concurrency issues - remove this from the possible caliper bindings to prevent users from using known bad SDKs

Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>
