### PR TITLE
Extracts identities from a wallet and stores in the in memory wallet

### DIFF
--- a/packages/caliper-fabric/lib/identity-management/IdentityManager.js
+++ b/packages/caliper-fabric/lib/identity-management/IdentityManager.js
@@ -186,6 +186,8 @@ class IdentityManager {
     async _extractIdentitiesFromWallet(mspId, wallet) {
         const walletFacade = await this.walletFacadeFactory.create(wallet.path);
         const allIDNames = await walletFacade.getAllIdentityNames();
+        // eslint-disable-next-line no-console
+        console.log({allIDNames});
         for (const identityName in allIDNames){
             const identity = await walletFacade.export(identityName);
             await this._addToWallet(identity.mspid, allIDNames[identityName], identity.certificate, identity.privateKey);

--- a/packages/caliper-fabric/lib/identity-management/IdentityManager.js
+++ b/packages/caliper-fabric/lib/identity-management/IdentityManager.js
@@ -184,7 +184,14 @@ class IdentityManager {
      * @private
      */
     async _extractIdentitiesFromWallet(mspId, wallet) {
-        // TODO: To be implemented
+        const walletFacade = await this.walletFacadeFactory.create(wallet.path);
+        const allIDNames = await walletFacade.getAllIdentityNames();
+        for (const identityNames in allIDNames){
+            const identity = await walletFacade.export(identityNames);
+            if (identity){
+                await this._addToWallet(identity.mspid, allIDNames[identityNames], identity.certificate, identity.privateKey);
+            }
+        }
     }
 
     /**

--- a/packages/caliper-fabric/lib/identity-management/IdentityManager.js
+++ b/packages/caliper-fabric/lib/identity-management/IdentityManager.js
@@ -186,11 +186,9 @@ class IdentityManager {
     async _extractIdentitiesFromWallet(mspId, wallet) {
         const walletFacade = await this.walletFacadeFactory.create(wallet.path);
         const allIDNames = await walletFacade.getAllIdentityNames();
-        for (const identityNames in allIDNames){
-            const identity = await walletFacade.export(identityNames);
-            if (identity){
-                await this._addToWallet(identity.mspid, allIDNames[identityNames], identity.certificate, identity.privateKey);
-            }
+        for (const identityName in allIDNames){
+            const identity = await walletFacade.export(identityName);
+            await this._addToWallet(identity.mspid, allIDNames[identityName], identity.certificate, identity.privateKey);
         }
     }
 

--- a/packages/caliper-fabric/test/connector-configuration/ConnectorConfiguration.js
+++ b/packages/caliper-fabric/test/connector-configuration/ConnectorConfiguration.js
@@ -301,8 +301,16 @@ describe('A valid Connector Configuration', () => {
 
         const stubWalletFacadeFactory = sinon.createStubInstance(IWalletFacadeFactory);
         const stubWalletFacade = sinon.createStubInstance(IWalletFacade);
-        stubWalletFacadeFactory.create.resolves(stubWalletFacade);
+        const secondStubWalletFacade = sinon.createStubInstance(IWalletFacade);
+        stubWalletFacadeFactory.create.onCall(0).resolves(stubWalletFacade);
+        stubWalletFacadeFactory.create.onCall(1).resolves(secondStubWalletFacade);
+        stubWalletFacadeFactory.create.onCall(2).resolves(secondStubWalletFacade);
+        secondStubWalletFacade.getAllIdentityNames.resolves([]);
         stubWalletFacade.getAllIdentityNames.resolves(['admin', 'user', '_org2MSP_admin', '_org2MSP_issuer']);
+
+        afterEach(() => {
+            sinon.resetHistory();
+        });
 
         it('should return the correct aliases for the default organisation', async () => {
             const connectorConfiguration = await new ConnectorConfigurationFactory().create('./test/sample-configs/BasicConfig.yaml', stubWalletFacadeFactory);

--- a/packages/caliper-fabric/test/identity-management/IdentityManager.js
+++ b/packages/caliper-fabric/test/identity-management/IdentityManager.js
@@ -233,13 +233,15 @@ describe('An Identity Manager', () => {
         const stubWalletFacadeFactory = sinon.createStubInstance(IWalletFacadeFactory);
         const stubWalletFacade = sinon.createStubInstance(IWalletFacade);
         const secondStubWalletFacade = sinon.createStubInstance(IWalletFacade);
-        stubWalletFacadeFactory.create.onFirstCall().resolves(stubWalletFacade);
         stubWalletFacade.getAllIdentityNames.resolves(['admin', 'user', '_org2MSP_admin', '_org2MSP_issuer']);
-
-        // const stubAllIdentityNames = sinon.stub();
-        // secondStubWalletFacade.getAllIdentityNames = stubAllIdentityNames.resolves([]);
         secondStubWalletFacade.getAllIdentityNames.resolves([]);
-        stubWalletFacadeFactory.create.onSecondCall().resolves(secondStubWalletFacade);
+        stubWalletFacadeFactory.create.onCall(0).resolves(stubWalletFacade);
+        stubWalletFacadeFactory.create.onCall(1).resolves(secondStubWalletFacade);
+        stubWalletFacadeFactory.create.onCall(2).resolves(secondStubWalletFacade);
+
+        afterEach(() => {
+            sinon.resetHistory();
+        });
 
         it('should return the correct aliases for the default organisation', async () => {
             const identityManagerFactory = new IdentityManagerFactory();
@@ -268,8 +270,17 @@ describe('An Identity Manager', () => {
 
         beforeEach(() => {
             stubWalletFacade = sinon.createStubInstance(IWalletFacade);
-            stubWalletFacadeFactory.create.resolves(stubWalletFacade);
             stubWalletFacade.getAllIdentityNames.resolves(['admin', 'user', '_org2MSP_admin', '_org2MSP_issuer']);
+            const secondStubWalletFacade = sinon.createStubInstance(IWalletFacade);
+            secondStubWalletFacade.getAllIdentityNames.resolves([]);
+            stubWalletFacadeFactory.create.onCall(0).resolves(stubWalletFacade);
+            stubWalletFacadeFactory.create.onCall(1).resolves(secondStubWalletFacade);
+            stubWalletFacadeFactory.create.onCall(2).resolves(secondStubWalletFacade);
+            secondStubWalletFacade.getAllIdentityNames.resolves([]);
+        });
+
+        afterEach(() => {
+            sinon.resetHistory();
         });
 
         it('should throw an error if certificates section isn\'t an array', async () => {
@@ -432,6 +443,12 @@ describe('An Identity Manager', () => {
             const stubWalletFacade = sinon.createStubInstance(IWalletFacade);
             stubWalletFacadeFactory.create.resolves(stubWalletFacade);
             stubWalletFacade.getAllIdentityNames.resolves(['User1']);
+            const testIdentity = {
+                mspid : 'org4MSP',
+                certificate : 'cert/path/to/somewhere.pem',
+                privateKey : 'key/path/to/somewhere.pem',
+            };
+            stubWalletFacade.export.resolves(testIdentity);
             const identityManagerFactory = new IdentityManagerFactory();
 
             const identityManager = await identityManagerFactory.create(stubWalletFacadeFactory, [org4MSP]);

--- a/packages/caliper-fabric/test/identity-management/IdentityManager.js
+++ b/packages/caliper-fabric/test/identity-management/IdentityManager.js
@@ -232,13 +232,14 @@ describe('An Identity Manager', () => {
     describe('when getting a list of alias names from an organisation', () => {
         const stubWalletFacadeFactory = sinon.createStubInstance(IWalletFacadeFactory);
         const stubWalletFacade = sinon.createStubInstance(IWalletFacade);
-        stubWalletFacadeFactory.create.resolves(stubWalletFacade);
+        const secondStubWalletFacade = sinon.createStubInstance(IWalletFacade);
+        stubWalletFacadeFactory.create.onFirstCall().resolves(stubWalletFacade);
         stubWalletFacade.getAllIdentityNames.resolves(['admin', 'user', '_org2MSP_admin', '_org2MSP_issuer']);
-        stubWalletFacade.export.resolves({
-            mspid : 'mspidstand',
-            certificate : 'cert/path/to/somewhere.pem',
-            privateKey : 'key/path/to/somewhere.pem',
-        });
+
+        // const stubAllIdentityNames = sinon.stub();
+        // secondStubWalletFacade.getAllIdentityNames = stubAllIdentityNames.resolves([]);
+        secondStubWalletFacade.getAllIdentityNames.resolves([]);
+        stubWalletFacadeFactory.create.onSecondCall().resolves(secondStubWalletFacade);
 
         it('should return the correct aliases for the default organisation', async () => {
             const identityManagerFactory = new IdentityManagerFactory();


### PR DESCRIPTION
Signed-off-by: RosieMurphy0 <rosie.murphy@ibm.com>

Implemented the `_extractIdentitiesFromWallet` method in the identity manager and the associated tests for the method. Takes identities from a wallet and stores them in the in memory wallet using an existing method. 

contributes to #940 
