### PR TITLE
support multiorg and channels

### DIFF
--- a/packages/caliper-fabric/lib/connector-versions/v1/FabricGateway.js
+++ b/packages/caliper-fabric/lib/connector-versions/v1/FabricGateway.js
@@ -235,13 +235,22 @@ class V1FabricGateway extends ConnectorBase {
         const contractMap = new Map();
         const channels = this.connectorConfiguration.getAllChannelNames();
         for (const channel of channels) {
-            const network = await gateway.getNetwork(channel);
+
+            let network;
+            try {
+                network = await gateway.getNetwork(channel);
+            } catch(err) {
+                logger.warn(`Couldn't initialize ${channel} for ${aliasName}. ${aliasName} not available for use on this channel. Error: ${err.message}`);
+                continue;
+            }
+
             const contracts = this.connectorConfiguration.getContractDefinitionsForChannelName(channel);
 
             for (const contract of contracts) {
                 const networkContract = await network.getContract(contract.id);
                 contractMap.set(`${channel}_${contract.id}`, networkContract);
             }
+
         }
         logger.debug('Exiting _createChannelAndChaincodeIdToContractMap');
 

--- a/packages/caliper-fabric/lib/connector-versions/v1/FabricNonGateway.js
+++ b/packages/caliper-fabric/lib/connector-versions/v1/FabricNonGateway.js
@@ -216,8 +216,7 @@ class V1Fabric extends ConnectorBase {
                     try {
                         await channel.initialize();
                     } catch (err) {
-                        logger.error(`Couldn't initialize ${channelName} for ${aliasName}: ${err.message}`);
-                        throw err;
+                        logger.warn(`Couldn't initialize ${channelName} for ${aliasName}. ${aliasName} not available for use on this channel. Error: ${err.message}`);
                     }
                 }
             }

--- a/packages/caliper-fabric/lib/connector-versions/v2/FabricGateway.js
+++ b/packages/caliper-fabric/lib/connector-versions/v2/FabricGateway.js
@@ -227,7 +227,15 @@ class V2FabricGateway extends ConnectorBase {
         const contractMap = new Map();
         const channels = this.connectorConfiguration.getAllChannelNames();
         for (const channel of channels) {
-            const network = await gateway.getNetwork(channel);
+
+            let network;
+            try {
+                network = await gateway.getNetwork(channel);
+            } catch(err) {
+                logger.warn(`Couldn't initialize ${channel} for ${aliasName}. ${aliasName} not available for use on this channel. Error: ${err.message}`);
+                continue;
+            }
+
             const contracts = this.connectorConfiguration.getContractDefinitionsForChannelName(channel);
 
             for (const contract of contracts) {

--- a/packages/caliper-fabric/test/connector-versions/v1/FabricNonGateway.js
+++ b/packages/caliper-fabric/test/connector-versions/v1/FabricNonGateway.js
@@ -128,13 +128,6 @@ describe('A Node-SDK V1 Fabric Non Gateway', () => {
         ChannelEventHub.disconnectCalls.should.equal(2);
     });
 
-    it('should throw an error if channel fails to initialize', async () => {
-        Channel.throwOnInitialize(new Error('init-failure'));
-        const connectorConfiguration = await new ConnectorConfigurationFactory().create(path.resolve(__dirname, configWith2Orgs1AdminInWallet), stubWalletFacadeFactory);
-        const fabricNonGateway = new FabricNonGateway(connectorConfiguration, 1, 'fabric');
-        await fabricNonGateway.getContext().should.be.rejectedWith(/init-failure/);
-    });
-
     describe('when interacting with a fabric network', () => {
         let fabricNonGateway;
 


### PR DESCRIPTION
Need to ensure we don't stop working when precaching the environment
because in a multiorg definition they may not have access to all the
channels defined.
This is an edge case because multiple org definitions is not a good use
of this implementation. But because it supports it we want to remove
this restriction.

Signed-off-by: D <d_kelsey@uk.ibm.com>


