### PR TITLE
Fixed link to Fabric connector configuration for docs v0.4.2 for Caliper website homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@ layout: home
         <strong>Ethereum</strong>
         <img src="https://avatars1.githubusercontent.com/u/6250754?s=200&v=4" alt="Ethereum">
       </a>
-      <a class="project" href="{{ site.baseurl }}/{{ site.caliper.current_release }}/fabric-config">
+      <a class="project" href="{{ site.baseurl }}/{{ site.caliper.current_release }}/fabric-config/new/">
         <strong>Hyperledger Fabric</strong>
         <img src="https://www.hyperledger.org/wp-content/uploads/2018/03/Hyperledger_Fabric_Logo_White.png" alt="Fabric">
       </a>


### PR DESCRIPTION
Signed-off-by: Aastha Bist <abist119@gmail.com>

<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [x]  How to recreate the problem without the fix
   - The link to Hyperledger Fabric configuration on [https://hyperledger.github.io/caliper/](https://hyperledger.github.io/caliper/) gives a 404 error on being clicked
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->
The current documentation release v0.4.2 is the one being referenced so I kept the link for the new Fabric confic docs instead of the previous broken link.

