### PR TITLE
Extract identities from wallet to memory wallet

### DIFF
--- a/packages/caliper-fabric/lib/identity-management/IdentityManager.js
+++ b/packages/caliper-fabric/lib/identity-management/IdentityManager.js
@@ -71,7 +71,6 @@ class IdentityManager {
             if (mspId !== this.defaultMspId) {
                 return identityName.startsWith(this._getPrefixForIdentityNameFromOrganisation(mspId));
             }
-
             return identityName.search(/^_..*_/) === -1;
         });
     }
@@ -186,12 +185,17 @@ class IdentityManager {
     /**
      * Extract identities from a version specific wallet and store in the in memory wallet
      * @param {string} mspId mspId of the organisation
-     * @param {*} wallet the wallet information
+     * @param {*} wallet the wallet information from the configuration file
      * @async
      * @private
      */
     async _extractIdentitiesFromWallet(mspId, wallet) {
-        // TODO: To be implemented
+        const walletFacade = await this.walletFacadeFactory.create(wallet.path);
+        const allIdentityNames = await walletFacade.getAllIdentityNames();
+        for (const identityName of allIdentityNames){
+            const identity = await walletFacade.export(identityName);
+            await this._addToWallet(identity.mspid, identityName, identity.certificate, identity.privateKey);
+        }
     }
 
     /**

--- a/packages/caliper-fabric/test/connector-configuration/ConnectorConfiguration.js
+++ b/packages/caliper-fabric/test/connector-configuration/ConnectorConfiguration.js
@@ -30,6 +30,7 @@ describe('A valid Connector Configuration', () => {
 
     const walletFacadeFactory = sinon.createStubInstance(IWalletFacadeFactory);
     const walletFacade = sinon.createStubInstance(IWalletFacade);
+    walletFacade.getAllIdentityNames.resolves([]);
     walletFacadeFactory.create.resolves(walletFacade);
 
     describe('for mutual TLS', () => {
@@ -308,6 +309,12 @@ describe('A valid Connector Configuration', () => {
         const stubWalletFacade = sinon.createStubInstance(IWalletFacade);
         stubWalletFacadeFactory.create.resolves(stubWalletFacade);
         stubWalletFacade.getAllIdentityNames.resolves(['admin', 'user', '_org2MSP_admin', '_org2MSP_issuer']);
+        const testIdentity = {
+            mspid : 'Org1MSP',
+            certificate : '-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----',
+            privateKey : '-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----',
+        };
+        stubWalletFacade.export.resolves(testIdentity);
 
         it('should return the correct aliases for the default organisation', async () => {
             const connectorConfiguration = await new ConnectorConfigurationFactory().create('./test/sample-configs/BasicConfig.yaml', stubWalletFacadeFactory);
@@ -409,6 +416,7 @@ describe('A valid Connector Configuration', () => {
         const stubWalletFacadeFactory = sinon.createStubInstance(IWalletFacadeFactory);
         const stubWalletFacade = sinon.createStubInstance(IWalletFacade);
         stubWalletFacadeFactory.create.resolves(stubWalletFacade);
+        stubWalletFacade.getAllIdentityNames.resolves([]);
         stubWalletFacade.getWallet.returns('IamAwallet');
         const connectorConfiguration = await new ConnectorConfigurationFactory().create('./test/sample-configs/BasicConfig.yaml', stubWalletFacadeFactory);
         await connectorConfiguration.getWallet().should.equal('IamAwallet');
@@ -418,6 +426,7 @@ describe('A valid Connector Configuration', () => {
         const stubWalletFacadeFactory = sinon.createStubInstance(IWalletFacadeFactory);
         const stubWalletFacade = sinon.createStubInstance(IWalletFacade);
         stubWalletFacadeFactory.create.resolves(stubWalletFacade);
+        stubWalletFacade.getAllIdentityNames.resolves([]);
         const connectorConfiguration = await new ConnectorConfigurationFactory().create('./test/sample-configs/BasicConfig.yaml', stubWalletFacadeFactory);
         await connectorConfiguration.getWalletFacade().should.equal(stubWalletFacade);
     });

--- a/packages/caliper-fabric/test/connector-configuration/ConnectorConfigurationFactory.js
+++ b/packages/caliper-fabric/test/connector-configuration/ConnectorConfigurationFactory.js
@@ -29,6 +29,7 @@ describe('A Connector Configuration Factory', () => {
 
     const walletFacadeFactory = sinon.createStubInstance(IWalletFacadeFactory);
     const walletFacade = sinon.createStubInstance(IWalletFacade);
+    walletFacade.getAllIdentityNames.resolves([]);
     walletFacadeFactory.create.resolves(walletFacade);
 
     it('should accept a valid YAML file', async () => {


### PR DESCRIPTION
Implemented the _extractIdentitiesFromWallet method in the identity manager and the associated tests for the method. Takes identities from a wallet and stores them in the in memory wallet using an existing method. Changed some tests in the connector file as well that were effected. 

contributes to #940