### PR TITLE
Fix#1377 Change the generator binding from 2.2 to 1.4

### DIFF
--- a/packages/caliper-tests-integration/generator_tests/fabric/run.sh
+++ b/packages/caliper-tests-integration/generator_tests/fabric/run.sh
@@ -47,7 +47,7 @@ ${GENERATOR_METHOD} -- --workspace 'myWorkspace' --contractId 'mymarbles' --cont
 cd ../
 # bind the sdk into the packages directory as it will search for it there, this ensures it doesn't contaminate real node_modules dirs (2.2 will work with a 1.4 fabric)
 pushd $SUT_DIR
-${CALL_METHOD} bind --caliper-bind-sut fabric:2.2
+${CALL_METHOD} bind --caliper-bind-sut fabric:1.4
 popd
 ${CALL_METHOD} launch manager --caliper-workspace 'fabric/myWorkspace' --caliper-networkconfig 'networkconfig.yaml' --caliper-benchconfig 'benchmarks/config.yaml' --caliper-flow-skip-end
 rc=$?


### PR DESCRIPTION
Signed-off-by: Tezas-6174 <jamdade.2@iitj.ac.in>

- Fixes #1377.
- Changed the generator binding from 2.2 to 1.4 in ``run.sh`` in generator-tests of ``caliper-test-integration`` package.
