### PR TITLE
Cache node modules across CI workflows

### DIFF
--- a/.build/benchmark-integration-test-direct.sh
+++ b/.build/benchmark-integration-test-direct.sh
@@ -17,9 +17,6 @@
 set -e
 set -o pipefail
 
-# Bootstrap the project again
-npm i && npm run repoclean -- --yes && npm run bootstrap
-
 # Get the root directory of the caliper source
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 echo $ROOT_DIR

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,6 +16,22 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
+    - name: Cache lerna
+      id: cache-lerna
+      uses: actions/cache@v2
+      with:
+        path: |
+          node_modules
+          packages/*/node_modules
+        key: ${{ matrix.node-version  }}-lerna-${{ hashFiles('**/package.json') }}
+        restore-keys: |
+          ${{ matrix.node-version }}-lerna-
+    - name: Install project dependencies
+      if: steps.cache-lerna.outputs.cache-hit != 'true'
+      run: npm install
+    - name: Bootstrap lerna
+      if: steps.cache-lerna.outputs.cache-hit != 'true'
+      run: npm run bootstrap
     - name: Fabric Integration Test
       run: .build/benchmark-integration-test-direct.sh
       env:
@@ -33,6 +49,22 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
+    - name: Cache lerna
+      id: cache-lerna
+      uses: actions/cache@v2
+      with:
+        path: |
+          node_modules
+          packages/*/node_modules
+        key: ${{ matrix.node-version  }}-lerna-${{ hashFiles('**/package.json') }}
+        restore-keys: |
+          ${{ matrix.node-version }}-lerna-
+    - name: Install project dependencies
+      if: steps.cache-lerna.outputs.cache-hit != 'true'
+      run: npm install
+    - name: Bootstrap lerna
+      if: steps.cache-lerna.outputs.cache-hit != 'true'
+      run: npm run bootstrap
     - name: Ethereum Integration Test
       run: .build/benchmark-integration-test-direct.sh
       env:
@@ -50,6 +82,22 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
+    - name: Cache lerna
+      id: cache-lerna
+      uses: actions/cache@v2
+      with:
+        path: |
+          node_modules
+          packages/*/node_modules
+        key: ${{ matrix.node-version  }}-lerna-${{ hashFiles('**/package.json') }}
+        restore-keys: |
+          ${{ matrix.node-version }}-lerna-
+    - name: Install project dependencies
+      if: steps.cache-lerna.outputs.cache-hit != 'true'
+      run: npm install
+    - name: Bootstrap lerna
+      if: steps.cache-lerna.outputs.cache-hit != 'true'
+      run: npm run bootstrap
     - name: Besu Integration Test
       run: .build/benchmark-integration-test-direct.sh
       env:
@@ -67,6 +115,22 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
+    - name: Cache lerna
+      id: cache-lerna
+      uses: actions/cache@v2
+      with:
+        path: |
+          node_modules
+          packages/*/node_modules
+        key: ${{ matrix.node-version  }}-lerna-${{ hashFiles('**/package.json') }}
+        restore-keys: |
+          ${{ matrix.node-version }}-lerna-
+    - name: Install project dependencies
+      if: steps.cache-lerna.outputs.cache-hit != 'true'
+      run: npm install
+    - name: Bootstrap lerna
+      if: steps.cache-lerna.outputs.cache-hit != 'true'
+      run: npm run bootstrap
     - name: FISCO BCOS Integration Test
       run: .build/benchmark-integration-test-direct.sh
       env:
@@ -84,6 +148,22 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
+    - name: Cache lerna
+      id: cache-lerna
+      uses: actions/cache@v2
+      with:
+        path: |
+          node_modules
+          packages/*/node_modules
+        key: ${{ matrix.node-version  }}-lerna-${{ hashFiles('**/package.json') }}
+        restore-keys: |
+          ${{ matrix.node-version }}-lerna-
+    - name: Install project dependencies
+      if: steps.cache-lerna.outputs.cache-hit != 'true'
+      run: npm install
+    - name: Bootstrap lerna
+      if: steps.cache-lerna.outputs.cache-hit != 'true'
+      run: npm run bootstrap
     - name: Generator Integration Test
       run: .build/benchmark-integration-test-direct.sh
       env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,14 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: |
+          packages/caliper-publish/node_modules
+        key: publish-${{ hashFiles('**/package.json') }}
+        restore-keys: |
+          publish-
     - name: Publish Caliper
       run: .build/publish-caliper.sh
       env:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,11 +16,23 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
+    - name: Cache lerna
+      id: cache-lerna
+      uses: actions/cache@v2
+      with:
+        path: |
+          node_modules
+          packages/*/node_modules
+        key: ${{ matrix.node-version  }}-lerna-${{ hashFiles('**/package.json') }}
+        restore-keys: |
+          ${{ matrix.node-version }}-lerna-
     - name: Check correct usage of Caliper package names
       run: ./scripts/check-package-names.sh
     - name: Install project dependencies
+      if: steps.cache-lerna.outputs.cache-hit != 'true'
       run: npm install
     - name: Bootstrap lerna
+      if: steps.cache-lerna.outputs.cache-hit != 'true'
       run: npm run bootstrap
     - name: Check the version consistency of subpackages
       run: ./packages/caliper-publish/publish.js version check


### PR DESCRIPTION
In this PR:
* The `node_modules` folder is cached across workflows using a method inspired by the workflow in [jupyterlab/extension-examples](https://github.com/jupyterlab/extension-examples/blob/master/.github/workflows/main.yml)

Closes #1374
