### PR TITLE
Collect Prometheus metrics in manager using messages

### DIFF
--- a/packages/caliper-core/lib/common/messages/parse.js
+++ b/packages/caliper-core/lib/common/messages/parse.js
@@ -24,6 +24,7 @@ const InitializeMessage = require('./initializeMessage');
 const ReadyMessage = require('./readyMessage');
 const PrepareMessage = require('./prepareMessage');
 const PreparedMessage = require('./preparedMessage');
+const PrometheusUpdateMessage = require('./prometheusUpdateMessage');
 const TestMessage = require('./testMessage');
 const TxResetMessage = require('./txResetMessage');
 const TxUpdateMessage = require('./txUpdateMessage');
@@ -64,6 +65,8 @@ function parse(rawMessage) {
         return new PrepareMessage(from, to, msg.content, date, err);
     case MessageTypes.Prepared:
         return new PreparedMessage(from, to, date, err);
+    case MessageTypes.PrometheusUpdate:
+        return new PrometheusUpdateMessage(from, to, msg.content, date, err);
     case MessageTypes.Test:
         return new TestMessage(from, to, msg.content, date, err);
     case MessageTypes.TxReset:

--- a/packages/caliper-core/lib/common/messages/prometheusUpdateMessage.js
+++ b/packages/caliper-core/lib/common/messages/prometheusUpdateMessage.js
@@ -1,0 +1,37 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const Message = require('./message');
+const MessageTypes = require('./../utils/constants').Messages.Types;
+
+/**
+ * Class for the "prometheusUpdate" message.
+ */
+class PrometheusUpdateMessage extends Message {
+    /**
+     * Constructor for a "prometheusUpdate" message instance.
+     * @param {string} sender The sender of the message.
+     * @param {string[]} recipients The recipients of the message.
+     * @param {object} content The content of the message.
+     * @param {string} date The date string of the message.
+     * @param {string} error The potential error associated with the message.
+     */
+    constructor(sender, recipients, content, date = undefined, error = undefined) {
+        super(sender, recipients, MessageTypes.PrometheusUpdate, content, date, error);
+    }
+}
+
+module.exports = PrometheusUpdateMessage;

--- a/packages/caliper-core/lib/common/utils/constants.js
+++ b/packages/caliper-core/lib/common/utils/constants.js
@@ -26,6 +26,7 @@ module.exports = {
             Ready: 'ready',
             Prepare: 'prepare',
             Prepared: 'prepared',
+            PrometheusUpdate: 'prometheusUpdate',
             Test: 'test',
             TxReset: 'txReset',
             TxUpdate: 'txUpdate',

--- a/packages/caliper-core/lib/manager/prometheus/prometheus-manager-scrape-target.js
+++ b/packages/caliper-core/lib/manager/prometheus/prometheus-manager-scrape-target.js
@@ -1,0 +1,151 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
+'use strict';
+
+const CaliperUtils = require('../../common/utils/caliper-utils');
+const ConfigUtil = require('../../common/config/config-util');
+
+const express = require('express');
+const appServer = express();
+const prometheusClient = require('prom-client');
+const prometheusGcStats = require('prometheus-gc-stats');
+
+const Logger = CaliperUtils.getLogger('prometheus-scrape-target');
+
+/**
+ * Class for creating a Prometheus scrape target
+ */
+class PrometheusManagerScrapeTarget {
+    /**
+     * Constructor
+     * @param {object} benchmarkConfig The benchmark configuration object.
+     */
+    constructor(benchmarkConfig) {
+        this.benchmarkConfig = benchmarkConfig;
+
+        const observerConfig = benchmarkConfig.monitors && benchmarkConfig.monitors.transaction ? benchmarkConfig.monitors.transaction : [];
+        const prometheusConfig = observerConfig.find((observer) => observer.module === 'prometheus-manager');
+        const options = prometheusConfig ? prometheusConfig.options : {};
+        this.metricPath = (options && options.metricPath) ? options.metricPath : '/metrics';
+        this.scrapePort = (options && options.scrapePort) ? Number(options.scrapePort) : ConfigUtil.get(ConfigUtil.keys.Observer.Prometheus.ScrapePort);
+        this.processMetricCollectInterval =  (options && options.processMetricCollectInterval) ? options.processMetricCollectInterval : undefined;
+
+        Logger.debug(`Configuring Prometheus scrape server for manager on port ${this.scrapePort}, with metrics exposed on ${this.metricPath} endpoint`);
+
+        this.registry = new prometheusClient.Registry();
+        this.labelNames = ['workerIndex', 'roundIndex', 'roundLabel'];
+
+        // Exposed metrics
+        this.counterTxSubmitted = new prometheusClient.Counter({
+            name: 'caliper_tx_submitted',
+            help: 'The total number of submitted transactions.',
+            labelNames: this.labelNames,
+            registers: [this.registry]
+        });
+
+        this.counterTxFinished = new prometheusClient.Counter({
+            name: 'caliper_tx_finished',
+            help: 'The total number of finished transactions.',
+            labelNames: ['final_status', ...this.labelNames],
+            registers: [this.registry]
+        });
+
+        // configure buckets
+        let buckets = prometheusClient.linearBuckets(0.1, 0.5, 10); // default
+        if (options && options.histogramBuckets) {
+            if (options.histogramBuckets.explicit) {
+                buckets = options.histogramBuckets.explicit;
+            } else if (options.histogramBuckets.linear) {
+                let linear = options.histogramBuckets.linear;
+                buckets = prometheusClient.linearBuckets(linear.start, linear.width, linear.count);
+            } else if (options.histogramBuckets.exponential) {
+                let exponential = options.histogramBuckets.exponential;
+                buckets = prometheusClient.exponentialBuckets(exponential.start, exponential.factor, exponential.count);
+            }
+        }
+
+        this.histogramLatency = new prometheusClient.Histogram({
+            name: 'caliper_tx_e2e_latency',
+            help: 'The histogram of end-to-end transaction latencies in seconds.',
+            labelNames: ['final_status', ...this.labelNames],
+            buckets,
+            registers: [this.registry]
+        });
+
+        if (this.processMetricCollectInterval) {
+            this.processMetricHandle = prometheusClient.collectDefaultMetrics({
+                register: this.registry,
+                timestamps: false,
+                timeout: this.processMetricCollectInterval
+            });
+            const startGcStats = prometheusGcStats(this.registry);
+            startGcStats();
+        }
+
+        appServer.get(`${this.metricPath}`, async (req, res) => {
+            try {
+                const metrics = await this.registry.metrics();
+                res.set('Content-Type', this.registry.contentType);
+                res.end(metrics);
+            } catch (err) {
+                Logger.error('Error in metrics provision within manager', err.stack);
+                res.status(500).end('Error collecting metrics from Hyperledger Caliper manager');
+            }
+        });
+    }
+
+    /**
+     * Process update from worker
+     * @param {object} data The data to process
+     */
+    processUpdate(data) {
+        if (data.event === 'txSubmitted') {
+            const labels = [data.workerIndex, data.roundIndex, data.roundLabel];
+            this.counterTxSubmitted.labels(...labels).inc(data.count);
+        } else if (data.event === 'txFinished') {
+            const labels = [data.status, data.workerIndex, data.roundIndex, data.roundLabel];
+            this.counterTxFinished.labels(...labels).inc();
+            this.histogramLatency.labels(...labels).observe(data.latency);
+        }
+    }
+
+    /**
+     * Reset the Prometheus scrape server
+     */
+    reset() {
+        this.counterTxSubmitted.reset();
+        this.counterTxFinished.reset();
+        this.histogramLatency.reset();
+    }
+
+    /**
+     * Start the Prometheus scrape server
+     */
+    start() {
+        Logger.debug('Starting Prometheus scrape server');
+        this.server = appServer.listen(this.scrapePort);
+        Logger.debug(`Enabled Prometheus scrape server on ${this.scrapePort}, with metrics exposed on ${this.metricPath} endpoint`);
+    }
+
+    /**
+     * Stop the Prometheus scrape server
+     */
+    stop() {
+        this.server.close();
+    }
+}
+
+module.exports = PrometheusManagerScrapeTarget;

--- a/packages/caliper-core/lib/worker/tx-observers/prometheus-manager-tx-observer.js
+++ b/packages/caliper-core/lib/worker/tx-observers/prometheus-manager-tx-observer.js
@@ -1,0 +1,97 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const TxObserverInterface = require('./tx-observer-interface');
+
+const PrometheusUpdateMessage = require('../../common/messages/prometheusUpdateMessage');
+
+/**
+ * Prometheus Manager TX observer used to send updates to the Prometheus scrape server in the manager.
+ */
+class PrometheusManagerTxObserver extends TxObserverInterface {
+    /**
+     * Initializes the instance.
+     * @param {object} options The observer configuration object.
+     * @param {MessengerInterface} messenger The worker messenger instance. Not used.
+     * @param {number} workerIndex The 0-based index of the worker node.
+     * @param {string} managerUuid The UUID of the manager messenger.
+     */
+    constructor(options, messenger, workerIndex, managerUuid) {
+        super(messenger, workerIndex);
+
+        this.managerUuid = managerUuid;
+    }
+    /**
+     * Called when TXs are submitted.
+     * @param {number} count The number of submitted TXs. Can be greater than one for a batch of TXs.
+     */
+    txSubmitted(count) {
+        const message = new PrometheusUpdateMessage(this.messenger.getUUID(), [this.managerUuid], {
+            event: 'txSubmitted',
+            workerIndex: this.workerIndex,
+            roundIndex: this.currentRound,
+            roundLabel: this.roundLabel,
+            count: count
+        });
+        this.messenger.send(message);
+    }
+
+    /**
+     * Called when TXs are finished.
+     * @param {TxStatus | TxStatus[]} results The result information of the finished TXs. Can be a collection of results for a batch of TXs.
+     */
+    txFinished(results) {
+        if (Array.isArray(results)) {
+            for (const result of results) {
+                // pass/fail status from result.GetStatus()
+                const message = new PrometheusUpdateMessage(this.messenger.getUUID(), [this.managerUuid], {
+                    event: 'txFinished',
+                    workerIndex: this.workerIndex,
+                    roundIndex: this.currentRound,
+                    roundLabel: this.roundLabel,
+                    status: result.GetStatus(),
+                    latency: result.GetTimeFinal() - result.GetTimeCreate()
+                });
+                this.messenger.send(message);
+            }
+        } else {
+            // pass/fail status from result.GetStatus()
+            const message = new PrometheusUpdateMessage(this.messenger.getUUID(), [this.managerUuid], {
+                event: 'txFinished',
+                workerIndex: this.workerIndex,
+                roundIndex: this.currentRound,
+                roundLabel: this.roundLabel,
+                status: results.GetStatus(),
+                latency: (results.GetTimeFinal() - results.GetTimeCreate())/1000
+            });
+            this.messenger.send(message);
+        }
+    }
+}
+
+/**
+ * Factory function for creating a PrometheusManagerTxObserver instance.
+ * @param {object} options The observer configuration object.
+ * @param {MessengerInterface} messenger The worker messenger instance.
+ * @param {number} workerIndex The 0-based index of the worker node.
+ * @param {string} managerUuid The UUID of the manager messenger.
+ * @return {TxObserverInterface} The observer instance.
+ */
+function createTxObserver(options, messenger, workerIndex, managerUuid) {
+    return new PrometheusManagerTxObserver(options, messenger, workerIndex, managerUuid);
+}
+
+module.exports.createTxObserver = createTxObserver;

--- a/packages/caliper-core/lib/worker/tx-observers/tx-observer-dispatch.js
+++ b/packages/caliper-core/lib/worker/tx-observers/tx-observer-dispatch.js
@@ -21,6 +21,7 @@ const CaliperUtils = require('../../common/utils/caliper-utils');
 const builtInTxObservers = new Map([
     ['logging', path.join(__dirname, 'logging-tx-observer.js')],
     ['prometheus', path.join(__dirname, 'prometheus-tx-observer.js')],
+    ['prometheus-manager', path.join(__dirname, 'prometheus-manager-tx-observer.js')],
     ['prometheus-push', path.join(__dirname, 'prometheus-push-tx-observer.js')]
 ]);
 
@@ -46,7 +47,7 @@ class TxObserverDispatch extends TxObserverInterface {
         let observerConfigs = super.getDeclaredTxObservers();
         for (let observer of observerConfigs) {
             const factoryFunction = CaliperUtils.loadModuleFunction(builtInTxObservers, observer.module, 'createTxObserver');
-            this.txObservers.push(factoryFunction(observer.options, messenger, workerIndex));
+            this.txObservers.push(factoryFunction(observer.options, messenger, workerIndex, managerUuid));
         }
 
         // always load the internal TX observer


### PR DESCRIPTION
Alternative implementation that works for both local and remote workers.
(This is just a draft implementation, discussions are ongoing in Discord)

## Checklist
 - [x]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
#1353

## Design of the fix
WIP

## Validation of the fix
|Approach|Results|
|:--:|:--:|
|PushGateway with local workers and mqtt communication|![image](https://user-images.githubusercontent.com/36656347/183692152-be68eb1f-a34c-4b09-aeac-50ab29bfc03e.png)|
|This PR (metrics communicated using messages) with local workers and mqtt communication|![image](https://user-images.githubusercontent.com/36656347/183691928-b704009f-f7dc-4dd6-8bbb-f0206ce0790a.png)|
|PR #1434 (metrics communicated using IPC) with local workers and mqtt communication|![image](https://user-images.githubusercontent.com/36656347/183694509-08504e92-0584-46f2-a5e5-e220187cf6f7.png)|

## Automated Tests
WIP

## What documentation has been provided for this pull request
WIP
