### PR TITLE
Allow specification of custom EOA's and nonces

### DIFF
--- a/packages/caliper-tests-integration/besu_tests/store.js
+++ b/packages/caliper-tests-integration/besu_tests/store.js
@@ -51,8 +51,8 @@ class StoreWorkload extends WorkloadModuleBase {
 
             if (this.isPrivate) {
                 args.privacy = this.privacyOpts;
-                args.privacy.sender = web3.eth.accounts.create();
-                args.privacy.sender.nonce = 0;
+                args.sender = web3.eth.accounts.create();
+                args.sender.nonce = 0;
             }
 
             workload.push(args);


### PR DESCRIPTION
Proposes a solution to #1135 , namely by allowing users to set request.sender.privateKey and request.sender.nonce.