### PR TITLE
Correct timeout defaults

### DIFF
--- a/packages/caliper-core/lib/common/config/default.yaml
+++ b/packages/caliper-core/lib/common/config/default.yaml
@@ -208,8 +208,8 @@ caliper:
             contractinstantiate: 300000
             # Timeout in milliseconds for receiving the event about the result of a contract instantiation
             contractinstantiateevent: 100000
-            # The default timeout in milliseconds to use for invoking or querying transactions (applied for the entire life-cycle)
-            invokeorquery: 60000
+            # The default timeout in seconds to use for invoking or querying transactions (applied for the entire life-cycle)
+            invokeorquery: 60
         # Determines how automatic load balancing is applied if the worker callback module doesn’t provide explicit targets.
         # Use the value 'worker' to perform worker-based load balancing, meaning that each worker process will have fix target peers and target orderer.
         # Use the value 'tx' to perform transaction-based load balancing, meaning that the peer and orderer targets change for every submitted transaction or query.

--- a/packages/caliper-fabric/lib/connector-versions/v1/FabricGateway.js
+++ b/packages/caliper-fabric/lib/connector-versions/v1/FabricGateway.js
@@ -90,7 +90,7 @@ class V1FabricGateway extends ConnectorBase {
 
         // this value is hardcoded, if it's used, that means that the provided timeouts are not sufficient
         this.configSmallestTimeout = 1000;
-        this.configDefaultTimeout = ConfigUtil.get(ConfigUtil.keys.Fabric.Timeout.InvokeOrQuery, 60000);
+        this.configDefaultTimeout = ConfigUtil.get(ConfigUtil.keys.Fabric.Timeout.InvokeOrQuery, 60);
         this.configCountQueryAsLoad = ConfigUtil.get(ConfigUtil.keys.Fabric.CountQueryAsLoad, true);
 
         // Gateway connector

--- a/packages/caliper-fabric/lib/connector-versions/v1/FabricNonGateway.js
+++ b/packages/caliper-fabric/lib/connector-versions/v1/FabricNonGateway.js
@@ -81,7 +81,7 @@ class V1Fabric extends ConnectorBase {
         this.configVerifyProposalResponse = ConfigUtil.get(ConfigUtil.keys.Fabric.Verify.ProposalResponse, true);
         this.configVerifyReadWriteSets = ConfigUtil.get(ConfigUtil.keys.Fabric.Verify.ReadWriteSets, true);
         this.configLatencyThreshold = ConfigUtil.get(ConfigUtil.keys.Fabric.LatencyThreshold, 1.0);
-        this.configDefaultTimeout = ConfigUtil.get(ConfigUtil.keys.Fabric.Timeout.InvokeOrQuery, 60000);
+        this.configDefaultTimeout = ConfigUtil.get(ConfigUtil.keys.Fabric.Timeout.InvokeOrQuery, 60);
         this.configClientBasedLoadBalancing = ConfigUtil.get(ConfigUtil.keys.Fabric.LoadBalancing, 'client') === 'client';
         this.configCountQueryAsLoad = ConfigUtil.get(ConfigUtil.keys.Fabric.CountQueryAsLoad, true);
 

--- a/packages/caliper-fabric/lib/connector-versions/v1/fabric-gateway.js
+++ b/packages/caliper-fabric/lib/connector-versions/v1/fabric-gateway.js
@@ -164,7 +164,7 @@ class LegacyV1FabricGateway extends ConnectorBase {
         this.configOverwriteGopath = ConfigUtil.get(ConfigUtil.keys.Fabric.OverwriteGopath, true);
         this.configContractInstantiateTimeout = ConfigUtil.get(ConfigUtil.keys.Fabric.Timeout.ContractInstantiate, 300000);
         this.configContractInstantiateEventTimeout = ConfigUtil.get(ConfigUtil.keys.Fabric.Timeout.ContractInstantiateEvent, 300000);
-        this.configDefaultTimeout = ConfigUtil.get(ConfigUtil.keys.Fabric.Timeout.InvokeOrQuery, 60000);
+        this.configDefaultTimeout = ConfigUtil.get(ConfigUtil.keys.Fabric.Timeout.InvokeOrQuery, 60);
         this.configCountQueryAsLoad = ConfigUtil.get(ConfigUtil.keys.Fabric.CountQueryAsLoad, true);
 
         // Gateway connector

--- a/packages/caliper-fabric/lib/connector-versions/v1/fabric.js
+++ b/packages/caliper-fabric/lib/connector-versions/v1/fabric.js
@@ -113,7 +113,7 @@ class LegacyV1Fabric extends ConnectorBase {
         this.configOverwriteGopath = ConfigUtil.get(ConfigUtil.keys.Fabric.OverwriteGopath, true);
         this.configContractInstantiateTimeout = ConfigUtil.get(ConfigUtil.keys.Fabric.Timeout.ContractInstantiate, 300000);
         this.configContractInstantiateEventTimeout = ConfigUtil.get(ConfigUtil.keys.Fabric.Timeout.ContractInstantiateEvent, 300000);
-        this.configDefaultTimeout = ConfigUtil.get(ConfigUtil.keys.Fabric.Timeout.InvokeOrQuery, 60000);
+        this.configDefaultTimeout = ConfigUtil.get(ConfigUtil.keys.Fabric.Timeout.InvokeOrQuery, 60);
         this.configClientBasedLoadBalancing = ConfigUtil.get(ConfigUtil.keys.Fabric.LoadBalancing, 'client') === 'client';
         this.configCountQueryAsLoad = ConfigUtil.get(ConfigUtil.keys.Fabric.CountQueryAsLoad, true);
 

--- a/packages/caliper-fabric/lib/connector-versions/v2/FabricGateway.js
+++ b/packages/caliper-fabric/lib/connector-versions/v2/FabricGateway.js
@@ -89,7 +89,7 @@ class V2FabricGateway extends ConnectorBase {
 
         // Timeouts
         this.configSmallestTimeout = 1000;
-        this.configDefaultTimeout = ConfigUtil.get(ConfigUtil.keys.Fabric.Timeout.InvokeOrQuery, 60000);
+        this.configDefaultTimeout = ConfigUtil.get(ConfigUtil.keys.Fabric.Timeout.InvokeOrQuery, 60);
         this.configCountQueryAsLoad = ConfigUtil.get(ConfigUtil.keys.Fabric.CountQueryAsLoad, true);
 
         // Gateway connector

--- a/packages/caliper-fabric/lib/connector-versions/v2/fabric-gateway.js
+++ b/packages/caliper-fabric/lib/connector-versions/v2/fabric-gateway.js
@@ -117,7 +117,7 @@ class LegacyV2FabricGateway extends ConnectorBase {
 
         // Timeouts
         this.configSmallestTimeout = 1000;
-        this.configDefaultTimeout = ConfigUtil.get(ConfigUtil.keys.Fabric.Timeout.InvokeOrQuery, 60000);
+        this.configDefaultTimeout = ConfigUtil.get(ConfigUtil.keys.Fabric.Timeout.InvokeOrQuery, 60);
         this.configCountQueryAsLoad = ConfigUtil.get(ConfigUtil.keys.Fabric.CountQueryAsLoad, true);
 
         // Gateway connector


### PR DESCRIPTION
This is the apparent cause of a caliper run hang where it continues to
run with unfinished txns. It's actually waiting 60,000 seconds for txns
to finish which won't finish as it looks like the node sdk misses the
events.

code part of #1141 also addresses in part

Signed-off-by: D <d_kelsey@uk.ibm.com>
