### PR TITLE
Caliper terminates if prometheus is not available

### DIFF
--- a/packages/caliper-core/lib/common/prometheus/prometheus-query-client.js
+++ b/packages/caliper-core/lib/common/prometheus/prometheus-query-client.js
@@ -149,10 +149,11 @@ class PrometheusQueryClient {
                         resolve();
                     }
                 });
-                res.on('error', err => {
-                    Logger.error(err);
-                    reject(err);
-                });
+            });
+
+            req.on('error', err => {
+                Logger.error(err);
+                reject(err);
             });
 
             req.end();


### PR DESCRIPTION
This is due to the error event not being correctly captured when a
request is made to prometheus

Also added some extra code to output a warning and stop trying to do any
more queries for the round.

It won't stop it for all rounds but checks on every round.

closes #1267

Signed-off-by: D <d_kelsey@uk.ibm.com>
