### PR TITLE
Peer Gateway: Added Connector Selector implementation modifications to support the new Peer Gateway Connector

### DIFF
--- a/packages/caliper-cli/lib/lib/config.yaml
+++ b/packages/caliper-cli/lib/lib/config.yaml
@@ -42,6 +42,8 @@ sut:
         2.2.11: &fabric-v2-lts
             packages: ['fabric-network@2.2.11']
         2.2: *fabric-v2-lts
+        2.4: 
+            packages: ['@hyperledger/fabric-gateway@1.0.1']
         latest: *fabric-v1-lts
         latest-v2-lts: *fabric-v2-lts
         latest-v2: *fabric-v2-lts

--- a/packages/caliper-fabric/test/FabricConnectorFactory.js
+++ b/packages/caliper-fabric/test/FabricConnectorFactory.js
@@ -29,6 +29,7 @@ const { ConfigUtil } = require('@hyperledger/caliper-core');
 const unsupportedConfig = './sample-configs/LegacyNetworkConfig.yaml';
 const v2Config = './sample-configs/NoIdentitiesNetworkConfig.yaml';
 const unknownVersionConfig = './sample-configs/UnknownVersionConfig.yaml';
+const peerGatewayConfig = './sample-configs/BasicConfig.yaml';
 
 const DefaultEventHandlerStrategies = {};
 const DefaultQueryHandlerStrategies = {};
@@ -163,19 +164,58 @@ describe('A Fabric Connector Factory', () => {
         mockery.deregisterAll();
     });
 
-    it('should throw an error if no fabric library is bound', async () => {
-        // Can't test this with mockery because really need require to fail trying to
-        // find `fabric-network` or `fabric-client`
+    it('should create a Peer Gateway Fabric connector if a 1.x fabric-gateway library is bound', async () => {
+        mockery.registerMock('@hyperledger/fabric-gateway', {});
+        mockery.registerMock('@hyperledger/fabric-gateway/package', {version: '1.0.1'});
+        mockery.registerMock('@grpc/grpc-js', {});
+        ConfigUtil.set(ConfigUtil.keys.NetworkConfig, path.resolve(__dirname, peerGatewayConfig));
+        ConfigUtil.set(ConfigUtil.keys.Fabric.Gateway.Enabled, false);
+        const connector = await ConnectorFactory(1);
+        connector.constructor.name.should.equal('PeerGateway');
+        mockery.deregisterAll();
     });
 
-    it('should throw an error if fabric library bound is not V1 or V2', async () => {
+    it('should throw an error if no fabric library is bound', async () => {
+        ConfigUtil.set(ConfigUtil.keys.NetworkConfig, path.resolve(__dirname, peerGatewayConfig));
+        ConfigUtil.set(ConfigUtil.keys.Fabric.Gateway.Enabled, true);
+        await ConnectorFactory(1).should.be.rejectedWith(/Unable to detect required Fabric binding packages/);
+    });
+
+    it('should throw an error if fabric-gateway library bound is not than v1.x', async () => {
+        mockery.registerMock('@hyperledger/fabric-gateway', {});
+        mockery.registerMock('@hyperledger/fabric-gateway/package', {version: '0.5.0'});
+        ConfigUtil.set(ConfigUtil.keys.NetworkConfig, path.resolve(__dirname, peerGatewayConfig));
+        ConfigUtil.set(ConfigUtil.keys.Fabric.Gateway.Enabled, true);
+        await ConnectorFactory(1).should.be.rejectedWith(/Installed fabric-gateway SDK version 0.5.0 did not match any compatible Fabric connectors/);
+        mockery.deregisterAll();
+        mockery.registerMock('@hyperledger/fabric-gateway', {});
+        mockery.registerMock('@hyperledger/fabric-gateway/package', {version: '2.5.0'});
+        await ConnectorFactory(1).should.be.rejectedWith(/Installed fabric-gateway SDK version 2.5.0 did not match any compatible Fabric connectors/);
+        mockery.deregisterAll();
+    });
+
+    it('should throw an error if fabric network library bound is not v1.4, v2.x', async () => {
         mockery.registerMock('fabric-network', {});
         mockery.registerMock('fabric-network/package', {version: '3.0.0'});
         ConfigUtil.set(ConfigUtil.keys.NetworkConfig, path.resolve(__dirname, v2Config));
         ConfigUtil.set(ConfigUtil.keys.Fabric.Gateway.Enabled, true);
-        await ConnectorFactory(1).should.be.rejectedWith(/Installed SDK version 3.0.0 did not match any compatible Fabric connectors/);
+        await ConnectorFactory(1).should.be.rejectedWith(/Installed fabric-network SDK version 3.0.0 did not match any compatible Fabric connectors/);
         mockery.deregisterAll();
     });
+
+    it('should throw an error if both fabric-network and fabric-gateway are bound', async () => {
+        mockery.registerMock('fabric-network', {});
+        mockery.registerMock('fabric-network/package', {version: '3.0.0'});
+        ConfigUtil.set(ConfigUtil.keys.NetworkConfig, path.resolve(__dirname, v2Config));
+        ConfigUtil.set(ConfigUtil.keys.Fabric.Gateway.Enabled, true);
+        mockery.registerMock('@hyperledger/fabric-gateway', {});
+        mockery.registerMock('@hyperledger/fabric-gateway/package', {version: '1.0.1'});
+        ConfigUtil.set(ConfigUtil.keys.NetworkConfig, path.resolve(__dirname, peerGatewayConfig));
+        ConfigUtil.set(ConfigUtil.keys.Fabric.Gateway.Enabled, true);
+        await ConnectorFactory(1).should.be.rejectedWith(/Multiple bindings for fabric have been detected, you need to unbind one or more to ensure only a single bind is present to continue/);
+        mockery.deregisterAll();
+    });
+
 
     it('should throw a generic error if network configuration version is not 1.0 or 2.0', async () => {
         mockery.registerMock('fabric-network', {});

--- a/packages/caliper-fabric/test/connector-versions/peer-gateway/PeerGateway.js
+++ b/packages/caliper-fabric/test/connector-versions/peer-gateway/PeerGateway.js
@@ -118,23 +118,13 @@ describe('A Fabric Peer Gateway sdk gateway', () => {
     });
 
 
-    it('should pass a defined grpcClinet in the gateway options', async () => {
+    it('should pass a defined grpcClient in the gateway options', async () => {
         const connectorConfiguration = await new ConnectorConfigurationFactory().create(path.resolve(__dirname, configWith2Orgs1AdminInWalletNotMutual), walletFacadeFactory);
         const peerGateway = new PeerGateway(connectorConfiguration, 1, 'fabric');
         await peerGateway.getContext();
         for(const args of Gateway.connectArgs){
             args.client.should.be.instanceOf(GrpcClient);
         }
-    });
-
-    it('should pass the default timeout in the gateway options', async () => {
-        const connectorConfiguration = await new ConnectorConfigurationFactory().create(path.resolve(__dirname, configWith2Orgs1AdminInWalletNotMutual), walletFacadeFactory);
-        const peerGateway = new PeerGateway(connectorConfiguration, 1, 'fabric');
-        const now = new Date();
-        const clock = sinon.useFakeTimers(now.getTime());
-        await peerGateway.getContext();
-        Gateway.connectArgs[0].evaluateOptions().should.be.deep.equal({deadline: now.getTime() + 60000});
-        clock.restore();
     });
 
     it('should pass the default timeout in the gateway options', async () => {
@@ -173,6 +163,14 @@ describe('A Fabric Peer Gateway sdk gateway', () => {
         const peerGateway = new PeerGateway(connectorConfiguration, 1, 'fabric');
         await peerGateway.getContext();
         Gateway.constructed.should.equal(4);
+    });
+
+
+    it('should create a Gateway with the specified created identity', async () => {
+        const connectorConfiguration = await new ConnectorConfigurationFactory().create(path.resolve(__dirname, configWith2Orgs1AdminInWalletNotMutual), walletFacadeFactory);
+        const peerGateway = new PeerGateway(connectorConfiguration, 1, 'fabric');
+        await peerGateway.getContext();
+        Gateway.connectArgs[0].identity.should.deep.equal({mspId: 'Org1MSP', credentials: Buffer.from('-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----')});
     });
 
     it('should a attempt to create a grpc client with default grpc options when not provided through the connection profile', async () => {


### PR DESCRIPTION
- added logic to pick new Peer Gateway connector in the connector selector in FabriConnectorFactory.js 
- added 2.4 fabric SUT version with binding packages in .config.yaml
- added last fixes for the Peer Gateway connector implementation