### PR TITLE
Resolve issue in which only first round would be docker-monitored

### DIFF
--- a/packages/caliper-core/lib/manager/monitors/monitor-docker.js
+++ b/packages/caliper-core/lib/manager/monitors/monitor-docker.js
@@ -274,7 +274,7 @@ class MonitorDocker extends MonitorInterface {
      */
     async start() {
         // Conditionally build monitored containers, these are persisted between rounds and restart action
-        if (!this.containers || this.containers.length == 0) {
+        if (!this.containers || this.containers.length === 0) {
             await this.findContainers();
         }
         // Read stats immediately, then kick off monitor refresh at interval

--- a/packages/caliper-core/lib/manager/monitors/monitor-docker.js
+++ b/packages/caliper-core/lib/manager/monitors/monitor-docker.js
@@ -274,7 +274,7 @@ class MonitorDocker extends MonitorInterface {
      */
     async start() {
         // Conditionally build monitored containers, these are persisted between rounds and restart action
-        if (!this.containers) {
+        if (!this.containers || this.containers.length == 0) {
             await this.findContainers();
         }
         // Read stats immediately, then kick off monitor refresh at interval


### PR DESCRIPTION
There is an issue that docker containers are only monitored during the first round of a multi-round benchmark as described in issue #1134.
The problem is caused by the fact that the `stop()` command sets the `this.containers` property to the empty array `[]`, while it expects a `null` value to (re)set the containers list. By setting this to `if (!this.containers || this.containers.length == 0)`, we account for both cases.

Resolves #1134
