### PR TITLE
Terminate Caliper workers on interrupting Caliper manager

### DIFF
--- a/packages/caliper-cli/lib/launch/lib/launchManager.js
+++ b/packages/caliper-cli/lib/launch/lib/launchManager.js
@@ -59,6 +59,25 @@ class LaunchManager {
                 sutType, Constants.Factories.Connector, require);
 
             const engine = new CaliperEngine(benchmarkConfig, networkConfig, connectorFactory);
+            process.on('SIGINT', async () => {
+                // support a force stop
+                if (!this.terminationAlreadyRequested) {
+                    this.terminationAlreadyRequested = true;
+                    logger.info('Request to terminate received, stopping workers');
+                    try {
+                        await engine.stop();
+                    } catch(error) {
+                        logger.error(`Failed to stop workers: ${error}`);
+                        process.exit(1);
+                    }
+                    logger.info('Workers terminated');
+                    process.exit(0);
+                } else {
+                    logger.info('Termination already requested, terminating immediately');
+                    process.exit(2);
+                }
+            });
+
             const response = await engine.run();
 
             if (response === 0) {

--- a/packages/caliper-core/lib/manager/caliper-engine.js
+++ b/packages/caliper-core/lib/manager/caliper-engine.js
@@ -180,6 +180,15 @@ class CaliperEngine {
 
         return this.returnCode;
     }
+
+    /**
+     * Stops the benchmark run
+     */
+    async stop() {
+        if (this.roundOrchestrator) {
+            await this.roundOrchestrator.stop();
+        }
+    }
 }
 
 module.exports = CaliperEngine;

--- a/packages/caliper-core/lib/manager/orchestrators/round-orchestrator.js
+++ b/packages/caliper-core/lib/manager/orchestrators/round-orchestrator.js
@@ -177,12 +177,6 @@ class RoundOrchestrator {
             logger.error(`Could not prepare worker connections: ${err.stack || err}`);
         }
 
-        process.on('SIGINT', async () => {
-            logger.info('SIGINT received, stopping workers');
-            await this._cleanup();
-            process.exit(0);
-        });
-
         let benchStartTime = Date.now();
 
         for (const [index, roundConfig] of roundConfigs.entries()) {
@@ -238,7 +232,7 @@ class RoundOrchestrator {
             logger.error(`Error while finalizing the report: ${err.stack || err}`);
         }
 
-        await this._cleanup();
+        await this.stop();
 
         let benchEndTime = Date.now();
         logger.info(`Benchmark finished in ${(benchEndTime - benchStartTime)/1000.0} seconds. Total rounds: ${success + failed}. Successful rounds: ${success}. Failed rounds: ${failed}.`);
@@ -247,7 +241,7 @@ class RoundOrchestrator {
     /**
      * Stops the benchmark.
      */
-    async _cleanup() {
+    async stop() {
         // clean up, with "silent" failure handling
         try {
             await this.monitorOrchestrator.stopAllMonitors();


### PR DESCRIPTION
In this PR:
* The SIGINT signal is handled in the manager to cleanly terminate workers when user tries to terminate Caliper manager.

Fixes #1361