### PR TITLE
Fix: When selecting v0.4.2 in the caliper docs the dropdown switches to 0.2

### DIFF
--- a/_includes/v0.4.2.html
+++ b/_includes/v0.4.2.html
@@ -4,7 +4,7 @@
     style="width:5rem; height: 1.5rem;">
     <option value="/caliper/v0.2/getting-started/"> v0.2</option>
     <option value="/caliper/v0.3.2/getting-started/">v0.3.2</option>
-    <option value="/caliper/v0.4.2/getting-started/">v0.4.2</option>
+    <option value="/caliper/v0.4.2/getting-started/" selected>v0.4.2</option>
     <option value="/caliper/v0.5.0/getting-started/">v0.5.0</option>
     <option value="/caliper/vNext/getting-started/">vNext</option>
   </select>


### PR DESCRIPTION
fixes #1381

Signed-off-by: Shreesh Kulkarni <sgkul2000@gmail.com>

<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ x ]  A link to the issue/user story that the pull request relates to
 - [ x ]  How to recreate the problem without the fix
 - [ x ]  Design of the fix
 - [ x ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
#1381 

## Steps to Reproduce
 1. go to caliper docs
 2. select v0.4.2 under versions


## Design of the fix
the fix adds "selected" to the appropriate option to make it the selected option by default

## Validation of the fix
manual testing proves that the fix works
