### PR TITLE
Make fixed load rate controller honor the target duration

### DIFF
--- a/packages/caliper-core/lib/worker/rate-control/fixedLoad.js
+++ b/packages/caliper-core/lib/worker/rate-control/fixedLoad.js
@@ -60,11 +60,6 @@ class FixedLoad extends RateInterface {
         // Get transaction details
         let unfinished = this.stats.getTotalSubmittedTx() - this.stats.getTotalFinishedTx();
 
-        // Shortcut if we are below the target threshold
-        if (unfinished < this.targetLoad) {
-            return;
-        }
-
         const targetLoadDifference = unfinished - this.targetLoad;
 
         // Shortcut if we are below the target threshold and need to increase the loading

--- a/packages/caliper-core/lib/worker/rate-control/fixedLoad.js
+++ b/packages/caliper-core/lib/worker/rate-control/fixedLoad.js
@@ -52,7 +52,8 @@ class FixedLoad extends RateInterface {
     async applyRateControl() {
 
         // Waiting until transactions have completed.
-        if (this.stats.getTotalFinishedTx() === 0) {
+        const completedTransactions = this.stats.getTotalFinishedTx();
+        if (completedTransactions === 0) {
             await Sleep(this.sleepTime);
             return;
         }
@@ -69,17 +70,11 @@ class FixedLoad extends RateInterface {
         }
 
         // Determine the current TPS
-        const completedTransactions = this.stats.getTotalSuccessfulTx() + this.stats.getTotalFailedTx();
         const latency = (this.stats.getTotalLatencyForSuccessful() + this.stats.getTotalLatencyForFailed()) / 1000;
         const tps = (completedTransactions / latency);
 
         // Determine the required sleep to reduce the backlog ( deltaTXN * 1/TPS = sleep in seconds to build the desired txn load)
-        let sleepTime = 0;
-        if (tps !== 0) {
-            sleepTime = targetLoadDifference * 1000 / tps;
-        } else {
-            sleepTime = targetLoadDifference * this.sleepTime;
-        }
+        let sleepTime = targetLoadDifference * 1000 / tps;
 
         Logger.debug('Difference between current and desired transaction backlog: ' + targetLoadDifference);
         await Sleep(sleepTime);


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - ~~A link to the issue/user story that the pull request relates to~~
 - [x]  How to recreate the problem without the fix
 - [x]  Design of the fix
 - [x]  How to prove that the fix works
 - [x]  Automated tests that prove the fix keeps on working
 - ~~Documentation - any JSDoc, website, or Stackoverflow answers?~~


## Issue/User story
<!--- What issue / user story is this for -->
When using the fixed load rate controller we did run into issues where a hanging SUT or a suden drop in the SUT's TPS caused our target duration exceeded by a factor of 50.

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
Running the benchmarks added in https://github.com/hyperledger/besu/pull/2716 with higher transaction backlogs than used in https://github.com/hyperledger/besu/pull/2716/files#diff-bbce9037b01a9a2ee863e5a760f513e416f2efa57669582a6c316a168044c310 causes this behaviour--e.g. with backlog 300 instead of the used 200. The benchmarks can be executed using `cd benchmark && docker-compose -f docker-compose.yml run caliper`.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-caliper)
- [ ] [GitHub Issues](https://github.com/hyperledger/caliper/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/caliper)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->
1. The total runtime of a round is bounded by twice the target duration. Exceeding it causes aborting with an exception.
2. The fixed load rate controller is modified to wait indefinitely as long as the target backlog size is exceeded by a factor of more than two.

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->
- [x] Tested via unit test
- [ ] Tested using the above mentioned besu benchmark suite

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->
Unit tests are adapted and added for the fixed load rate controller.

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->
None.
