### PR TITLE
Fix CompositeRateController class bug (#1181)

### DIFF
--- a/packages/caliper-core/lib/common/messages/testMessage.js
+++ b/packages/caliper-core/lib/common/messages/testMessage.js
@@ -67,6 +67,14 @@ class TestMessage extends Message {
     }
 
     /**
+     * Sets the rate control specification for the round.
+     * @param {object} rateControlSpec The rate control specification.
+     */
+    setRateControlSpec(rateControlSpec) {
+        this.content.rateControl = rateControlSpec;
+    }
+
+    /**
      * Gets the trim length for the round.
      * @return {number} The trim length.
      */
@@ -107,11 +115,36 @@ class TestMessage extends Message {
     }
 
     /**
+     * Sets the number of TXs to perform in the round.
+     * @param {number} numberOfTxs The number of TXs.
+     */
+    setNumberOfTxs(numberOfTxs) {
+        this.content.numb = numberOfTxs;
+    }
+
+    /**
      * Gets the target duration for the round in seconds.
      * @return {number} The duration of the round in seconds.
      */
     getRoundDuration() {
         return this.content.txDuration;
+    }
+
+    /**
+     * Sets the target duration for the round in seconds.
+     * @param {number} txDuration The duration of the round in seconds.
+     */
+    setRoundDuration(txDuration) {
+        this.content.txDuration = txDuration;
+    }
+
+    /**
+     * Deep-clones the test message.
+     * @returns {TestMessage} The clone test message.
+     */
+    clone() {
+        const contentClone = JSON.parse(JSON.stringify(this.content));
+        return new TestMessage(this.sender, Array.from(this.recipients), contentClone, this.date, this.error);
     }
 }
 

--- a/packages/caliper-tests-integration/fabric_tests/phase5/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase5/benchconfig.yaml
@@ -20,7 +20,17 @@ test:
     rounds:
     - label: query1
       txNumber: 50
-      rateControl: { type: 'fixed-rate', opts: { tps: 3 } }
+      rateControl:
+        type: composite-rate
+        opts:
+          weights: [2,1]
+          rateControllers:
+          - type: fixed-rate
+            opts:
+              tps: 2
+          - type: fixed-rate
+            opts:
+              tps: 4
       workload:
         module: ./../query.js
     - label: query2


### PR DESCRIPTION
* Rename old "roundConfig" references to the new "testMessage"
* Extend TestMessage class with some functions to allow modification by CompositeRateController
* Fix passed arguments to the new RateControl constructor when creating subcontrollers
* Add a composite rate controller to one of the Fabric CI phases

Fixes #1181 

Signed-off-by: Attila Klenik <a.klenik@gmail.com>