### PR TITLE
Change monitor intervals from milliseconds to seconds

### DIFF
--- a/packages/caliper-tests-integration/fabric_tests/phase2/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase2/benchconfig.yaml
@@ -37,5 +37,5 @@ monitors:
     resource:
     - module: process
       options:
-        interval: 3
+        interval: 3000
         processes: [{ command: 'node', arguments: 'caliper.js', multiOutput: 'avg' }]

--- a/packages/caliper-tests-integration/fabric_tests/phase3/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase3/benchconfig.yaml
@@ -37,9 +37,9 @@ monitors:
     resource:
     - module: process
       options:
-        interval: 3
+        interval: 3000
         processes: [{ command: 'node', arguments: 'caliper.js', multiOutput: 'avg' }]
     - module: docker
       options:
-        interval: 4
+        interval: 4000
         containers: ['peer0.org1.example.com', 'peer0.org2.example.com', 'orderer0.example.com', 'orderer1.example.com']

--- a/packages/caliper-tests-integration/fabric_tests/phase4/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase4/benchconfig.yaml
@@ -51,12 +51,12 @@ monitors:
         messageLevel: info
     - module: prometheus-push
       options:
-        pushInterval: 5
+        pushInterval: 5000
         pushUrl: "http://localhost:9091"
     resource:
     - module: prometheus
       options:
-        interval: 5
+        interval: 5000
         url: "http://localhost:9090"
         metrics:
             include: [peer*, dev*]

--- a/packages/caliper-tests-integration/fabric_tests/phase5/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase5/benchconfig.yaml
@@ -43,12 +43,12 @@ monitors:
     transaction:
     - module: prometheus-push
       options:
-        pushInterval: 5
+        pushInterval: 5000
         pushUrl: "http://localhost:9091"
     resource:
     - module: prometheus
       options:
-        interval: 5
+        interval: 5000
         url: "http://localhost:9090"
         metrics:
             include: [peer*, dev*]
@@ -71,9 +71,9 @@ monitors:
                 metrics: [all]
     - module: process
       options:
-        interval: 3
+        interval: 3000
         processes: [{ command: 'node', arguments: 'caliper.js', multiOutput: 'avg' }]
     - module: docker
       options:
-        interval: 4
+        interval: 4000
         containers: ['peer0.org1.example.com', 'peer0.org2.example.com', 'orderer0.example.com', 'orderer1.example.com']

--- a/packages/caliper-tests-integration/fabric_tests/phase6/benchconfig.yaml
+++ b/packages/caliper-tests-integration/fabric_tests/phase6/benchconfig.yaml
@@ -46,12 +46,12 @@ monitors:
     transaction:
     - module: prometheus-push
       options:
-        pushInterval: 5
+        pushInterval: 5000
         pushUrl: "http://localhost:9091"
     resource:
     - module: prometheus
       options:
-        interval: 5
+        interval: 5000
         url: "http://localhost:9090"
         metrics:
             include: [peer*, dev*]


### PR DESCRIPTION
For the fabric tests the monitor intervals were set to single
millisecond values such as 3, 4, 5. This adds a massive overhead to the
running of the integration tests and isn't needed, so changing them to
be seconds instead.

Signed-off-by: D <d_kelsey@uk.ibm.com>
