### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,7 +7,6 @@ The following are lists of the Caliper maintainers, Chat IDs are valid for [Disc
 | Name                      | GitHub           | Chat             |
 |---------------------------|------------------|------------------|
 | Attila Klenik             | aklenik          | Attila Klenik    |
-| Nick Lincoln              | nklincoln        |                  |
 | Dave Kelsey               | davidkel         | NorfolkAndChance |
 
 
@@ -17,7 +16,7 @@ The following are lists of the Caliper maintainers, Chat IDs are valid for [Disc
 |---------------------------|------------------|----------------|
 | FeihuJiang                | feihujiang       |                |
 | HaojunZhou                | haojun           |                |
-
+| Nick Lincoln              | nklincoln        |                |
 
 Contributors
 ===========


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

hyperledger/toc#32

Signed-off-by: Ry Jones <ry@linux.com>
