### PR TITLE
Extract identities from a version specific wallet and store in the in memory wallet

### DIFF
--- a/packages/caliper-fabric/lib/identity-management/IdentityManager.js
+++ b/packages/caliper-fabric/lib/identity-management/IdentityManager.js
@@ -191,7 +191,14 @@ class IdentityManager {
      * @private
      */
     async _extractIdentitiesFromWallet(mspId, wallet) {
-        // TODO: To be implemented
+        const walletFacade = await this.walletFacadeFactory.create(wallet.path);
+        const allIDNames = await walletFacade.getAllIdentityNames();
+        // eslint-disable-next-line no-console
+        console.log({allIDNames});
+        for (const identityName in allIDNames){
+            const identity = await walletFacade.export(identityName);
+            await this._addToWallet(identity.mspid, allIDNames[identityName], identity.certificate, identity.privateKey);
+        }
     }
 
     /**

--- a/packages/caliper-fabric/test/connector-configuration/ConnectorConfiguration.js
+++ b/packages/caliper-fabric/test/connector-configuration/ConnectorConfiguration.js
@@ -306,8 +306,16 @@ describe('A valid Connector Configuration', () => {
     describe('when getting a list of alias names from an organisation', () => {
         const stubWalletFacadeFactory = sinon.createStubInstance(IWalletFacadeFactory);
         const stubWalletFacade = sinon.createStubInstance(IWalletFacade);
-        stubWalletFacadeFactory.create.resolves(stubWalletFacade);
+        const secondStubWalletFacade = sinon.createStubInstance(IWalletFacade);
+        stubWalletFacadeFactory.create.onCall(0).resolves(stubWalletFacade);
+        stubWalletFacadeFactory.create.onCall(1).resolves(secondStubWalletFacade);
+        stubWalletFacadeFactory.create.onCall(2).resolves(secondStubWalletFacade);
+        secondStubWalletFacade.getAllIdentityNames.resolves([]);
         stubWalletFacade.getAllIdentityNames.resolves(['admin', 'user', '_org2MSP_admin', '_org2MSP_issuer']);
+
+        afterEach(() => {
+            sinon.resetHistory();
+        });
 
         it('should return the correct aliases for the default organisation', async () => {
             const connectorConfiguration = await new ConnectorConfigurationFactory().create('./test/sample-configs/BasicConfig.yaml', stubWalletFacadeFactory);


### PR DESCRIPTION
Implemented the _extractIdentitiesFromWallet method in the identity manager and the associated tests for the method. Takes identities from a wallet and stores them in the in memory wallet using an existing method.

contributes to #940
