### PR TITLE
Prevent failures in integration tests

### DIFF
--- a/packages/caliper-tests-integration/besu_tests/caliper.yaml
+++ b/packages/caliper-tests-integration/besu_tests/caliper.yaml
@@ -17,8 +17,6 @@ caliper:
     networkconfig: networkconfig.json
     txupdatetime: 500
     workspace: ./
-    report:
-        path: ./report/report.html
     logging:
         template: '%timestamp%%level%%module%%message%%metadata%'
         formats:

--- a/packages/caliper-tests-integration/ethereum_tests/caliper.yaml
+++ b/packages/caliper-tests-integration/ethereum_tests/caliper.yaml
@@ -17,8 +17,6 @@ caliper:
     networkconfig: networkconfig.json
     txupdatetime: 500
     workspace: ./
-    report:
-        path: report.html
     logging:
         template: '%timestamp%%level%%module%%message%%metadata%'
         formats:

--- a/packages/caliper-tests-integration/fabric_tests/caliper.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/caliper.yaml
@@ -16,8 +16,6 @@ caliper:
     benchconfig: benchconfig.yaml
     networkconfig: networkconfig.yaml
     txupdatetime: 500
-    report:
-        path: ../report.html
     logging:
         template: '%timestamp%%level%%module%%message%%metadata%'
         formats:

--- a/packages/caliper-tests-integration/fisco-bcos_tests/caliper.yaml
+++ b/packages/caliper-tests-integration/fisco-bcos_tests/caliper.yaml
@@ -17,8 +17,6 @@ caliper:
     networkconfig: networkconfig.json
     workspace: ./
     txupdatetime: 500
-    report:
-        path: report.html
     logging:
         template: '%timestamp%%level%%module%%message%%metadata%'
         formats:

--- a/packages/caliper-tests-integration/generator_tests/fabric/caliper.yaml
+++ b/packages/caliper-tests-integration/generator_tests/fabric/caliper.yaml
@@ -15,8 +15,6 @@
 caliper:
     benchconfig: benchconfig.yaml
     networkconfig: networkconfig.yaml
-    report:
-        path: ../report.html
     logging:
         template: '%timestamp%%level%%module%%message%%metadata%'
         formats:


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

Travis is not permitting access to create folders, so the ethereum tests are showing invalid errors. 

This PR modifies the ethereum/besu integration tests (report path)  to prevent the error