### PR TITLE
address fabric:1.4 sut binding not working in caliper container

### DIFF
--- a/packages/caliper-cli/lib/lib/config.yaml
+++ b/packages/caliper-cli/lib/lib/config.yaml
@@ -43,9 +43,9 @@ sut:
             settings:
             - *new-node-old-grpc
         1.4.11:
-            packages: ['fabric-client@1.4.11', 'fabric-protos@2.0.0-snapshot.1', 'fabric-network@1.4.11']
+            packages: ['fabric-client@1.4.11', 'fabric-protos@2.0.0-snapshot.1', 'fabric-network@1.4.11','fs-extra@8.1.0']
         1.4.14: &fabric-v1-lts
-            packages: ['fabric-client@1.4.14', 'fabric-protos@2.0.0-snapshot.1', 'fabric-network@1.4.14']
+            packages: ['fabric-client@1.4.14', 'fabric-protos@2.0.0-snapshot.1', 'fabric-network@1.4.14','fs-extra@8.1.0']
         1.4: *fabric-v1-lts
         2.1.0: &fabric-v2-2.1
             packages: ['fabric-common@2.1.0', 'fabric-protos@2.1.0', 'fabric-network@2.1.0', 'fabric-ca-client@2.1.0']


### PR DESCRIPTION
Issue in 1.4 node sdk means that some dependencies aren't available when
binding to a 1.4 fabric sut in the caliper docker container

closes #1146

Signed-off-by: D <d_kelsey@uk.ibm.com>
