### PR TITLE
Add DCI linting to CI of PRs

### DIFF
--- a/.github/workflows/dci.yml
+++ b/.github/workflows/dci.yml
@@ -1,0 +1,18 @@
+# Taken from https://github.com/petermetz/gh-action-dci-lint
+name: DCI
+
+on:
+  workflow_call:
+
+jobs:
+  DCI-lint:
+    name: DCI-Lint
+    runs-on: ubuntu-latest
+    steps:
+    - name: Lint Git Repo
+      id: lint-git-repo
+      uses: petermetz/gh-action-dci-lint@v0.6.1
+      with:
+        lint-git-repo-request: '{"cloneUrl": "${{ github.server_url }}/${{ github.repository }}.git", "fetchArgs": ["--no-tags", "--prune", "--progress", "--no-recurse-submodules", "--depth=1", "origin" ,"+${{ github.sha }}:${{ github.ref }}"], "checkoutArgs": [ "${{ github.ref }}"], "targetPhrasePatterns": [], "configDefaultsUrl": "https://inclusivenaming.org/json/dci-lint-config-recommended-v1.json" }'
+    - name: Get the output response
+      run: echo "${{ steps.lint-git-repo.outputs.lint-git-repo-response }}"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "main" ]
 
 jobs:
+  dci-lint:
+    uses: ./.github/workflows/dci.yml
   unit-tests:
     uses: ./.github/workflows/unit-tests.yml
   integration-tests:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,6 +9,7 @@ jobs:
     uses: ./.github/workflows/dci.yml
   unit-tests:
     uses: ./.github/workflows/unit-tests.yml
+    needs: dci-lint
   integration-tests:
     uses: ./.github/workflows/integration-tests.yml
     needs: unit-tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ This release of caliper adds new capabilities and addresses lots of bugs. Note t
 * [6ced65a](https://github.com/hyperledger/caliper/commit/6ced65a) update conditionals (#1112)
 * [6fa9b12](https://github.com/hyperledger/caliper/commit/6fa9b12) publish to npm stage (#1110)
 * [730a884](https://github.com/hyperledger/caliper/commit/730a884) Update contributing guide (#1109)
-* [d6f0027](https://github.com/hyperledger/caliper/commit/d6f0027) Enable builds for PRs that target master branch (#1108)
+* [d6f0027](https://github.com/hyperledger/caliper/commit/d6f0027) Enable builds for PRs that target main branch (#1108)
 * [bc436e8](https://github.com/hyperledger/caliper/commit/bc436e8) Azure pipelines build (#1105)
 
 ## 0.4.2
@@ -110,7 +110,7 @@ This release of caliper adds new capabilities and addresses lots of bugs. Note t
   * [Breaking] Alignment of rate controller configuration to be SUT centric ([PR959](https://github.com/hyperledger/caliper/pull/959))
   * [Breaking] Caliper API change for workload specification ([PR950](https://github.com/hyperledger/caliper/pull/950))
   * [Breaking] Caliper API change: removal of queryState ([PR931](https://github.com/hyperledger/caliper/pull/931))
-  * [Breaking] Caliper API change: master -> manager ([PR893](https://github.com/hyperledger/caliper/pull/893))
+  * [Breaking] Caliper API change: rename CLI subcommand to manager ([PR893](https://github.com/hyperledger/caliper/pull/893))
   * [Breaking] Caliper API change: chaincode -> contract ([PR891](https://github.com/hyperledger/caliper/pull/891))
   * [Breaking] Caliper API change: adaptor -> connector ([PR881](https://github.com/hyperledger/caliper/pull/881))
   * [Breaking] Caliper API change: callbacks converted to Workload module class ([PR856](https://github.com/hyperledger/caliper/pull/856))
@@ -178,7 +178,7 @@ This release of caliper adds new capabilities and addresses lots of bugs. Note t
   * Added statistic summation option to Prometheus queries ([PR#720](https://github.com/hyperledger/caliper/pull/720)).
   * Fixed monitor bugs resulting in extra empty columns/metrics ([PR#718](https://github.com/hyperledger/caliper/pull/718)).
   * __BREAKING:__ Simplified backlog rate controller configuration ([PR#704](https://github.com/hyperledger/caliper/pull/704)).
-  * Added MQTT-based communication between the master and worker processes for fully distributed operation ([PR#682](https://github.com/hyperledger/caliper/pull/682)).
+  * Added MQTT-based communication between the manager and worker processes for fully distributed operation ([PR#682](https://github.com/hyperledger/caliper/pull/682)).
   * Added Yeoman generator for the benchmark configuration and workload module files ([PR#671](https://github.com/hyperledger/caliper/pull/671)).
   * Added charting capabilities to the report generation ([PR#650](https://github.com/hyperledger/caliper/pull/650)).
   * __BREAKING:__ Configuration structure for Docker and process monitoring changed ([PR#650](https://github.com/hyperledger/caliper/pull/650)).

--- a/packages/caliper-core/test/worker/tx-observers/prometheus-push-tx-observer.js
+++ b/packages/caliper-core/test/worker/tx-observers/prometheus-push-tx-observer.js
@@ -217,7 +217,7 @@ describe('When using a PrometheusPushTxObserver', () => {
         await prometheusPushTxObserver.deactivate();
 
         // Values should be zero, or empty 
-        // Ref: https://github.com/siimon/prom-client/  file test/counterTest.js
+        // Ref: https://github.com/siimon/prom-client/blob/721829cc593bb7da28ae009985caeeacb4b59e05/test/counterTest.js
         const txSubmitted = await prometheusPushTxObserver.counterTxSubmitted.get();
         txSubmitted.values[0].value.should.equal(0);
 

--- a/packages/caliper-core/test/worker/tx-observers/prometheus-push-tx-observer.js
+++ b/packages/caliper-core/test/worker/tx-observers/prometheus-push-tx-observer.js
@@ -216,7 +216,8 @@ describe('When using a PrometheusPushTxObserver', () => {
 
         await prometheusPushTxObserver.deactivate();
 
-        // Values should be zero, or empty (https://github.com/siimon/prom-client/blob/master/test/counterTest.js)
+        // Values should be zero, or empty 
+        // Ref: https://github.com/siimon/prom-client/  file test/counterTest.js
         const txSubmitted = await prometheusPushTxObserver.counterTxSubmitted.get();
         txSubmitted.values[0].value.should.equal(0);
 

--- a/packages/caliper-core/test/worker/tx-observers/prometheus-tx-observer.js
+++ b/packages/caliper-core/test/worker/tx-observers/prometheus-tx-observer.js
@@ -182,7 +182,7 @@ describe('When using a PrometheusTxObserver', () => {
         await prometheusTxObserver.deactivate();
 
         // Values should be zero, or empty
-        // Ref: https://github.com/siimon/prom-client/   file test/counterTest.js
+        // Ref: https://github.com/siimon/prom-client/blob/721829cc593bb7da28ae009985caeeacb4b59e05/test/counterTest.js
         const txSubmitted = await prometheusTxObserver.counterTxSubmitted.get();
         txSubmitted.values[0].value.should.equal(0);
 

--- a/packages/caliper-core/test/worker/tx-observers/prometheus-tx-observer.js
+++ b/packages/caliper-core/test/worker/tx-observers/prometheus-tx-observer.js
@@ -181,7 +181,8 @@ describe('When using a PrometheusTxObserver', () => {
 
         await prometheusTxObserver.deactivate();
 
-        // Values should be zero, or empty (https://github.com/siimon/prom-client/blob/master/test/counterTest.js)
+        // Values should be zero, or empty
+        // Ref: https://github.com/siimon/prom-client/   file test/counterTest.js
         const txSubmitted = await prometheusTxObserver.counterTxSubmitted.get();
         txSubmitted.values[0].value.should.equal(0);
 

--- a/packages/caliper-tests-integration/fisco-bcos_tests/config/node0/config.ini
+++ b/packages/caliper-tests-integration/fisco-bcos_tests/config/node0/config.ini
@@ -19,11 +19,6 @@
     ;enable/disable network compress
     ;enable_compress=false
 
-;certificate rejected list		
-[certificate_blacklist]		
-    ; crl.0 should be nodeid, nodeid's length is 128 
-    ;crl.0=
-
 ;group configurations
 ;WARNING: group 0 is forbided
 [group]

--- a/packages/caliper-tests-integration/fisco-bcos_tests/config/node1/config.ini
+++ b/packages/caliper-tests-integration/fisco-bcos_tests/config/node1/config.ini
@@ -19,11 +19,6 @@
     ;enable/disable network compress
     ;enable_compress=false
 
-;certificate rejected list		
-[certificate_blacklist]		
-    ; crl.0 should be nodeid, nodeid's length is 128 
-    ;crl.0=
-
 ;group configurations
 ;WARNING: group 0 is forbided
 [group]

--- a/packages/caliper-tests-integration/fisco-bcos_tests/config/node2/config.ini
+++ b/packages/caliper-tests-integration/fisco-bcos_tests/config/node2/config.ini
@@ -19,11 +19,6 @@
     ;enable/disable network compress
     ;enable_compress=false
 
-;certificate rejected list		
-[certificate_blacklist]		
-    ; crl.0 should be nodeid, nodeid's length is 128 
-    ;crl.0=
-
 ;group configurations
 ;WARNING: group 0 is forbided
 [group]

--- a/packages/caliper-tests-integration/fisco-bcos_tests/config/node3/config.ini
+++ b/packages/caliper-tests-integration/fisco-bcos_tests/config/node3/config.ini
@@ -19,11 +19,6 @@
     ;enable/disable network compress
     ;enable_compress=false
 
-;certificate rejected list		
-[certificate_blacklist]		
-    ; crl.0 should be nodeid, nodeid's length is 128 
-    ;crl.0=
-
 ;group configurations
 ;WARNING: group 0 is forbided
 [group]


### PR DESCRIPTION
As recommended by the project update template and https://github.com/petermetz/gh-action-dci-lint
Let's see whether the remnant phrases in the changelog and third-party artifacts will trigger the alarm before making this a branch protection rule.

Signed-off-by: Attila Klenik <a.klenik@gmail.com>