### PR TITLE
Distinguish different workers in Prometheus PushGateway

### DIFF
--- a/packages/caliper-core/lib/worker/tx-observers/prometheus-push-tx-observer.js
+++ b/packages/caliper-core/lib/worker/tx-observers/prometheus-push-tx-observer.js
@@ -111,7 +111,9 @@ class PrometheusPushTxObserver extends TxObserverInterface {
      * @private
      */
     async _sendUpdate() {
-        this.prometheusPushGateway.pushAdd({jobName: 'workers'}, function(err, _resp, _body) {
+        this.prometheusPushGateway.pushAdd({jobName: 'workers', groupings: {
+            'workerIndex': this.workerIndex,
+        }}, function(err, _resp, _body) {
             if (err) {
                 Logger.error(`Error sending update to Prometheus Push Gateway: ${err.stack}`);
             }

--- a/packages/caliper-core/lib/worker/tx-observers/prometheus-push-tx-observer.js
+++ b/packages/caliper-core/lib/worker/tx-observers/prometheus-push-tx-observer.js
@@ -45,8 +45,6 @@ class PrometheusPushTxObserver extends TxObserverInterface {
 
         // automatically apply default internal and user supplied labels
         this.defaultLabels = (options && options.defaultLabels) ? options.defaultLabels : {};
-        this.defaultLabels.workerIndex = this.workerIndex;
-        this.defaultLabels.roundIndex = this.currentRound;
         this.defaultLabels.roundLabel = this.roundLabel;
         this.registry.setDefaultLabels(this.defaultLabels);
 
@@ -111,8 +109,9 @@ class PrometheusPushTxObserver extends TxObserverInterface {
      * @private
      */
     async _sendUpdate() {
-        this.prometheusPushGateway.pushAdd({jobName: 'workers', groupings: {
-            'workerIndex': this.workerIndex,
+        this.prometheusPushGateway.pushAdd({jobName: 'caliper-workers', groupings: {
+            workerIndex: this.workerIndex,
+            roundIndex: this.currentRound
         }}, function(err, _resp, _body) {
             if (err) {
                 Logger.error(`Error sending update to Prometheus Push Gateway: ${err.stack}`);
@@ -128,9 +127,7 @@ class PrometheusPushTxObserver extends TxObserverInterface {
     async activate(roundIndex, roundLabel) {
         await super.activate(roundIndex, roundLabel);
 
-        // update worker and round metadata
-        this.defaultLabels.workerIndex = this.workerIndex;
-        this.defaultLabels.roundIndex = this.currentRound;
+        // update round metadata
         this.defaultLabels.roundLabel = this.roundLabel;
         this.registry.setDefaultLabels(this.defaultLabels);
 


### PR DESCRIPTION
In this PR:
* The worker index of each worker is added as a label when pushing metrics to PushGateway to distinguish workers.

Fixes #1354 

### Results:

#### /metrics endpoint of PushGateway
![image](https://user-images.githubusercontent.com/36656347/182789819-de441ba3-db97-48e6-8343-c6ac4ff792ba.png)

#### Grafana dashboard showing metrics from two workers simultaneously
![image](https://user-images.githubusercontent.com/36656347/182790028-e23265f3-d2c2-4bdc-9123-e7b2bd8f0f70.png)
