### PR TITLE
Fix cli and update dependabot security dependencies

### DIFF
--- a/packages/caliper-cli/caliper.js
+++ b/packages/caliper-cli/caliper.js
@@ -38,6 +38,11 @@ let results = yargs
     .strict(false)
     .argv;
 
+if (!results.thePromise) {
+    Logger.error(`Unrecognised command: '${results._[0]}'`);
+    process.exit(1);
+}
+
 results.thePromise.then( () => {
     // DO NOT EXIT THE PROCESS HERE
     // The event loops of the workers are still running at this point

--- a/packages/caliper-core/package.json
+++ b/packages/caliper-core/package.json
@@ -29,7 +29,7 @@
         "js-yaml": "^3.13.1",
         "mustache": "^2.3.0",
         "mqtt": "3.0.0",
-        "nconf": "^0.10.0",
+        "nconf": "0.12.0",
         "nconf-yaml": "^1.0.2",
         "pidusage": "^1.1.6",
         "prom-client": "12.0.0",

--- a/packages/caliper-gui-dashboard/package.json
+++ b/packages/caliper-gui-dashboard/package.json
@@ -31,7 +31,7 @@
         "@fortawesome/free-brands-svg-icons": "^5.12.1",
         "@fortawesome/free-solid-svg-icons": "^5.12.1",
         "@fortawesome/react-fontawesome": "^0.1.8",
-        "axios": "0.21.1",
+        "axios": "0.21.2",
         "bootstrap": "4.4.1",
         "chart.js": "^2.9.3",
         "d3": "^5.15.0",


### PR DESCRIPTION
`caliper unknowncmd`

fails with a horrible `Cannot read property 'then' of undefined`

this pr gives a more helpful message

Also addressed are a couple of dependencies which dependabot reports as
high severity

Signed-off-by: D <d_kelsey@uk.ibm.com>
