### PR TITLE
Upload coverage reports on merge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   unit-tests:
     uses: ./.github/workflows/unit-tests.yml
+  coverage:
+    uses: ./.github/workflows/coverage.yml
+    needs: unit-tests
   publish-caliper:
     uses: ./.github/workflows/publish.yml
     needs: unit-tests


### PR DESCRIPTION
In this PR:
* The coverage report workflow is run on merge as well so that the coverage of the main branch can be obtained and used as a basis for comparing the coverage of PRs.