### PR TITLE
Update the versions of fabric sdks

### DIFF
--- a/packages/caliper-cli/lib/lib/config.yaml
+++ b/packages/caliper-cli/lib/lib/config.yaml
@@ -39,23 +39,18 @@ sut:
     # the 2.4 key without creating a new version and the integration tests will automatically pick it up.
     fabric:
         # The name/key of the SDK binding
-        1.4.11:
-            packages: ['fabric-client@1.4.11', 'fabric-network@1.4.11','fs-extra@8.1.0']
-        1.4.14:
-            packages: ['fabric-client@1.4.14', 'fabric-network@1.4.14','fs-extra@8.1.0']
-        1.4.20: &fabric-v1-lts
+        1.4: &fabric-sdk-v1
             packages: ['fabric-client@1.4.20', 'fabric-network@1.4.20','fs-extra@8.1.0']
-        1.4: *fabric-v1-lts
-        2.2.3:
-            packages: ['fabric-network@2.2.3']
-        2.2.14: &fabric-v2-lts
-            packages: ['fabric-network@2.2.14']
-        2.2: *fabric-v2-lts
-        2.4:
-            packages: ['@hyperledger/fabric-gateway@1.1.0', '@grpc/grpc-js@1.6.7']
-        latest: *fabric-v1-lts
-        latest-v2-lts: *fabric-v2-lts
-        latest-v2: *fabric-v2-lts
+        1.4.20: *fabric-sdk-v1
+        1: *fabric-sdk-v1
+        2.2: &fabric-sdk-v2
+            packages: ['fabric-network@2.2.20']
+        2.2.20: *fabric-sdk-v2
+        2.4: &fabric-gateway
+            packages: ['@hyperledger/fabric-gateway@1.5.0', '@grpc/grpc-js@1.10.3']
+        2.5: *fabric-gateway
+        3: *fabric-gateway
+        fabric-gateway: *fabric-gateway
 
     ethereum:
         1.2.1:

--- a/packages/caliper-tests-integration/fabric_tests/run.sh
+++ b/packages/caliper-tests-integration/fabric_tests/run.sh
@@ -92,7 +92,7 @@ fi
 # BIND with 2.2 SDK, using the package dir as CWD
 # Note: do not use env variables for unbinding settings, as subsequent launch calls will pick them up and bind again
 # Note: Fabric 2.2 binding is cached in CI
-export FABRIC_VERSION=2.2.14
+export FABRIC_VERSION=2.2.20
 export NODE_PATH="$SUT_DIR/cached/v$FABRIC_VERSION/node_modules"
 if [[ "${BIND_IN_PACKAGE_DIR}" = "true" ]]; then
     mkdir -p $SUT_DIR/cached/v$FABRIC_VERSION
@@ -110,7 +110,7 @@ if [[ ${rc} != 0 ]]; then
     exit ${rc};
 fi
 
-# BIND with 2.4 SDK, using the package dir as CWD
+# BIND with 2.4 SDK (which is the same as 2.5, 3, fabric-gateway), using the package dir as CWD
 # Note: do not use env variables for unbinding settings, as subsequent launch calls will pick them up and bind again
 # Note: Fabric 2.4 binding is NOT cached in CI. This binding is lightweight so doesn't take much time and allows the 2.4 binding to be modified in the config.yaml binding file
 export FABRIC_VERSION=2.4

--- a/packages/caliper-tests-integration/generator_tests/fabric/run.sh
+++ b/packages/caliper-tests-integration/generator_tests/fabric/run.sh
@@ -50,7 +50,7 @@ ${GENERATOR_METHOD} -- --workspace 'myWorkspace' --contractId 'mymarbles' --cont
 cd ../
 # bind the sdk into the packages directory as it will search for it there, this ensures it doesn't contaminate real node_modules dirs (2.2 will work with a 1.4 fabric)
 # Note: Fabric 2.2 binding is cached in CI
-export FABRIC_VERSION=2.2.14
+export FABRIC_VERSION=2.2.20
 export NODE_PATH="$SUT_DIR/cached/v$FABRIC_VERSION/node_modules"
 if [[ "${BIND_IN_PACKAGE_DIR}" = "true" ]]; then
     mkdir -p $SUT_DIR/cached/v$FABRIC_VERSION


### PR DESCRIPTION
This rationalises the versions and we should only document the following binding versions

1, 1.4 (use 1.4 legacy sdk)
2.2 (use 2.2 legacy sdk)
2.4, 2.5, 3, fabric-gateway (use the fabric-gateway sdk)

We will keep 2.4 (for legacy reasons only as 2.4 was never LTS), 2.5 to cover the published versions of fabric we support however the binding of fabric-gateway should be the one going forward and seen in the documentation.
because Fabric 2 changed the recommended client version in a point release (2.5 deprecated the legacy sdks and the only real option if the fabric-gateway) otherwise we will specify a single digit version for fabric (1,3)

the 1.4, 2.2 sdks are now deprecated and 2.2 is now or version soon to be out of lts, therefore fabric-gateway is the only version that will and should be used in the future and there is no plan to change the client side much given the reduction in resource of people using it and the use of SmartBFT should not affect the client side version (I hope :-) )


