### PR TITLE
Added support for v1 connectors with wallets 

### DIFF
--- a/packages/caliper-fabric/lib/connector-versions/v1/WalletFacade.js
+++ b/packages/caliper-fabric/lib/connector-versions/v1/WalletFacade.js
@@ -65,7 +65,7 @@ class WalletFacade extends IWalletFacade {
     async export(identityName) {
         const exported = await this.wallet.export(identityName);
         if (exported) {
-            return new ExportedIdentity(exported.mspId, exported.credentials.certificate, exported.credentials.privateKey);
+            return new ExportedIdentity(exported.mspId, exported.certificate, exported.privateKey);
         }
         return null;
     }

--- a/packages/caliper-fabric/lib/connector-versions/v1/WalletFacade.js
+++ b/packages/caliper-fabric/lib/connector-versions/v1/WalletFacade.js
@@ -1,0 +1,96 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const IWalletFacade = require('../../identity-management/IWalletFacade');
+const ExportedIdentity = require('../../identity-management/ExportedIdentity');
+const {FileSystemWallet, InMemoryWallet, X509WalletMixin} = require('fabric-network');
+
+/**
+ * a Facade for the V1 Wallet implementation
+ */
+class WalletFacade extends IWalletFacade {
+
+    /**
+     */
+    constructor() {
+        super();
+        this.wallet = null;
+    }
+
+    /**
+     * initialize this WalletFacade
+     *
+     * @param {string} [walletPath] an optional path to a file system wallet
+     */
+    async initialize(walletPath) {
+        if (!walletPath) {
+            this.wallet = new InMemoryWallet();
+        } else {
+            this.wallet = new FileSystemWallet(walletPath);
+        }
+    }
+
+    /**
+     * Import an identity
+     *
+     * @param {string} mspId The mspId that owns the identity
+     * @param {string} identityName The name of the identity
+     * @param {string} certificate The identity certificate
+     * @param {string} privateKey The identity private key
+     */
+    async import(mspId, identityName, certificate, privateKey) {
+        const exists = await this.wallet.export(identityName);
+
+        if (exists) {
+            throw new Error(`${identityName} already exists in the wallet`);
+        }
+
+        const identity = X509WalletMixin.createIdentity(mspId, certificate, privateKey);
+        await this.wallet.import(identityName, identity);
+    }
+
+    /**
+     * Export an identity
+     *
+     * @param {string} identityName The identity to export
+     * @returns {ExportedIdentity} The exported identity or null if it doesn't exist
+     */
+    async export(identityName) {
+        const exported = await this.wallet.export(identityName);
+        if (exported) {
+            return new ExportedIdentity(exported.mspid, exported.credentials.cert, exported.credentials.key);
+        }
+        return null;
+    }
+
+    /**
+     * Get all the identity names in the wallet
+     *
+     * @returns {[string]} all the identity names in the wallet
+     */
+    async getAllIdentityNames() {
+        return await this.wallet.list();
+    }
+
+    /**
+     * @returns {*} wallet
+     */
+    getWallet() {
+        return this.wallet;
+    }
+}
+
+module.exports = WalletFacade;

--- a/packages/caliper-fabric/lib/connector-versions/v1/WalletFacade.js
+++ b/packages/caliper-fabric/lib/connector-versions/v1/WalletFacade.js
@@ -24,18 +24,12 @@ const {FileSystemWallet, InMemoryWallet, X509WalletMixin} = require('fabric-netw
 class WalletFacade extends IWalletFacade {
 
     /**
-     */
-    constructor() {
-        super();
-        this.wallet = null;
-    }
-
-    /**
-     * initialize this WalletFacade
      *
      * @param {string} [walletPath] an optional path to a file system wallet
      */
-    async initialize(walletPath) {
+    constructor(walletPath) {
+        super();
+        this.wallet = null;
         if (!walletPath) {
             this.wallet = new InMemoryWallet();
         } else {
@@ -52,7 +46,7 @@ class WalletFacade extends IWalletFacade {
      * @param {string} privateKey The identity private key
      */
     async import(mspId, identityName, certificate, privateKey) {
-        const exists = await this.wallet.export(identityName);
+        const exists = await this.wallet.exists(identityName);
 
         if (exists) {
             throw new Error(`${identityName} already exists in the wallet`);
@@ -71,7 +65,7 @@ class WalletFacade extends IWalletFacade {
     async export(identityName) {
         const exported = await this.wallet.export(identityName);
         if (exported) {
-            return new ExportedIdentity(exported.mspid, exported.credentials.cert, exported.credentials.key);
+            return new ExportedIdentity(exported.mspId, exported.credentials.certificate, exported.credentials.privateKey);
         }
         return null;
     }
@@ -82,7 +76,7 @@ class WalletFacade extends IWalletFacade {
      * @returns {[string]} all the identity names in the wallet
      */
     async getAllIdentityNames() {
-        return await this.wallet.list();
+        return await this.wallet.getAllLabels();
     }
 
     /**

--- a/packages/caliper-fabric/lib/connector-versions/v1/WalletFacadeFactory.js
+++ b/packages/caliper-fabric/lib/connector-versions/v1/WalletFacadeFactory.js
@@ -1,0 +1,37 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const IWalletFacadeFactory = require('../../identity-management/IWalletFacadeFactory');
+const WalletFacade = require('./WalletFacade');
+
+/**
+ * Factory for a V1 Wallet Facade
+ */
+class WalletFacadeFactory extends IWalletFacadeFactory {
+
+    /**
+     * create a V1 Wallet Facade
+     *
+     * @param {[string]} walletPath optional path to a file system wallet
+     */
+    async create(walletPath) {
+        const walletFacade = new WalletFacade();
+        await walletFacade.initialize(walletPath);
+        return walletFacade;
+    }
+}
+
+module.exports = WalletFacadeFactory;

--- a/packages/caliper-fabric/lib/connector-versions/v1/WalletFacadeFactory.js
+++ b/packages/caliper-fabric/lib/connector-versions/v1/WalletFacadeFactory.js
@@ -28,8 +28,7 @@ class WalletFacadeFactory extends IWalletFacadeFactory {
      * @param {[string]} walletPath optional path to a file system wallet
      */
     async create(walletPath) {
-        const walletFacade = new WalletFacade();
-        await walletFacade.initialize(walletPath);
+        const walletFacade = new WalletFacade(walletPath);
         return walletFacade;
     }
 }

--- a/packages/caliper-fabric/test/connector-versions/v1/WalletFacade.js
+++ b/packages/caliper-fabric/test/connector-versions/v1/WalletFacade.js
@@ -1,0 +1,141 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+chai.should();
+const mockery = require('mockery');
+
+/**
+ * simulate a node sdk v1 wallet
+ */
+class StubWallet {
+    /**
+     * Mock V1 wallet implementation
+     */
+    constructor() {
+        this.map = new Map();
+    }
+
+    /**
+     *
+     * @param {*} key b
+     * @param {*} value b
+     */
+    async import(key, value) {
+        this.map.set(key, value);
+    }
+
+    /**
+     *
+     * @param {*} key b
+     */
+    async export(key) {
+        return this.map.get(key);
+    }
+
+    /**
+     *
+     */
+    async list() {
+        return Array.from(this.map.keys());
+    }
+}
+
+/**
+ * InMemoryWallet copy
+ */
+class InMemoryWallet extends StubWallet {}
+
+/**
+ * FileSystemWallet copy
+ */
+class FileSystemWallet extends StubWallet {}
+
+/**
+ * x509walletmixin class
+ */
+class X509WalletMixin {
+    /**
+    * @param {*} mspid b
+    * @param {*} cert b
+    * @param {*} key b
+    * @return {*} identity b
+    */
+    static createIdentity(mspid, cert, key){
+        const identity = {
+            credentials: {
+                cert,
+                key
+            },
+            mspid,
+            type: 'X.509',
+        };
+        return identity;
+    }
+}
+
+mockery.enable();
+mockery.registerMock('fabric-network',  {FileSystemWallet, InMemoryWallet, X509WalletMixin});
+
+const WalletFacadeFactory = require('../../../lib/connector-versions/v1/WalletFacadeFactory');
+const WalletFacade = require('../../../lib/connector-versions/v1/WalletFacade');
+
+describe('When testing a V1 Wallet Facade Implementation', () => {
+
+    beforeEach(() => {
+        mockery.enable();
+        mockery.registerMock('fabric-network',  {FileSystemWallet, InMemoryWallet, X509WalletMixin});
+    });
+
+    afterEach(() => {
+        mockery.deregisterAll();
+        mockery.disable();
+    });
+    it('A Wallet Facade Factory should create a wallet facade', async () => {
+        const walletFacade = await new WalletFacadeFactory().create();
+        walletFacade.should.be.instanceOf(WalletFacade);
+        const walletFacade2 = await new WalletFacadeFactory().create('optionalString');
+        walletFacade2.should.be.instanceOf(WalletFacade);
+    });
+
+    it('A wallet facade should be able to import and export identities', async () => {
+        const walletFacade = await new WalletFacadeFactory().create();
+        await walletFacade.import('mspid', 'label', 'cert', 'key');
+        const exported = await walletFacade.export('label');
+        exported.should.deep.equal({mspid: 'mspid', certificate: 'cert', privateKey: 'key'});
+    });
+
+    it('A wallet facade should throw an error if an identity already exists', async () => {
+        const walletFacade = await new WalletFacadeFactory().create();
+        await walletFacade.import('mspid', 'label', 'cert', 'key');
+        await walletFacade.import('mspid', 'label', 'cert', 'key').should.be.rejectedWith(/already exists/);
+    });
+
+    it('A wallet facade should get all identity names it has', async () => {
+        const walletFacade = await new WalletFacadeFactory().create();
+        await walletFacade.import('mspid', 'label', 'cert', 'key');
+        await walletFacade.import('mspid', 'bart', 'cert', 'key');
+        await walletFacade.import('mspid', 'lisa', 'cert', 'key');
+        (await walletFacade.getAllIdentityNames()).should.deep.equal(['label', 'bart', 'lisa']);
+    });
+
+    it('A wallet facade should return the real wallet instance', async () => {
+        const walletFacade = await new WalletFacadeFactory().create();
+        walletFacade.getWallet().should.be.instanceOf(StubWallet);
+    });
+});

--- a/packages/caliper-fabric/test/connector-versions/v1/WalletFacade.js
+++ b/packages/caliper-fabric/test/connector-versions/v1/WalletFacade.js
@@ -50,10 +50,8 @@ class FileSystemWallet extends StubWallet {}
 class X509WalletMixin {
     static createIdentity(mspId, certificate, privateKey){
         const identity = {
-            credentials: {
-                certificate,
-                privateKey
-            },
+            certificate,
+            privateKey,
             mspId,
             type: 'X.509',
         };


### PR DESCRIPTION
Signed-off-by: RosieMurphy0 <rosie.murphy@ibm.com>

Adds support for v1 connectors through 2 files: `WalletFacade` and `WalletFacadeFactory`. 

Contributes to #940 