### PR TITLE
Remove CountQueryAsLoad Option

### DIFF
--- a/packages/caliper-core/lib/common/config/Config.js
+++ b/packages/caliper-core/lib/common/config/Config.js
@@ -157,7 +157,6 @@ const keys = {
         LoadBalancing: 'caliper-fabric-loadbalancing',
         OverwriteGopath: 'caliper-fabric-overwritegopath',
         LatencyThreshold: 'caliper-fabric-latencythreshold',
-        CountQueryAsLoad: 'caliper-fabric-countqueryasload',
         SkipCreateChannelPrefix: 'caliper-fabric-skipcreatechannel-',
         Gateway: {
             Enabled: 'caliper-fabric-gateway-enabled',

--- a/packages/caliper-fabric/lib/connector-versions/v1/FabricGateway.js
+++ b/packages/caliper-fabric/lib/connector-versions/v1/FabricGateway.js
@@ -89,9 +89,7 @@ class V1FabricGateway extends ConnectorBase {
         this.context = undefined;
 
         // this value is hardcoded, if it's used, that means that the provided timeouts are not sufficient
-        this.configSmallestTimeout = 1000;
         this.configDefaultTimeout = ConfigUtil.get(ConfigUtil.keys.Fabric.Timeout.InvokeOrQuery, 60);
-        this.configCountQueryAsLoad = ConfigUtil.get(ConfigUtil.keys.Fabric.CountQueryAsLoad, true);
 
         // Gateway connector
         this.configLocalHost = ConfigUtil.get(ConfigUtil.keys.Fabric.Gateway.LocalHost, true);

--- a/packages/caliper-fabric/lib/connector-versions/v1/FabricNonGateway.js
+++ b/packages/caliper-fabric/lib/connector-versions/v1/FabricNonGateway.js
@@ -83,7 +83,6 @@ class V1Fabric extends ConnectorBase {
         this.configLatencyThreshold = ConfigUtil.get(ConfigUtil.keys.Fabric.LatencyThreshold, 1.0);
         this.configDefaultTimeout = ConfigUtil.get(ConfigUtil.keys.Fabric.Timeout.InvokeOrQuery, 60);
         this.configClientBasedLoadBalancing = ConfigUtil.get(ConfigUtil.keys.Fabric.LoadBalancing, 'client') === 'client';
-        this.configCountQueryAsLoad = ConfigUtil.get(ConfigUtil.keys.Fabric.CountQueryAsLoad, true);
 
         this.transactionCounter = -1;
     }

--- a/packages/caliper-fabric/lib/connector-versions/v2/FabricGateway.js
+++ b/packages/caliper-fabric/lib/connector-versions/v2/FabricGateway.js
@@ -88,9 +88,7 @@ class V2FabricGateway extends ConnectorBase {
         this.context = undefined;
 
         // Timeouts
-        this.configSmallestTimeout = 1000;
         this.configDefaultTimeout = ConfigUtil.get(ConfigUtil.keys.Fabric.Timeout.InvokeOrQuery, 60);
-        this.configCountQueryAsLoad = ConfigUtil.get(ConfigUtil.keys.Fabric.CountQueryAsLoad, true);
 
         // Gateway connector
         this.configLocalHost = ConfigUtil.get(ConfigUtil.keys.Fabric.Gateway.LocalHost, true);

--- a/packages/caliper-tests-integration/package.json
+++ b/packages/caliper-tests-integration/package.json
@@ -88,7 +88,9 @@
             "fisco-bcos_tests/config/node3",
             "fisco-bcos_tests/config/sdk",
             "generator_tests/fabric/.gitignore",
-            "generator_tests/fabric/config/.gitignore"
+            "generator_tests/fabric/config/.gitignore",
+            "generator_tests/fabric/config/bin",
+            "generator_tests/fabric/config/config"
         ],
         "file_type_method": "EXCLUDE",
         "file_types": [


### PR DESCRIPTION
Also fixes
1. unused timeout property in fabric gateway connectors
2. ignore license check in generator tests for downloaded files

Doc update to follow

Signed-off-by: D <d_kelsey@uk.ibm.com>
