### PR TITLE
Fix integration test CI trigger

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,24 +23,32 @@ jobs:
             - 'packages/caliper-fabric/**'
             - 'packages/caliper-publish/**'
             - 'packages/caliper-tests-integration/fabric_tests/**'
+            - '.github/workflows/integration-tests.yml'
+            - 'package-lock.json'
           ethereum:
             - 'packages/caliper-cli/**'
             - 'packages/caliper-core/**'
             - 'packages/caliper-ethereum/**'
             - 'packages/caliper-publish/**'
             - 'packages/caliper-tests-integration/ethereum_tests/**'
+            - '.github/workflows/integration-tests.yml'
+            - 'package-lock.json'
           besu:
             - 'packages/caliper-cli/**'
             - 'packages/caliper-core/**'
             - 'packages/caliper-ethereum/**'
             - 'packages/caliper-publish/**'
             - 'packages/caliper-tests-integration/besu_tests/**'
+            - '.github/workflows/integration-tests.yml'
+            - 'package-lock.json'
           fisco-bcos:
             - 'packages/caliper-cli/**'
             - 'packages/caliper-core/**'
             - 'packages/caliper-fisco-bcos/**'
             - 'packages/caliper-publish/**'
             - 'packages/caliper-tests-integration/fisco-bcos_tests/**'
+            - '.github/workflows/integration-tests.yml'
+            - 'package-lock.json'
           generator:
             - 'packages/caliper-cli/**'
             - 'packages/caliper-core/**'
@@ -48,6 +56,8 @@ jobs:
             - 'packages/generator-caliper/**'
             - 'packages/caliper-publish/**'
             - 'packages/caliper-tests-integration/generator_tests/**'
+            - '.github/workflows/integration-tests.yml'
+            - 'package-lock.json'
 
   integration-tests:
     needs: changes


### PR DESCRIPTION
* Run integration tests when package-lock.json or the workflow file are modified

Fixes #1441