### PR TITLE
allow creating onchain privacy groups during test setup

### DIFF
--- a/packages/caliper-tests-integration/besu_tests/config/docker-compose.yml
+++ b/packages/caliper-tests-integration/besu_tests/config/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - ./orion:/orion
     ports:
       - 8545-8547:8545-8547
-    command: --min-gas-price 0 --revert-reason-enabled --rpc-ws-enabled --rpc-ws-host 0.0.0.0 --host-whitelist=* --rpc-ws-apis admin,eth,miner,web3,net,priv,eea --graphql-http-enabled --discovery-enabled=false --privacy-enabled=true --privacy-url=http://orion:8888 --privacy-public-key-file=/orion/key/orion.pub
+    command: --min-gas-price 0 --revert-reason-enabled --rpc-ws-enabled --rpc-ws-host 0.0.0.0 --host-whitelist=* --rpc-ws-apis admin,eth,miner,web3,net,priv,eea --graphql-http-enabled --discovery-enabled=false --privacy-enabled=true --privacy-url=http://orion:8888 --privacy-public-key-file=/orion/key/orion.pub --privacy-flexible-groups-enabled
   orion:
     image: "pegasyseng/orion:1.6.0"
     container_name: orion

--- a/packages/caliper-tests-integration/besu_tests/privatetxs/benchconfig.yaml
+++ b/packages/caliper-tests-integration/besu_tests/privatetxs/benchconfig.yaml
@@ -40,5 +40,4 @@
             module: ./../store.js
             arguments:
               contract: private_storage
-              private: group1
-    
+              private: group3

--- a/packages/caliper-tests-integration/besu_tests/privatetxs/networkconfig.json
+++ b/packages/caliper-tests-integration/besu_tests/privatetxs/networkconfig.json
@@ -13,37 +13,37 @@
         "fromAddressSeed": "0x3f841bf589fdf83a521e55d51afddc34fa65351161eead24f064855fc29c9580",
         "transactionConfirmationBlocks": 1,
         "chainId": 48122,
-    "privacy":  {
-        "group1": {
-            "groupType": "legacy",
-            "privateFrom": "GGilEkXLaQ9yhhtbpBT03Me9iYa7U/mWXxrJhnbl1XY=",
-            "privateFor": ["GGilEkXLaQ9yhhtbpBT03Me9iYa7U/mWXxrJhnbl1XY="]
-        },
-        "group2": {
-            "groupType": "pantheon",
-            "privateFrom": "GGilEkXLaQ9yhhtbpBT03Me9iYa7U/mWXxrJhnbl1XY=",
-            "privacyGroupId": "cskJg3WXZxU9kII4Tu42cZ6OmaB0ykldWsymFDhiTSQ="
-        },
-        "group3": {
-            "groupType": "onchain",
-            "privateFrom": "GGilEkXLaQ9yhhtbpBT03Me9iYa7U/mWXxrJhnbl1XY=",
-            "privacyGroupId": "cskJg3WXZxU9kII4Tu42cZ6OmaB0ykldWsymFDhiTSQ="
-        }
-    },
-    "contracts": {
-        "public_storage": {
-            "path": "../src/storage/storage.json",
-            "gas": {
-                "update": 30000
+        "privacy":  {
+            "group1": {
+                "groupType": "legacy",
+                "privateFrom": "GGilEkXLaQ9yhhtbpBT03Me9iYa7U/mWXxrJhnbl1XY=",
+                "privateFor": ["GGilEkXLaQ9yhhtbpBT03Me9iYa7U/mWXxrJhnbl1XY="]
+            },
+            "group2": {
+                "groupType": "pantheon",
+                "privateFrom": "GGilEkXLaQ9yhhtbpBT03Me9iYa7U/mWXxrJhnbl1XY=",
+                "privateKey": "uTJGpd4ZEEtDPFSZM0+GT11xn5NFIr2KGP2Q4SdVPRM="
+            },
+            "group3": {
+                "groupType": "onchain",
+                "privateFrom": "GGilEkXLaQ9yhhtbpBT03Me9iYa7U/mWXxrJhnbl1XY=",
+                "privateKey": "uTJGpd4ZEEtDPFSZM0+GT11xn5NFIr2KGP2Q4SdVPRM="
             }
         },
-        "private_storage": {
-            "path": "../src/storage/storage.json",
-            "gas": {
-                "update": 30000
+        "contracts": {
+            "public_storage": {
+                "path": "../src/storage/storage.json",
+                "gas": {
+                    "update": 30000
+                }
             },
-            "private": "group1" 
+            "private_storage": {
+                "path": "../src/storage/storage.json",
+                "gas": {
+                    "update": 30000
+                },
+                "private": "group3"
+            }
         }
-    }
     }
 }


### PR DESCRIPTION
Signed-off-by: Taccat Isid <taccatisid@protonmail.com>

<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - ~~A link to the issue/user story that the pull request relates to~~
 - [x]  How to recreate the problem without the fix
 - [x]  Design of the fix
 - [x]  How to prove that the fix works
 - [x]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
<!--- What issue / user story is this for -->
When using caliper with onchain privacy the user currently has to create privacy groups outside of caliper and then record the privacyGroupId in the caliper network config. The id itself is created randomly. Having a fixed value in the caliper network config would require to also have a lot of ossified smart contract state the besu genesis file.

## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [x] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-caliper)
- [x] [GitHub Issues](https://github.com/hyperledger/caliper/issues)
- [x] [Rocket Chat history](https://chat.hyperledger.org/channel/caliper)

<!-- please include any links to issues here -->

## Design of the fix
The setup phase of the ethereum connector was extended to allow creation of privacy groups. The generated group ids are injected into the configuration and passed to individual workers via `prepareWorkerArguments` and `getContext`.
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->
The PR has been tested by using both the existing and the extended (see below) integration tests.

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->
The existing privacy integration tests have been modified to use onchain privacy with dynamically generated groups. It would be preferable to test onchain and legacy privacy groups at the same time. But a single besu instance only supports one or the other and using onchain allows for far more coverage.

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->
None so far.