### PR TITLE
Temporarily revert publish to using node 16.x to fix broken publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js 18.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v3
       with:
-        node-version: 18.x
+        node-version: 16.x
     - name: Publish Caliper
       run: .build/publish-caliper.sh
       env:


### PR DESCRIPTION
This is more of a case of quickly dropping down to an older version of `npm` so that it will fix the publish action.

Ideally we want to move to a supported version of node and address the issue that comes with that version of npm to perform a publish. It could be

1. move to an older version of npm (ie that one that comes with node 16), but this is not ideal
2. move to a newer version of npm as it may be an issue with the version that came with node 18, but this isn't likely
3. look at the npm publish command to see what needs to be done to make it work.

