### PR TITLE
Cache node modules across CI workflows

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,11 +7,13 @@ env:
   NPM_VERSION: 8.15.0
 
 jobs:
-  fabric-integration-tests:
-    name: Fabric Integration Tests
+  integration-tests:
+    name: Integration Tests
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
+        adaptor: [fabric, ethereum, besu, fisco-bcos, generator]
         node-version: [14.x, 16.x]
     steps:
     - uses: actions/checkout@v3
@@ -21,83 +23,37 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: Install higher version of NPM
       run: npm install -g npm@${{ env.NPM_VERSION }}
-    - name: Fabric Integration Test
-      run: .build/benchmark-integration-test-direct.sh
-      env:
-        BENCHMARK: fabric
-
-  ethereum-integration-tests:
-    name: Ethereum Integration Tests
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [14.x, 16.x]
-    steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+    - name: Cache node modules
+      id: cache-npm
+      uses: actions/cache@v2
       with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install higher version of NPM
-      run: npm install -g npm@${{ env.NPM_VERSION }}
-    - name: Ethereum Integration Test
-      run: .build/benchmark-integration-test-direct.sh
-      env:
-        BENCHMARK: ethereum
-
-  besu-integration-tests:
-    name: Besu Integration Tests
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [14.x, 16.x]
-    steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+        path: |
+          node_modules
+          packages/*/node_modules
+        key: ${{ matrix.node-version }}-npm-cache-${{ hashFiles('**/package.json') }}
+        restore-keys: |
+          ${{ matrix.node-version }}-npm-cache-
+    - name: Cache SUT binding
+      id: cache-sut
+      uses: actions/cache@v2
       with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install higher version of NPM
-      run: npm install -g npm@${{ env.NPM_VERSION }}
-    - name: Besu Integration Test
-      run: .build/benchmark-integration-test-direct.sh
+        path: /tmp/sut
+        key: ${{ format('{0}-sut-cache-{1}-{2}', matrix.node-version, matrix.adaptor, hashFiles(format('packages/caliper-tests-integration/{0}_tests/run.sh', matrix.adaptor))) }}
+        restore-keys: |
+          ${{ matrix.node-version }}-sut-cache-${{ matrix.adaptor }}-
+    - name: Install project dependencies
+      if: steps.cache-npm.outputs.cache-hit != 'true'
+      run: npm ci
+    - name: Create SUT binding
+      if: steps.cache-sut.outputs.cache-hit != 'true'
+      run: mkdir -p /tmp/sut
+    - name: Run integration tests
+      run: ./run-tests.sh
+      working-directory: ./packages/caliper-tests-integration/
       env:
-        BENCHMARK: besu
-
-  fisco-bcos-integration-tests:
-    name: FISCO BCOS Integration Tests
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [14.x, 16.x]
-    steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install higher version of NPM
-      run: npm install -g npm@${{ env.NPM_VERSION }}
-    - name: FISCO BCOS Integration Test
-      run: .build/benchmark-integration-test-direct.sh
-      env:
-        BENCHMARK: fisco-bcos
-
-  generator-integration-tests:
-    name: Generator Integration Tests
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [14.x, 16.x]
-    steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install higher version of NPM
-      run: npm install -g npm@${{ env.NPM_VERSION }}
-    - name: Generator Integration Test
-      run: .build/benchmark-integration-test-direct.sh
-      env:
-        BENCHMARK: generator
+        BENCHMARK: ${{ matrix.adaptor }}
+        CALL_METHOD: "node ${{ github.workspace }}/packages/caliper-cli/caliper.js"
+        BIND_IN_PACKAGE_DIR: "true"
+        GENERATOR_METHOD: "yo ${{ github.workspace }}/packages/generator-caliper/generators/benchmark/index.js"
+        SUT_DIR: "/tmp/sut"
+        NODE_PATH: "/tmp/sut/node_modules"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Install project dependencies
       if: steps.cache-npm.outputs.cache-hit != 'true'
       run: npm ci
-    - name: Create SUT binding
+    - name: Create directory to store SUT bindings
       if: steps.cache-sut.outputs.cache-hit != 'true'
       run: mkdir -p /tmp/sut
     - name: Run integration tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -37,7 +37,7 @@ jobs:
       id: cache-sut
       uses: actions/cache@v2
       with:
-        path: /tmp/sut
+        path: /tmp/sut/cached
         key: ${{ format('{0}-sut-cache-{1}-{2}', matrix.node-version, matrix.adaptor, hashFiles(format('packages/caliper-tests-integration/{0}_tests/run.sh', matrix.adaptor))) }}
         restore-keys: |
           ${{ matrix.node-version }}-sut-cache-${{ matrix.adaptor }}-
@@ -56,4 +56,3 @@ jobs:
         BIND_IN_PACKAGE_DIR: "true"
         GENERATOR_METHOD: "yo ${{ github.workspace }}/packages/generator-caliper/generators/benchmark/index.js"
         SUT_DIR: "/tmp/sut"
-        NODE_PATH: "/tmp/sut/node_modules"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,9 +21,20 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: Install higher version of NPM
       run: npm install -g npm@${{ env.NPM_VERSION }}
+    - name: Cache node modules
+      id: cache-npm
+      uses: actions/cache@v2
+      with:
+        path: |
+          node_modules
+          packages/*/node_modules
+        key: ${{ matrix.node-version }}-npm-cache-${{ hashFiles('**/package.json') }}
+        restore-keys: |
+          ${{ matrix.node-version }}-npm-cache-
     - name: Check correct usage of Caliper package names
       run: ./scripts/check-package-names.sh
     - name: Install project dependencies
+      if: steps.cache-npm.outputs.cache-hit != 'true'
       run: npm ci
     - name: Check the version consistency of subpackages
       run: ./packages/caliper-publish/publish.js version check

--- a/packages/caliper-cli/lib/lib/config.yaml
+++ b/packages/caliper-cli/lib/lib/config.yaml
@@ -28,8 +28,15 @@ settingProfiles:
 # Specifies the supported target platforms
 sut:
     # Specifies the available SDK bindings and their Node.js-specific install settings
-    # Note: The minor version for the SUT in integration tests need to be upgraded
-    #       if a new version is added here
+    # IMPORTANT:
+    # The Integration tests cache all the SUT bindings EXCEPT for the fabric:2.4 binding. Therefore
+    # for those bindings if you want to update a binding with new version dependencies you need to
+    # create a new version and update the integration tests explicitly to reference this new version.
+    # For example if the current version of the fabric 2.2 binding is 2.2.14 and you want to update
+    # the binding to include a new level of dependencies, you must create a 2.2.15 binding and update
+    # the integration tests to reference this.
+    # The exception is fabric:2.4 which isn't cached in the integration tests. This means you can modify
+    # the 2.4 key without creating a new version and the integration tests will automatically pick it up.
     fabric:
         # The name/key of the SDK binding
         1.4.11:

--- a/packages/caliper-cli/lib/lib/config.yaml
+++ b/packages/caliper-cli/lib/lib/config.yaml
@@ -28,6 +28,8 @@ settingProfiles:
 # Specifies the supported target platforms
 sut:
     # Specifies the available SDK bindings and their Node.js-specific install settings
+    # Note: The minor version for the SUT in integration tests need to be upgraded
+    #       if a new version is added here
     fabric:
         # The name/key of the SDK binding
         1.4.11:

--- a/packages/caliper-tests-integration/besu_tests/run.sh
+++ b/packages/caliper-tests-integration/besu_tests/run.sh
@@ -26,7 +26,7 @@ npm i
 # Note: do not use env variables for binding settings, as subsequent launch calls will pick them up and bind again
 if [[ "${BIND_IN_PACKAGE_DIR}" = "true" ]]; then
     pushd $SUT_DIR
-    ${CALL_METHOD} bind --caliper-bind-sut besu:latest
+    ${CALL_METHOD} bind --caliper-bind-sut besu:1.4
     popd
 fi
 

--- a/packages/caliper-tests-integration/besu_tests/run.sh
+++ b/packages/caliper-tests-integration/besu_tests/run.sh
@@ -24,9 +24,13 @@ npm i
 
 # bind during CI tests, using the package dir as CWD
 # Note: do not use env variables for binding settings, as subsequent launch calls will pick them up and bind again
+# Note: Besu 1.4 binding is cached in CI
+export BESU_VERSION=1.4
+export NODE_PATH="$SUT_DIR/cached/v$BESU_VERSION/node_modules"
 if [[ "${BIND_IN_PACKAGE_DIR}" = "true" ]]; then
-    pushd $SUT_DIR
-    ${CALL_METHOD} bind --caliper-bind-sut besu:1.4
+    mkdir -p $SUT_DIR/cached/v$BESU_VERSION
+    pushd $SUT_DIR/cached/v$BESU_VERSION
+    ${CALL_METHOD} bind --caliper-bind-sut besu:$BESU_VERSION
     popd
 fi
 

--- a/packages/caliper-tests-integration/ethereum_tests/run.sh
+++ b/packages/caliper-tests-integration/ethereum_tests/run.sh
@@ -24,7 +24,7 @@ cd "${DIR}"
 # Note: do not use env variables for binding settings, as subsequent launch calls will pick them up and bind again
 if [[ "${BIND_IN_PACKAGE_DIR}" = "true" ]]; then
     pushd $SUT_DIR
-    ${CALL_METHOD} bind --caliper-bind-sut ethereum:latest
+    ${CALL_METHOD} bind --caliper-bind-sut ethereum:1.3
     popd
 fi
 

--- a/packages/caliper-tests-integration/ethereum_tests/run.sh
+++ b/packages/caliper-tests-integration/ethereum_tests/run.sh
@@ -22,9 +22,13 @@ cd "${DIR}"
 
 # bind during CI tests, using the package dir as CWD
 # Note: do not use env variables for binding settings, as subsequent launch calls will pick them up and bind again
+# Note: Ethereum 1.3 binding is cached in CI
+ETHEREUM_VERSION=1.3
+NODE_PATH="$SUT_DIR/cached/v$ETHEREUM_VERSION/node_modules"
 if [[ "${BIND_IN_PACKAGE_DIR}" = "true" ]]; then
-    pushd $SUT_DIR
-    ${CALL_METHOD} bind --caliper-bind-sut ethereum:1.3
+    mkdir -p $SUT_DIR/cached/v$ETHEREUM_VERSION
+    pushd $SUT_DIR/cached/v$ETHEREUM_VERSION
+    ${CALL_METHOD} bind --caliper-bind-sut ethereum:$ETHEREUM_VERSION
     popd
 fi
 

--- a/packages/caliper-tests-integration/fabric_tests/run.sh
+++ b/packages/caliper-tests-integration/fabric_tests/run.sh
@@ -29,13 +29,14 @@ cd ${DIR}
 
 # bind during CI tests, using the package dir as CWD
 # Note: do not use env variables for binding settings, as subsequent launch calls will pick them up and bind again
-FABRIC_VERSION=1.4.20
+# Note: Fabric 1.4 binding is cached in CI
+export FABRIC_VERSION=1.4.20
+export NODE_PATH="$SUT_DIR/cached/v$FABRIC_VERSION/node_modules"
 if [[ "${BIND_IN_PACKAGE_DIR}" = "true" ]]; then
-    mkdir -p $SUT_DIR/v$FABRIC_VERSION
-    pushd $SUT_DIR/v$FABRIC_VERSION
+    mkdir -p $SUT_DIR/cached/v$FABRIC_VERSION
+    pushd $SUT_DIR/cached/v$FABRIC_VERSION
     ${CALL_METHOD} bind --caliper-bind-sut fabric:$FABRIC_VERSION
     popd
-    NODE_PATH=$SUT_DIR/v$FABRIC_VERSION/node_modules
 fi
 
 # change default settings (add config paths too)
@@ -86,11 +87,12 @@ fi
 
 # BIND with 2.2 SDK, using the package dir as CWD
 # Note: do not use env variables for unbinding settings, as subsequent launch calls will pick them up and bind again
-FABRIC_VERSION=2.2.14
+# Note: Fabric 2.2 binding is cached in CI
+export FABRIC_VERSION=2.2.14
+export NODE_PATH="$SUT_DIR/cached/v$FABRIC_VERSION/node_modules"
 if [[ "${BIND_IN_PACKAGE_DIR}" = "true" ]]; then
-    mkdir -p $SUT_DIR/v$FABRIC_VERSION
-    NODE_PATH=$SUT_DIR/v$FABRIC_VERSION/node_modules
-    pushd $SUT_DIR/v$FABRIC_VERSION
+    mkdir -p $SUT_DIR/cached/v$FABRIC_VERSION
+    pushd $SUT_DIR/cached/v$FABRIC_VERSION
     ${CALL_METHOD} bind --caliper-bind-sut fabric:$FABRIC_VERSION
     popd
 fi
@@ -106,11 +108,12 @@ fi
 
 # BIND with 2.4 SDK, using the package dir as CWD
 # Note: do not use env variables for unbinding settings, as subsequent launch calls will pick them up and bind again
-FABRIC_VERSION=2.4
+# Note: Fabric 2.4 binding is NOT cached in CI as it doesn't have the minor version in the cache key
+export FABRIC_VERSION=2.4
+export NODE_PATH="$SUT_DIR/uncached/v$FABRIC_VERSION/node_modules"
 if [[ "${BIND_IN_PACKAGE_DIR}" = "true" ]]; then
-    mkdir -p $SUT_DIR/v$FABRIC_VERSION
-    NODE_PATH=$SUT_DIR/v$FABRIC_VERSION/node_modules
-    pushd $SUT_DIR/v$FABRIC_VERSION
+    mkdir -p $SUT_DIR/uncached/v$FABRIC_VERSION
+    pushd $SUT_DIR/uncached/v$FABRIC_VERSION
     ${CALL_METHOD} bind --caliper-bind-sut fabric:$FABRIC_VERSION
     popd
 fi

--- a/packages/caliper-tests-integration/fabric_tests/run.sh
+++ b/packages/caliper-tests-integration/fabric_tests/run.sh
@@ -108,7 +108,7 @@ fi
 
 # BIND with 2.4 SDK, using the package dir as CWD
 # Note: do not use env variables for unbinding settings, as subsequent launch calls will pick them up and bind again
-# Note: Fabric 2.4 binding is NOT cached in CI as it doesn't have the minor version in the cache key
+# Note: Fabric 2.4 binding is NOT cached in CI. This binding is lightweight so doesn't take much time and allows the 2.4 binding to be modified in the config.yaml binding file
 export FABRIC_VERSION=2.4
 export NODE_PATH="$SUT_DIR/uncached/v$FABRIC_VERSION/node_modules"
 if [[ "${BIND_IN_PACKAGE_DIR}" = "true" ]]; then

--- a/packages/caliper-tests-integration/fabric_tests/run.sh
+++ b/packages/caliper-tests-integration/fabric_tests/run.sh
@@ -29,10 +29,13 @@ cd ${DIR}
 
 # bind during CI tests, using the package dir as CWD
 # Note: do not use env variables for binding settings, as subsequent launch calls will pick them up and bind again
+FABRIC_VERSION=1.4.20
 if [[ "${BIND_IN_PACKAGE_DIR}" = "true" ]]; then
-    pushd $SUT_DIR
-    ${CALL_METHOD} bind --caliper-bind-sut fabric:1.4
+    mkdir -p $SUT_DIR/v$FABRIC_VERSION
+    pushd $SUT_DIR/v$FABRIC_VERSION
+    ${CALL_METHOD} bind --caliper-bind-sut fabric:$FABRIC_VERSION
     popd
+    NODE_PATH=$SUT_DIR/v$FABRIC_VERSION/node_modules
 fi
 
 # change default settings (add config paths too)
@@ -81,18 +84,14 @@ if [[ ${rc} != 0 ]]; then
     exit ${rc};
 fi
 
-# UNBIND SDK, using the package dir as CWD
-# Note: do not use env variables for unbinding settings, as subsequent launch calls will pick them up and bind again
-if [[ "${BIND_IN_PACKAGE_DIR}" = "true" ]]; then
-    pushd $SUT_DIR
-    ${CALL_METHOD} unbind --caliper-bind-sut fabric:1.4
-    popd
-fi
 # BIND with 2.2 SDK, using the package dir as CWD
 # Note: do not use env variables for unbinding settings, as subsequent launch calls will pick them up and bind again
+FABRIC_VERSION=2.2.14
 if [[ "${BIND_IN_PACKAGE_DIR}" = "true" ]]; then
-    pushd $SUT_DIR
-    ${CALL_METHOD} bind --caliper-bind-sut fabric:2.2
+    mkdir -p $SUT_DIR/v$FABRIC_VERSION
+    NODE_PATH=$SUT_DIR/v$FABRIC_VERSION/node_modules
+    pushd $SUT_DIR/v$FABRIC_VERSION
+    ${CALL_METHOD} bind --caliper-bind-sut fabric:$FABRIC_VERSION
     popd
 fi
 
@@ -105,19 +104,14 @@ if [[ ${rc} != 0 ]]; then
     exit ${rc};
 fi
 
-# UNBIND SDK, using the package dir as CWD
-# Note: do not use env variables for unbinding settings, as subsequent launch calls will pick them up and bind again
-if [[ "${BIND_IN_PACKAGE_DIR}" = "true" ]]; then
-    pushd $SUT_DIR
-    ${CALL_METHOD} unbind --caliper-bind-sut fabric:2.2
-    popd
-fi
-
 # BIND with 2.4 SDK, using the package dir as CWD
 # Note: do not use env variables for unbinding settings, as subsequent launch calls will pick them up and bind again
+FABRIC_VERSION=2.4
 if [[ "${BIND_IN_PACKAGE_DIR}" = "true" ]]; then
-    pushd $SUT_DIR
-    ${CALL_METHOD} bind --caliper-bind-sut fabric:2.4
+    mkdir -p $SUT_DIR/v$FABRIC_VERSION
+    NODE_PATH=$SUT_DIR/v$FABRIC_VERSION/node_modules
+    pushd $SUT_DIR/v$FABRIC_VERSION
+    ${CALL_METHOD} bind --caliper-bind-sut fabric:$FABRIC_VERSION
     popd
 fi
 

--- a/packages/caliper-tests-integration/fisco-bcos_tests/run.sh
+++ b/packages/caliper-tests-integration/fisco-bcos_tests/run.sh
@@ -24,7 +24,7 @@ cd "${DIR}"
 # Note: do not use env variables for binding settings, as subsequent launch calls will pick them up and bind again
 if [[ "${BIND_IN_PACKAGE_DIR}" = "true" ]]; then
     pushd $SUT_DIR
-    ${CALL_METHOD} bind --caliper-bind-sut fisco-bcos:latest
+    ${CALL_METHOD} bind --caliper-bind-sut fisco-bcos:2.0.0
     popd
 fi
 

--- a/packages/caliper-tests-integration/fisco-bcos_tests/run.sh
+++ b/packages/caliper-tests-integration/fisco-bcos_tests/run.sh
@@ -22,11 +22,16 @@ cd "${DIR}"
 
 # bind during CI tests, using the package dir as CWD
 # Note: do not use env variables for binding settings, as subsequent launch calls will pick them up and bind again
+# Note: FISCO BCOS 2.0 binding is cached in CI
+export FISCO_BCOS_VERSION=2.0.0
+export NODE_PATH="$SUT_DIR/cached/v$FISCO_BCOS_VERSION/node_modules"
 if [[ "${BIND_IN_PACKAGE_DIR}" = "true" ]]; then
-    pushd $SUT_DIR
-    ${CALL_METHOD} bind --caliper-bind-sut fisco-bcos:2.0.0
+    mkdir -p $SUT_DIR/cached/v$FISCO_BCOS_VERSION
+    pushd $SUT_DIR/cached/v$FISCO_BCOS_VERSION
+    ${CALL_METHOD} bind --caliper-bind-sut fisco-bcos:$FISCO_BCOS_VERSION
     popd
 fi
+ls -lah $NODE_PATH
 
 # change default settings (add config paths too)
 export CALIPER_PROJECTCONFIG=caliper.yaml

--- a/packages/caliper-tests-integration/generator_tests/fabric/run.sh
+++ b/packages/caliper-tests-integration/generator_tests/fabric/run.sh
@@ -49,9 +49,15 @@ ${GENERATOR_METHOD} -- --workspace 'myWorkspace' --contractId 'mymarbles' --cont
 # start network and run benchmark test
 cd ../
 # bind the sdk into the packages directory as it will search for it there, this ensures it doesn't contaminate real node_modules dirs (2.2 will work with a 1.4 fabric)
-pushd $SUT_DIR
-${CALL_METHOD} bind --caliper-bind-sut fabric:2.2
-popd
+# Note: Fabric 2.2 binding is cached in CI
+export FABRIC_VERSION=2.2.14
+export NODE_PATH="$SUT_DIR/cached/v$FABRIC_VERSION/node_modules"
+if [[ "${BIND_IN_PACKAGE_DIR}" = "true" ]]; then
+    mkdir -p $SUT_DIR/cached/v$FABRIC_VERSION
+    pushd $SUT_DIR/cached/v$FABRIC_VERSION
+    ${CALL_METHOD} bind --caliper-bind-sut fabric:$FABRIC_VERSION
+    popd
+fi
 
 pushd ${TEST_NETWORK_DIR}
 ./network.sh up -s couchdb

--- a/packages/caliper-tests-integration/run-tests.sh
+++ b/packages/caliper-tests-integration/run-tests.sh
@@ -25,8 +25,6 @@ if [[ "${BENCHMARK}" = "" ]]; then
     exit 1
 fi
 
-mkdir -p $SUT_DIR
-
 TEST_DIR="${BENCHMARK}_tests"
 if [[ -d "${TEST_DIR}" ]]; then
     "${TEST_DIR}"/run.sh

--- a/packages/caliper-tests-integration/run-tests.sh
+++ b/packages/caliper-tests-integration/run-tests.sh
@@ -25,6 +25,8 @@ if [[ "${BENCHMARK}" = "" ]]; then
     exit 1
 fi
 
+mkdir -p $SUT_DIR
+
 TEST_DIR="${BENCHMARK}_tests"
 if [[ -d "${TEST_DIR}" ]]; then
     "${TEST_DIR}"/run.sh


### PR DESCRIPTION
In this PR:
* The integration tests workflow is refactored to be DRY
* The `node_modules` folder is cached across workflows
* The SUT binding is cached across integration test runs

Closes #1374
