### PR TITLE
Add GitHub Actions workflow for docs

### DIFF
--- a/.dcilintignore
+++ b/.dcilintignore
@@ -1,0 +1,4 @@
+assets/img
+docs/v0.2
+docs/v0.3.2
+docs/v0.4.2

--- a/.github/workflows/dci.yml
+++ b/.github/workflows/dci.yml
@@ -1,0 +1,18 @@
+# Taken from https://github.com/petermetz/gh-action-dci-lint
+name: DCI
+
+on:
+  workflow_call:
+
+jobs:
+  DCI-lint:
+    name: DCI-Lint
+    runs-on: ubuntu-latest
+    steps:
+    - name: Lint Git Repo
+      id: lint-git-repo
+      uses: petermetz/gh-action-dci-lint@v0.6.1
+      with:
+        lint-git-repo-request: '{"cloneUrl": "${{ github.server_url }}/${{ github.repository }}.git", "fetchArgs": ["--no-tags", "--prune", "--progress", "--no-recurse-submodules", "--depth=1", "origin" ,"+${{ github.sha }}:${{ github.ref }}"], "checkoutArgs": [ "${{ github.ref }}"], "targetPhrasePatterns": [], "configDefaultsUrl": "https://inclusivenaming.org/json/dci-lint-config-recommended-v1.json" }'
+    - name: Get the output response
+      run: echo "${{ steps.lint-git-repo.outputs.lint-git-repo-response }}"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-name: CI (PR)
+name: Pages CI (PR)
 
 on:
   pull_request:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,9 @@
+name: CI (PR)
+
+on:
+  pull_request:
+    branches: [ "gh-pages" ]
+
+jobs:
+  dci-lint:
+    uses: ./.github/workflows/dci.yml

--- a/docs/v0.5.0/Ethereum_Configuration.md
+++ b/docs/v0.5.0/Ethereum_Configuration.md
@@ -124,7 +124,7 @@ The address to use while invoking all the methods of the benchmark. Its private 
 
 ## Benchmark address seed
 
-As an alternative to `fromAddress`, `fromAddressPrivateKey`, and `fromAddressPassword` the network configuration can use a fixed seed and derive needed addresses via [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) key derivation.  Each caliper test worker will generate an address for use as `fromAddress` and `fromAddressPrivateKey` using the derivation path `m/44'/60'/<x>'/0/0`, where <x> is the `clientIdx` passed into `getContext`.
+As an alternative to `fromAddress`, `fromAddressPrivateKey`, and `fromAddressPassword` the network configuration can use a fixed seed and derive needed addresses via [BIP-44](https://github.com/bitcoin/bips/blob/43da5dec5eaf0d8194baa66ba3dd976f923f9d07/bip-0044.mediawiki) key derivation.  Each caliper test worker will generate an address for use as `fromAddress` and `fromAddressPrivateKey` using the derivation path `m/44'/60'/<x>'/0/0`, where <x> is the `clientIdx` passed into `getContext`.
 
 This configuration does not override `fromAddress`, but it takes priority over `fromAddressPrivateKey` and `fromAddressPassword`.
 

--- a/docs/v0.5.0/FISCO_BCOS_Configuration.md
+++ b/docs/v0.5.0/FISCO_BCOS_Configuration.md
@@ -144,7 +144,7 @@ In the example above, there are four nodes in the topology of network, whose act
 ]
 ```
 
-In the example above, there are three smart contracts need to be deployed on the blockchain. The first two are implemented by Solidity and their source code can be found in `src/contract/fisco-bcos/` directory. The last one is a FISCO BCOS precompiled contract, its source code can be found [here](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/master/libprecompiled/extension/DagTransferPrecompiled.cpp).
+In the example above, there are three smart contracts need to be deployed on the blockchain. The first two are implemented by Solidity and their source code can be found in `src/contract/fisco-bcos/` directory. The last one is a FISCO BCOS precompiled contract, its source code can be found [here](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/release-2.9.0/libprecompiled/extension/DagTransferPrecompiled.cpp).
 
 #### info
 

--- a/docs/v0.5.0/Logging_Control.md
+++ b/docs/v0.5.0/Logging_Control.md
@@ -148,7 +148,7 @@ For example, to really highlight error-level logs: `--caliper-logging-formats-co
 
 ## Configuring logging targets
 
-The source and target(s) of log messages are decoupled, thanks to the [transport mechanism](https://github.com/winstonjs/winston/blob/master/docs/transports.md) of winston. This means that a log message can be easily logged to multiple places, like the console, or different log files. Moreover, this is completely transparent to the module generating the log message!
+The source and target(s) of log messages are decoupled, thanks to the [transport mechanism](https://github.com/winstonjs/winston/blob/3.2.1/docs/transports.md) of winston. This means that a log message can be easily logged to multiple places, like the console, or different log files. Moreover, this is completely transparent to the module generating the log message!
 
 The different targets are specified under the `caliper.logging.targets` property. The `caliper.logging.targets` section takes the following general form:
 
@@ -179,8 +179,8 @@ The following `target` values (i.e., transports) are supported. Click on the lin
 
 | Target | Available options |
 |:------:|:-----------------:|
-| `console` | [Console Transport](https://github.com/winstonjs/winston/blob/master/docs/transports.md#console-transport) |
-| `file` | [File Transport](https://github.com/winstonjs/winston/blob/master/docs/transports.md#file-transport) |
+| `console` | [Console Transport](https://github.com/winstonjs/winston/blob/3.2.1/docs/transports.md#console-transport) |
+| `file` | [File Transport](https://github.com/winstonjs/winston/blob/3.2.1/docs/transports.md#file-transport) |
 | `daily-rotate-file` | [Daily Rotating File Transport](https://github.com/winstonjs/winston-daily-rotate-file#options) |
 
 ### Disabling loggers

--- a/docs/vNext/Ethereum_Configuration.md
+++ b/docs/vNext/Ethereum_Configuration.md
@@ -124,7 +124,7 @@ The address to use while invoking all the methods of the benchmark. Its private 
 
 ## Benchmark address seed
 
-As an alternative to `fromAddress`, `fromAddressPrivateKey`, and `fromAddressPassword` the network configuration can use a fixed seed and derive needed addresses via [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) key derivation.  Each caliper test worker will generate an address for use as `fromAddress` and `fromAddressPrivateKey` using the derivation path `m/44'/60'/<x>'/0/0`, where <x> is the `clientIdx` passed into `getContext`.
+As an alternative to `fromAddress`, `fromAddressPrivateKey`, and `fromAddressPassword` the network configuration can use a fixed seed and derive needed addresses via [BIP-44](https://github.com/bitcoin/bips/blob/43da5dec5eaf0d8194baa66ba3dd976f923f9d07/bip-0044.mediawiki) key derivation.  Each caliper test worker will generate an address for use as `fromAddress` and `fromAddressPrivateKey` using the derivation path `m/44'/60'/<x>'/0/0`, where <x> is the `clientIdx` passed into `getContext`.
 
 This configuration does not override `fromAddress`, but it takes priority over `fromAddressPrivateKey` and `fromAddressPassword`.
 

--- a/docs/vNext/FISCO_BCOS_Configuration.md
+++ b/docs/vNext/FISCO_BCOS_Configuration.md
@@ -144,7 +144,7 @@ In the example above, there are four nodes in the topology of network, whose act
 ]
 ```
 
-In the example above, there are three smart contracts need to be deployed on the blockchain. The first two are implemented by Solidity and their source code can be found in `src/contract/fisco-bcos/` directory. The last one is a FISCO BCOS precompiled contract, its source code can be found [here](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/master/libprecompiled/extension/DagTransferPrecompiled.cpp).
+In the example above, there are three smart contracts need to be deployed on the blockchain. The first two are implemented by Solidity and their source code can be found in `src/contract/fisco-bcos/` directory. The last one is a FISCO BCOS precompiled contract, its source code can be found [here](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/release-2.9.0/libprecompiled/extension/DagTransferPrecompiled.cpp).
 
 #### info
 

--- a/docs/vNext/Logging_Control.md
+++ b/docs/vNext/Logging_Control.md
@@ -148,7 +148,7 @@ For example, to really highlight error-level logs: `--caliper-logging-formats-co
 
 ## Configuring logging targets
 
-The source and target(s) of log messages are decoupled, thanks to the [transport mechanism](https://github.com/winstonjs/winston/blob/master/docs/transports.md) of winston. This means that a log message can be easily logged to multiple places, like the console, or different log files. Moreover, this is completely transparent to the module generating the log message!
+The source and target(s) of log messages are decoupled, thanks to the [transport mechanism](https://github.com/winstonjs/winston/blob/3.2.1/docs/transports.md) of winston. This means that a log message can be easily logged to multiple places, like the console, or different log files. Moreover, this is completely transparent to the module generating the log message!
 
 The different targets are specified under the `caliper.logging.targets` property. The `caliper.logging.targets` section takes the following general form:
 
@@ -179,8 +179,8 @@ The following `target` values (i.e., transports) are supported. Click on the lin
 
 | Target | Available options |
 |:------:|:-----------------:|
-| `console` | [Console Transport](https://github.com/winstonjs/winston/blob/master/docs/transports.md#console-transport) |
-| `file` | [File Transport](https://github.com/winstonjs/winston/blob/master/docs/transports.md#file-transport) |
+| `console` | [Console Transport](https://github.com/winstonjs/winston/blob/3.2.1/docs/transports.md#console-transport) |
+| `file` | [File Transport](https://github.com/winstonjs/winston/blob/3.2.1/docs/transports.md#file-transport) |
 | `daily-rotate-file` | [Daily Rotating File Transport](https://github.com/winstonjs/winston-daily-rotate-file#options) |
 
 ### Disabling loggers


### PR DESCRIPTION
In this PR:
* GitHub actions workflows are added to the gh-pages branch
* Issues pointed out by DCI lint are fixed for the latest and vNext docs

This is done because according to [GitHub Docs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow):
> The following steps occur to trigger a workflow run:
> ...
> 2. GitHub searches the .github/workflows directory in your repository for workflow files that are present **in the associated commit SHA or Git ref of the event**.

So, the workflow file is expected to be present in the gh-pages branch for it to run.