### PR TITLE
downgrade npm on publish as temp fix

### DIFF
--- a/.build/publish-caliper.sh
+++ b/.build/publish-caliper.sh
@@ -24,5 +24,7 @@ cp ./README.md ./packages/caliper-fabric/README.md
 
 cd ./packages/caliper-publish/
 npm ci
+# temporary workaround to downgrade npm in order to publish
+npm install -g npm@8.19.4
 ./publish.js npm
 ./publish.js docker --publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js 16.x
+    - name: Use Node.js 18.x
       uses: actions/setup-node@v3
       with:
-        node-version: 16.x
+        node-version: 18.x
     - name: Publish Caliper
       run: .build/publish-caliper.sh
       env:


### PR DESCRIPTION
downgrade the version of npm on the publish step to ensure that publish doesn't give an ENOWORKSPACES error

This should be considered a temporary solution to getting publish working again and a better solution needs to be found.

