### PR TITLE
Fixed docker monitor to use Dockerode only

### DIFF
--- a/packages/caliper-core/package.json
+++ b/packages/caliper-core/package.json
@@ -24,7 +24,7 @@
     "dependencies": {
         "color-scheme": "^1.0.1",
         "compare-versions": "^3.4.0",
-        "dockerode": "3.1.0",
+        "dockerode": "3.3.1",
         "express": "4.17.1",
         "js-yaml": "^3.13.1",
         "mustache": "^2.3.0",
@@ -35,7 +35,6 @@
         "prom-client": "12.0.0",
         "prometheus-gc-stats": "0.6.3",
         "ps-node": "^0.1.6",
-        "systeminformation": "^3.23.7",
         "table": "^4.0.1",
         "winston": "^3.2.1",
         "winston-daily-rotate-file": "^4.2.1",


### PR DESCRIPTION
- Eliminated the use of system information to retrieve local docker container metrics closes #1309 #1305 
- Upgraded the dockerode dependency and expanded it to be used for both local and remote containers stats monitoring