### PR TITLE
Upgraded node-sdk binding for fabric-v1-lts from 1.4.19 to 1.4.20

### DIFF
--- a/packages/caliper-cli/lib/lib/config.yaml
+++ b/packages/caliper-cli/lib/lib/config.yaml
@@ -34,8 +34,8 @@ sut:
             packages: ['fabric-client@1.4.11', 'fabric-protos@2.1.0', 'fabric-network@1.4.11','fs-extra@8.1.0']
         1.4.14:
             packages: ['fabric-client@1.4.14', 'fabric-protos@2.1.0', 'fabric-network@1.4.14','fs-extra@8.1.0']
-        1.4.19: &fabric-v1-lts
-            packages: ['fabric-client@1.4.19', 'fabric-protos@2.1.0', 'fabric-network@1.4.19','fs-extra@8.1.0']
+        1.4.20: &fabric-v1-lts
+            packages: ['fabric-client@1.4.20', 'fabric-protos@2.1.0', 'fabric-network@1.4.20','fs-extra@8.1.0']
         1.4: *fabric-v1-lts
         2.2.3:
             packages: ['fabric-network@2.2.3']

--- a/packages/caliper-tests-integration/fabric_tests/phase3/src/marbles/node/package.json
+++ b/packages/caliper-tests-integration/fabric_tests/phase3/src/marbles/node/package.json
@@ -12,6 +12,6 @@
 	"engine-strict": true,
 	"license": "Apache-2.0",
 	"dependencies": {
-		"fabric-shim": "1.4.5"
+		"fabric-shim": "2.4.2"
 	}
 }


### PR DESCRIPTION
Node SDK v1.4.20 relaxes the Node version check to >=10.13.0, so should be happy with any later Node version, even though only the LTS releases are “supported”

This upgrade will help remove all the warnings about node versions on caliper.

Signed-off-by: fraVlaca <ocsenarf@outlook.com>

