### PR TITLE
Pass secrets to CI workflow for publish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,3 +10,4 @@ jobs:
   publish-caliper:
     uses: ./.github/workflows/publish.yml
     needs: unit-tests
+    secrets: inherit


### PR DESCRIPTION
In this PR:
* Secrets are passed on from the parent workflow to the publish workflow as described in the GitHub Actions documentation

Fixes #1389
