### PR TITLE
Fix the unit of the interval of default-observer in the log

### DIFF
--- a/packages/caliper-core/lib/manager/test-observers/default-observer.js
+++ b/packages/caliper-core/lib/manager/test-observers/default-observer.js
@@ -34,7 +34,7 @@ class DefaultObserver extends TestObserverInterface {
 
         // set the observer interval
         this.observeInterval = ConfigUtil.get(ConfigUtil.keys.Progress.Reporting.Interval);
-        Logger.info(`Observer interval set to ${this.observeInterval} seconds`);
+        Logger.info(`Observer interval set to ${this.observeInterval} milliseconds`);
         this.observeIntervalObject = null;
         this.updateTail = 0;
         this.updateID   = 0;


### PR DESCRIPTION
It uses milliseconds not seconds.
It shows like:
`caliper  | 2021.12.27-13:26:12.001 info  [caliper] [default-observer] 	Observer interval set to 5000 seconds`

Signed-off-by: Justin Yang <justin.yang@themedium.io>
