### PR TITLE
Fix npmignore for report html

### DIFF
--- a/packages/caliper-core/.npmignore
+++ b/packages/caliper-core/.npmignore
@@ -17,5 +17,8 @@
 .eslintignore
 .eslintrc.yml
 
+*.html
+!/lib/manager/report/template/report.html
+
 # test directory
 test


### PR DESCRIPTION
In this PR:
* Workaround new npmignore rules from NPM 7 to include the missing `report.html`

Fixes #1451