### PR TITLE
Added support for Besu private transactions

### DIFF
--- a/packages/caliper-cli/lib/lib/config.yaml
+++ b/packages/caliper-cli/lib/lib/config.yaml
@@ -63,9 +63,9 @@ sut:
 
     besu:
         1.3.2:
-            packages: ['web3@1.2.2']
+            packages: ['web3@1.3.0']
         1.3:
-            packages: ['web3@1.2.2']
+            packages: ['web3@1.3.0']
         1.4: &besu-latest
-            packages: ['web3@1.2.2']
+            packages: ['web3@1.3.0']
         latest: *besu-latest

--- a/packages/caliper-ethereum/package.json
+++ b/packages/caliper-ethereum/package.json
@@ -23,10 +23,11 @@
     },
     "dependencies": {
         "@hyperledger/caliper-core": "0.4.0-unstable",
-        "ethereumjs-wallet": "^0.6.3"
+        "ethereumjs-wallet": "^0.6.3",
+        "web3": "1.3.0",
+        "web3-eea": "0.10.0"
     },
     "devDependencies": {
-        "web3": "1.2.2",
         "eslint": "^5.16.0",
         "mocha": "3.4.2",
         "nyc": "11.1.0",

--- a/packages/caliper-tests-integration/besu_tests/config/docker-compose.yml
+++ b/packages/caliper-tests-integration/besu_tests/config/docker-compose.yml
@@ -23,6 +23,14 @@ services:
     volumes:
       - ./keys:/root/.ethereum/keystore
       - ./data:/root
+      - ./orion:/orion
     ports:
       - 8545-8547:8545-8547
-    command: --revert-reason-enabled --rpc-ws-enabled --rpc-ws-host 0.0.0.0 --host-whitelist=* --rpc-ws-apis admin,eth,miner,web3,net --graphql-http-enabled --discovery-enabled=false
+    command: --min-gas-price 0 --revert-reason-enabled --rpc-ws-enabled --rpc-ws-host 0.0.0.0 --host-whitelist=* --rpc-ws-apis admin,eth,miner,web3,net,priv,eea --graphql-http-enabled --discovery-enabled=false --privacy-enabled=true --privacy-url=http://orion:8888 --privacy-public-key-file=/orion/key/orion.pub
+  orion:
+    image: "pegasyseng/orion:1.6.0"
+    container_name: orion
+    command: ["/config/orion.conf"]
+    volumes:
+      - ./orion/orion.conf:/config/orion.conf
+      - ./orion/key/:/keys/

--- a/packages/caliper-tests-integration/besu_tests/config/orion/key/orion.key
+++ b/packages/caliper-tests-integration/besu_tests/config/orion/key/orion.key
@@ -1,0 +1,1 @@
+{"data":{"bytes":"uTJGpd4ZEEtDPFSZM0+GT11xn5NFIr2KGP2Q4SdVPRM="},"type":"unlocked"}

--- a/packages/caliper-tests-integration/besu_tests/config/orion/key/orion.pub
+++ b/packages/caliper-tests-integration/besu_tests/config/orion/key/orion.pub
@@ -1,0 +1,1 @@
+GGilEkXLaQ9yhhtbpBT03Me9iYa7U/mWXxrJhnbl1XY=

--- a/packages/caliper-tests-integration/besu_tests/config/orion/orion.conf
+++ b/packages/caliper-tests-integration/besu_tests/config/orion/orion.conf
@@ -1,0 +1,12 @@
+nodeurl = "http://127.0.0.1:8080/"
+nodeport = 8080
+nodenetworkinterface = "0.0.0.0"
+
+clienturl = "http://127.0.0.1:8888/"
+clientport = 8888
+clientnetworkinterface = "0.0.0.0"
+
+tls = "off"
+
+publickeys = ["/keys/orion.pub"]
+privatekeys = ["/keys/orion.key"]

--- a/packages/caliper-tests-integration/besu_tests/package.json
+++ b/packages/caliper-tests-integration/besu_tests/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "besu_tests",
+  "version": "1.0.0",
+  "description": "Caliper Besu Integration Tests",
+  "keywords": [],
+  "author": "",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "web3": "1.3.0"
+  }
+}

--- a/packages/caliper-tests-integration/besu_tests/privatetxs/benchconfig.yaml
+++ b/packages/caliper-tests-integration/besu_tests/privatetxs/benchconfig.yaml
@@ -21,7 +21,7 @@
         number: 1
       rounds:
         - label: public store
-          txNumber: 5
+          txNumber: 100
           rateControl:
             type: fixed-rate
             opts:
@@ -31,7 +31,7 @@
             arguments:
               contract: public_storage
         - label: private store
-          txNumber: 5
+          txNumber: 100
           rateControl:
             type: fixed-rate
             opts:

--- a/packages/caliper-tests-integration/besu_tests/privatetxs/benchconfig.yaml
+++ b/packages/caliper-tests-integration/besu_tests/privatetxs/benchconfig.yaml
@@ -1,0 +1,44 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+    test:
+      name: Simple Storage
+      description: Test private transactions
+      workers:
+        type: local
+        number: 1
+      rounds:
+        - label: public store
+          txNumber: 5
+          rateControl:
+            type: fixed-rate
+            opts:
+              tps: 100
+          workload:
+            module: ./../store.js
+            arguments:
+              contract: public_storage
+        - label: private store
+          txNumber: 5
+          rateControl:
+            type: fixed-rate
+            opts:
+              tps: 100
+          workload:
+            module: ./../store.js
+            arguments:
+              contract: private_storage
+              private: group1
+    

--- a/packages/caliper-tests-integration/besu_tests/privatetxs/networkconfig.json
+++ b/packages/caliper-tests-integration/besu_tests/privatetxs/networkconfig.json
@@ -1,0 +1,49 @@
+{
+    "caliper": {
+        "blockchain": "ethereum",
+        "command" : {
+            "start": "docker-compose -f ../config/docker-compose.yml up -d && sleep 30",
+            "end" : "docker-compose -f ../config/docker-compose.yml down"
+          }
+    },
+    "ethereum": {
+        "url": "ws://localhost:8546",
+        "contractDeployerAddress": "0xD1cf9D73a91DE6630c2bb068Ba5fDdF9F0DEac09",
+        "contractDeployerAddressPrivateKey": "0x797c13f7235c627f6bd013dc17fff4c12213ab49abcf091f77c83f16db10e90b",
+        "fromAddressSeed": "0x3f841bf589fdf83a521e55d51afddc34fa65351161eead24f064855fc29c9580",
+        "transactionConfirmationBlocks": 1,
+        "chainId": 48122,
+    "privacy":  {
+        "group1": {
+            "groupType": "legacy",
+            "privateFrom": "GGilEkXLaQ9yhhtbpBT03Me9iYa7U/mWXxrJhnbl1XY=",
+            "privateFor": ["GGilEkXLaQ9yhhtbpBT03Me9iYa7U/mWXxrJhnbl1XY="]
+        },
+        "group2": {
+            "groupType": "pantheon",
+            "privateFrom": "GGilEkXLaQ9yhhtbpBT03Me9iYa7U/mWXxrJhnbl1XY=",
+            "privacyGroupId": "cskJg3WXZxU9kII4Tu42cZ6OmaB0ykldWsymFDhiTSQ="
+        },
+        "group3": {
+            "groupType": "onchain",
+            "privateFrom": "GGilEkXLaQ9yhhtbpBT03Me9iYa7U/mWXxrJhnbl1XY=",
+            "privacyGroupId": "cskJg3WXZxU9kII4Tu42cZ6OmaB0ykldWsymFDhiTSQ="
+        }
+    },
+    "contracts": {
+        "public_storage": {
+            "path": "../src/storage/storage.json",
+            "gas": {
+                "update": 30000
+            }
+        },
+        "private_storage": {
+            "path": "../src/storage/storage.json",
+            "gas": {
+                "update": 30000
+            },
+            "private": "group1" 
+        }
+    }
+    }
+}

--- a/packages/caliper-tests-integration/besu_tests/run.sh
+++ b/packages/caliper-tests-integration/besu_tests/run.sh
@@ -20,6 +20,8 @@ set -v
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "${DIR}"
 
+npm i
+
 # bind during CI tests, using the package dir as CWD
 # Note: do not use env variables for binding settings, as subsequent launch calls will pick them up and bind again
 if [[ "${BIND_IN_PACKAGE_DIR}" = "true" ]]; then
@@ -57,6 +59,15 @@ ${CALL_METHOD} launch manager --caliper-workspace phase3 --caliper-flow-skip-sta
 rc=$?
 if [[ ${rc} != 0 ]]; then
     echo "Failed CI step 3";
+    dispose;
+    exit ${rc};
+fi
+
+# PHASE 4: private transactions
+${CALL_METHOD} launch manager --caliper-workspace privatetxs --caliper-flow-skip-start --caliper-flow-skip-end
+rc=$?
+if [[ ${rc} != 0 ]]; then
+    echo "Failed CI step 4 - private txs";
     dispose;
     exit ${rc};
 fi

--- a/packages/caliper-tests-integration/besu_tests/src/storage/storage.json
+++ b/packages/caliper-tests-integration/besu_tests/src/storage/storage.json
@@ -1,0 +1,37 @@
+{
+    "name": "storage",
+    "abi": [
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "_value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "update",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "value",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        }
+    ],
+    "bytecode": "0x608060405234801561001057600080fd5b5060c38061001f6000396000f3fe6080604052348015600f57600080fd5b506004361060325760003560e01c80633fa4f24514603757806382ab890a146053575b600080fd5b603d607e565b6040518082815260200191505060405180910390f35b607c60048036036020811015606757600080fd5b81019080803590602001909291905050506084565b005b60005481565b806000819055505056fea265627a7a72315820e8496d56b71870b96edb4d71a4fd8101b771c4c269eb0d8ee8c27c6085fa76fc64736f6c63430005110032",
+    "gas": 3000000
+}

--- a/packages/caliper-tests-integration/besu_tests/src/storage/storage.sol
+++ b/packages/caliper-tests-integration/besu_tests/src/storage/storage.sol
@@ -1,0 +1,9 @@
+pragma solidity >=0.4.0 <0.6.0;
+
+contract SimpleStorage {
+    uint public value;
+    
+    function update(uint _value) public {
+        value = _value;
+    }
+}

--- a/packages/caliper-tests-integration/besu_tests/store.js
+++ b/packages/caliper-tests-integration/besu_tests/store.js
@@ -1,0 +1,109 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const { WorkloadModuleBase } = require('@hyperledger/caliper-core');
+const Web3 = require('web3');
+
+class StoreWorkload extends WorkloadModuleBase {
+
+    /**
+     * Initializes the parameters of the workload.
+     */
+    constructor() {
+        super();
+        this.txIndex = -1;
+        this.private = false;
+        this.contract;
+    }
+
+    /**
+     * Generates simple workload.
+     * @returns {{verb: String, args: Object[]}[]} Array of workload argument objects.
+     */
+    _generateWorkload() {
+        let web3 = new Web3(this.nodeUrl);
+
+        let workload = [];
+        for(let i= 0; i < this.roundArguments.txnPerBatch; i++) {
+            this.txIndex++;
+
+            let value = i;
+
+            let args = {
+                contract: this.roundArguments.contract,
+                verb: 'update',
+                args: [value],
+                readOnly: false,
+            }
+
+            if (this.isPrivate) {
+                args.privacy = this.privacyOpts;
+                args.privacy.sender = web3.eth.accounts.create();
+                args.privacy.sender.nonce = 0;
+            }
+
+            workload.push(args);
+        }
+
+        return workload;
+    }
+
+    /**
+     * Initialize the workload module with the given parameters.
+     * @param {number} workerIndex The 0-based index of the worker instantiating the workload module.
+     * @param {number} totalWorkers The total number of workers participating in the round.
+     * @param {number} roundIndex The 0-based index of the currently executing round.
+     * @param {Object} roundArguments The user-provided arguments for the round from the benchmark configuration file.
+     * @param {BlockchainConnector} sutAdapter The adapter of the underlying SUT.
+     * @param {Object} sutContext The custom context object provided by the SUT adapter.
+     * @async
+     */
+    async initializeWorkloadModule(workerIndex, totalWorkers, roundIndex, roundArguments, sutAdapter, sutContext) {
+        await super.initializeWorkloadModule(workerIndex, totalWorkers, roundIndex, roundArguments, sutAdapter, sutContext);
+
+        if (!this.roundArguments.contract) {
+            throw new Error('store - argument "contract" missing');
+        }
+
+        this.nodeUrl = sutContext.url;
+
+        if(this.roundArguments.private) {
+            this.isPrivate = true;
+            this.privacyOpts = sutContext.privacy[this.roundArguments.private];
+            this.privacyOpts['id'] = this.roundArguments.private;
+        } else {
+            this.private = false;
+        }
+
+        if(!this.roundArguments.txnPerBatch) {
+            this.roundArguments.txnPerBatch = 1;
+        }
+    }
+
+    /**
+     * Assemble TXs for opening new accounts.
+     */
+    async submitTransaction() {
+        let args = this._generateWorkload();
+        await this.sutAdapter.sendRequests(args);
+    }
+}
+
+function createWorkloadModule() {
+    return new StoreWorkload();
+}
+
+module.exports.createWorkloadModule = createWorkloadModule;

--- a/packages/caliper-tests-integration/besu_tests/store.js
+++ b/packages/caliper-tests-integration/besu_tests/store.js
@@ -85,7 +85,7 @@ class StoreWorkload extends WorkloadModuleBase {
             this.privacyOpts = sutContext.privacy[this.roundArguments.private];
             this.privacyOpts['id'] = this.roundArguments.private;
         } else {
-            this.private = false;
+            this.isPrivate = false;
         }
 
         if(!this.roundArguments.txnPerBatch) {

--- a/packages/caliper-tests-integration/besu_tests/store.js
+++ b/packages/caliper-tests-integration/besu_tests/store.js
@@ -26,7 +26,7 @@ class StoreWorkload extends WorkloadModuleBase {
         super();
         this.txIndex = -1;
         this.private = false;
-        this.contract;
+        this.contract = {};
     }
 
     /**

--- a/packages/caliper-tests-integration/package.json
+++ b/packages/caliper-tests-integration/package.json
@@ -112,7 +112,8 @@
             ".sol",
             ".address",
             ".proto",
-            ".cfg"
+            ".cfg",
+            ".conf"
         ],
         "insert_license": false,
         "license_formats": {


### PR DESCRIPTION
Besu supports [private transactions](https://besu.hyperledger.org/en/latest/Concepts/Privacy/Private-Transactions/) sent to a list of participant nodes. The library [web3js-eea](https://www.npmjs.com/package/web3-eea) supports sending private transactions to Besu.

By expanding the network configuration DSL and adding a few changes to the Ethereum connection, we can support sending private transactions to Besu using Caliper.

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [X]  Design of the change
 - [X]  How to prove that the change works
 - [X]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
As a user, I want to have performance metrics of Besu when using private transactions.

## Steps to Reproduce
N/A

## Existing issues
N/A
<!-- please include any links to issues here -->

## Design of the change
The core of the fix was to update `ethereum-connector.js` to be able to send private transactions. The network config DSL was extended to support some Besu privacy configurations.

In the network configuration, the `ethereum` object now can have a `privacy` section, enumerating privacy groups in the network. Also, there is the option of specifying what contracts should be private (and to what privacy group - aka participants - they belong to).

In the Ethereum connection, there are two new methods exclusively used for private transactions: `deployPrivateContract` and `_sendSinglePrivateRequest`.

## Validation of the change
I added a new step in the Besu integration tests to check the basic flow of public vs private contracts. I have done some manual testing as well to ensure the changes work.

## Automated Tests
See _Validation of the change_

## What documentation has been provided for this pull request
I'm not sure if we have specific Besu documentation for Caliper. If we do, we could probably add some info about using Besu with private transactions. Otherwise, the integration tests should be a good start for anyone wanting to use it.
