### PR TITLE
Add workflow to test npm packages

### DIFF
--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -1,0 +1,37 @@
+name: Test Published Package
+
+on:
+  workflow_call:
+
+jobs:
+  package-tests:
+    name: Test Published Package
+    runs-on: ubuntu-latest
+    services:
+      verdaccio:
+        image: verdaccio/verdaccio
+        ports:
+          - 4873:4873
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js 16.x
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.x
+    - name: Install dependencies
+      run: npm install
+      working-directory: ./packages/caliper-publish
+    - name: Initialize npm
+      run: |
+        npm install -g npm-cli-login
+        npm-cli-login
+      env:
+        NPM_USER: npm_user
+        NPM_PASS: npm_pass
+        NPM_EMAIL: npm_user@test.npm
+        NPM_REGISTRY: http://localhost:4873
+    - name: Publish Caliper
+      run: ./run-with-build.sh
+      working-directory: ./packages/caliper-tests-integration/fabric_docker_local_tests
+      env:
+        DOCKER_USER: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,3 +13,6 @@ jobs:
   integration-tests:
     uses: ./.github/workflows/integration-tests.yml
     needs: unit-tests
+  package-tests:
+    uses: ./.github/workflows/package-tests.yml
+    needs: dci-lint

--- a/packages/caliper-tests-integration/fabric_docker_local_tests/run-with-build.sh
+++ b/packages/caliper-tests-integration/fabric_docker_local_tests/run-with-build.sh
@@ -29,11 +29,8 @@ cd ${DIR}
 
 # Publish the packages locally and build a local test image
 cd ./../../caliper-publish/
-./publish.js verdaccio start
-sleep 5s
 ./publish.js npm --registry http://localhost:4873
 ./publish.js docker --registry http://localhost:4873 --image caliper --tag test
-./publish.js verdaccio stop
 
 # back to this dir
 cd ${DIR}


### PR DESCRIPTION
In this PR
* A new GitHub Actions workflow is added to test publishing of a package and the functioning of the published package using Verdaccio, with the help of scripts written previously

Closes #1403
