### PR TITLE
disable logging debug to file

### DIFF
--- a/packages/caliper-core/lib/common/config/default.yaml
+++ b/packages/caliper-core/lib/common/config/default.yaml
@@ -136,10 +136,10 @@ caliper:
                 enabled: true # Enables the target
                 options: # These are passed to the winston console target as-is
                     level: info
-            # Defines a target with debug level
+            # Defines a file target with debug level but is disabled by default
             file:
                 target: file
-                enabled: true
+                enabled: false
                 options:
                     level: debug
                     filename: caliper.log

--- a/packages/caliper-core/lib/worker/caliper-worker.js
+++ b/packages/caliper-core/lib/worker/caliper-worker.js
@@ -100,7 +100,7 @@ class CaliperWorker {
         }
 
         if (error) {
-            Logger.error(`Unhandled error while executing TX: ${error.stack || error}`);
+            // Already logged, no need to log again
             throw error;
         }
 

--- a/packages/caliper-tests-integration/fabric_tests/phase3/src/marbles/node/package.json
+++ b/packages/caliper-tests-integration/fabric_tests/phase3/src/marbles/node/package.json
@@ -12,6 +12,6 @@
 	"engine-strict": true,
 	"license": "Apache-2.0",
 	"dependencies": {
-		"fabric-shim": "1.4.5"
+		"fabric-shim": "2.4.2"
 	}
 }


### PR DESCRIPTION
To ensure that caliper manager and workers are at their most performant
out of the box, this disables logging debug output to a file

Signed-off-by: D <d_kelsey@uk.ibm.com>
