### PR TITLE
Revert "Add Node 18 to CI (#1455)"

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         adaptor: ${{ fromJSON(needs.changes.outputs.adaptor) }}
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js 18.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v3
       with:
-        node-version: 18.x
+        node-version: 16.x
     - name: Publish Caliper
       run: .build/publish-caliper.sh
       env:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
@@ -41,7 +41,7 @@ jobs:
     - name: Run unit tests
       run: npm test --workspaces
     - name: Upload coverage reports artifact
-      if: matrix.node-version == '18.x'
+      if: matrix.node-version == '16.x'
       uses: actions/upload-artifact@v3
       with:
         name: coverage-reports


### PR DESCRIPTION
The fisco-bcos adapter and the generator don't seem to be compatible with node 18, hence the change is reverted until it is fixed.