### PR TITLE
FIX: caliper bind command now compatible with Windows OS

### DIFF
--- a/packages/caliper-cli/lib/lib/bindCommon.js
+++ b/packages/caliper-cli/lib/lib/bindCommon.js
@@ -167,7 +167,7 @@ class BindCommon {
 
             logger.info(`Using working directory: ${cwd}`);
             logger.info(`Calling npm with: ${argArray.join(' ')}`);
-            await CaliperUtils.invokeCommand('npm', argArray,  { ...settings.env, ...process.env }, cwd);
+            await CaliperUtils.invokeCommand(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', argArray,  { ...settings.env, ...process.env }, cwd);
         } catch (e) {
             logger.error(e.message);
             throw e;


### PR DESCRIPTION
Signed-off-by: FranSoto7 <franciscomanuel.sotoramirez@gmail.com>

npx caliper bind command wouldn't work on a Windows machine, since the command for npm would be "npm.cmd" instead of just "npm".

Added a comprobation in runtime to check if the OS is Windows, otherwise it works like before.
