### PR TITLE
Fix generator integration test

### DIFF
--- a/packages/caliper-tests-integration/generator_tests/fabric/run.sh
+++ b/packages/caliper-tests-integration/generator_tests/fabric/run.sh
@@ -28,7 +28,7 @@ dispose () {
 }
 
 # Install yo
-npm install --global yo
+npm install --global yo@3.1.1
 
 # generate the crypto materials
 cd ./config

--- a/packages/generator-caliper/package.json
+++ b/packages/generator-caliper/package.json
@@ -29,7 +29,7 @@
         "generators"
     ],
     "dependencies": {
-        "yeoman-generator": "4.7.2",
+        "yeoman-generator": "3.1.1",
         "camelcase": "6.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
* Downgrade to v3 Yeoman generator in dependencies
* Downgrade to v3 Yeoman generator in integration test

Note: Yeoman v4 requires Node.js v14 LTS, bump back versions once Node version is also bumped.

Signed-off-by: Attila Klenik <a.klenik@gmail.com>