### PR TITLE
Remove collection of node gc stats in prometheus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,12 +27,12 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
-            "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+            "version": "7.24.2",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+            "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
             "dependencies": {
-                "@babel/highlight": "^7.23.4",
-                "chalk": "^2.4.2"
+                "@babel/highlight": "^7.24.2",
+                "picocolors": "^1.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -47,13 +47,14 @@
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.23.4",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-            "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
+            "version": "7.24.2",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
+            "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.22.20",
                 "chalk": "^2.4.2",
-                "js-tokens": "^4.0.0"
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -4439,637 +4440,6 @@
             "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
             "dev": true
         },
-        "node_modules/gc-stats": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/gc-stats/-/gc-stats-1.4.0.tgz",
-            "integrity": "sha512-4FcCj9e8j8rCjvLkqRpGZBLgTC/xr9XEf5By3x77cDucWWB3pJK6FEwXZCTCbb4z8xdaOoi4owBNrvn3ciDdxA==",
-            "bundleDependencies": [
-                "node-pre-gyp"
-            ],
-            "hasInstallScript": true,
-            "optional": true,
-            "dependencies": {
-                "nan": "^2.13.2",
-                "node-pre-gyp": "^0.13.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/gc-stats/node_modules/abbrev": {
-            "version": "1.1.1",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true
-        },
-        "node_modules/gc-stats/node_modules/ansi-regex": {
-            "version": "2.1.1",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/gc-stats/node_modules/aproba": {
-            "version": "1.2.0",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true
-        },
-        "node_modules/gc-stats/node_modules/are-we-there-yet": {
-            "version": "1.1.5",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
-            }
-        },
-        "node_modules/gc-stats/node_modules/balanced-match": {
-            "version": "1.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/gc-stats/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/gc-stats/node_modules/chownr": {
-            "version": "1.1.1",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true
-        },
-        "node_modules/gc-stats/node_modules/code-point-at": {
-            "version": "1.1.0",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/gc-stats/node_modules/concat-map": {
-            "version": "0.0.1",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/gc-stats/node_modules/console-control-strings": {
-            "version": "1.1.0",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true
-        },
-        "node_modules/gc-stats/node_modules/core-util-is": {
-            "version": "1.0.2",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/gc-stats/node_modules/debug": {
-            "version": "4.1.1",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "ms": "^2.1.1"
-            }
-        },
-        "node_modules/gc-stats/node_modules/deep-extend": {
-            "version": "0.6.0",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/gc-stats/node_modules/delegates": {
-            "version": "1.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/gc-stats/node_modules/detect-libc": {
-            "version": "1.0.3",
-            "inBundle": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "bin": {
-                "detect-libc": "bin/detect-libc.js"
-            },
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
-        "node_modules/gc-stats/node_modules/fs-minipass": {
-            "version": "1.2.5",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "minipass": "^2.2.1"
-            }
-        },
-        "node_modules/gc-stats/node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true
-        },
-        "node_modules/gc-stats/node_modules/gauge": {
-            "version": "2.7.4",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-            }
-        },
-        "node_modules/gc-stats/node_modules/glob": {
-            "version": "7.1.3",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/gc-stats/node_modules/has-unicode": {
-            "version": "2.0.1",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true
-        },
-        "node_modules/gc-stats/node_modules/iconv-lite": {
-            "version": "0.4.24",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/gc-stats/node_modules/ignore-walk": {
-            "version": "3.0.1",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "minimatch": "^3.0.4"
-            }
-        },
-        "node_modules/gc-stats/node_modules/inflight": {
-            "version": "1.0.6",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "node_modules/gc-stats/node_modules/inherits": {
-            "version": "2.0.3",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true
-        },
-        "node_modules/gc-stats/node_modules/ini": {
-            "version": "1.3.5",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true,
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/gc-stats/node_modules/is-fullwidth-code-point": {
-            "version": "1.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "number-is-nan": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/gc-stats/node_modules/isarray": {
-            "version": "1.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/gc-stats/node_modules/minimatch": {
-            "version": "3.0.4",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/gc-stats/node_modules/minimist": {
-            "version": "0.0.8",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/gc-stats/node_modules/minipass": {
-            "version": "2.3.5",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
-            }
-        },
-        "node_modules/gc-stats/node_modules/minizlib": {
-            "version": "1.2.1",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "minipass": "^2.2.1"
-            }
-        },
-        "node_modules/gc-stats/node_modules/mkdirp": {
-            "version": "0.5.1",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "minimist": "0.0.8"
-            },
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            }
-        },
-        "node_modules/gc-stats/node_modules/ms": {
-            "version": "2.1.1",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/gc-stats/node_modules/needle": {
-            "version": "2.3.1",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "debug": "^4.1.0",
-                "iconv-lite": "^0.4.4",
-                "sax": "^1.2.4"
-            },
-            "bin": {
-                "needle": "bin/needle"
-            },
-            "engines": {
-                "node": ">= 4.4.x"
-            }
-        },
-        "node_modules/gc-stats/node_modules/node-pre-gyp": {
-            "version": "0.13.0",
-            "inBundle": true,
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "dependencies": {
-                "detect-libc": "^1.0.2",
-                "mkdirp": "^0.5.1",
-                "needle": "^2.2.1",
-                "nopt": "^4.0.1",
-                "npm-packlist": "^1.1.6",
-                "npmlog": "^4.0.2",
-                "rc": "^1.2.7",
-                "rimraf": "^2.6.1",
-                "semver": "^5.3.0",
-                "tar": "^4"
-            },
-            "bin": {
-                "node-pre-gyp": "bin/node-pre-gyp"
-            }
-        },
-        "node_modules/gc-stats/node_modules/nopt": {
-            "version": "4.0.1",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
-            },
-            "bin": {
-                "nopt": "bin/nopt.js"
-            }
-        },
-        "node_modules/gc-stats/node_modules/npm-bundled": {
-            "version": "1.0.6",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true
-        },
-        "node_modules/gc-stats/node_modules/npm-packlist": {
-            "version": "1.4.1",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "ignore-walk": "^3.0.1",
-                "npm-bundled": "^1.0.1"
-            }
-        },
-        "node_modules/gc-stats/node_modules/npmlog": {
-            "version": "4.1.2",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-            }
-        },
-        "node_modules/gc-stats/node_modules/number-is-nan": {
-            "version": "1.0.1",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/gc-stats/node_modules/object-assign": {
-            "version": "4.1.1",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/gc-stats/node_modules/once": {
-            "version": "1.4.0",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "wrappy": "1"
-            }
-        },
-        "node_modules/gc-stats/node_modules/os-homedir": {
-            "version": "1.0.2",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/gc-stats/node_modules/os-tmpdir": {
-            "version": "1.0.2",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/gc-stats/node_modules/osenv": {
-            "version": "0.1.5",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
-            }
-        },
-        "node_modules/gc-stats/node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/gc-stats/node_modules/process-nextick-args": {
-            "version": "2.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/gc-stats/node_modules/rc": {
-            "version": "1.2.8",
-            "inBundle": true,
-            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-            "optional": true,
-            "dependencies": {
-                "deep-extend": "^0.6.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
-            },
-            "bin": {
-                "rc": "cli.js"
-            }
-        },
-        "node_modules/gc-stats/node_modules/rc/node_modules/minimist": {
-            "version": "1.2.0",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/gc-stats/node_modules/readable-stream": {
-            "version": "2.3.6",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            }
-        },
-        "node_modules/gc-stats/node_modules/rimraf": {
-            "version": "2.6.3",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            }
-        },
-        "node_modules/gc-stats/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/gc-stats/node_modules/safer-buffer": {
-            "version": "2.1.2",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/gc-stats/node_modules/sax": {
-            "version": "1.2.4",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true
-        },
-        "node_modules/gc-stats/node_modules/semver": {
-            "version": "5.7.0",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true,
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
-        "node_modules/gc-stats/node_modules/set-blocking": {
-            "version": "2.0.0",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true
-        },
-        "node_modules/gc-stats/node_modules/signal-exit": {
-            "version": "3.0.2",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true
-        },
-        "node_modules/gc-stats/node_modules/string_decoder": {
-            "version": "1.1.1",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "safe-buffer": "~5.1.0"
-            }
-        },
-        "node_modules/gc-stats/node_modules/string-width": {
-            "version": "1.0.2",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/gc-stats/node_modules/strip-ansi": {
-            "version": "3.0.1",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "ansi-regex": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/gc-stats/node_modules/strip-json-comments": {
-            "version": "2.0.1",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/gc-stats/node_modules/tar": {
-            "version": "4.4.8",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "chownr": "^1.1.1",
-                "fs-minipass": "^1.2.5",
-                "minipass": "^2.3.4",
-                "minizlib": "^1.1.1",
-                "mkdirp": "^0.5.0",
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=4.5"
-            }
-        },
-        "node_modules/gc-stats/node_modules/util-deprecate": {
-            "version": "1.0.2",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/gc-stats/node_modules/wide-align": {
-            "version": "1.1.3",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "string-width": "^1.0.2 || 2"
-            }
-        },
-        "node_modules/gc-stats/node_modules/wrappy": {
-            "version": "1.0.2",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true
-        },
-        "node_modules/gc-stats/node_modules/yallist": {
-            "version": "3.0.3",
-            "inBundle": true,
-            "license": "ISC",
-            "optional": true
-        },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -6669,6 +6039,28 @@
             "integrity": "sha512-BJ+ffciw5dRj+B7gsjlP5B8kmuveANbP6OTqb3YItv6vlRjtAGCkaDbguAHI4lUqv/gNBTwQzUEUEUTetcyGEg==",
             "dev": true
         },
+        "node_modules/make-dir": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+            "dependencies": {
+                "semver": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/make-dir/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
         "node_modules/map-cache": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -7486,6 +6878,25 @@
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
             "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
         },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/node-gyp-build": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
@@ -7534,25 +6945,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/npm-api/node_modules/node-fetch": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/npm-api/node_modules/shallow-clone": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
@@ -7562,25 +6954,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/npm-api/node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-        },
-        "node_modules/npm-api/node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-        },
-        "node_modules/npm-api/node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/nssocket": {
@@ -10086,11 +9459,6 @@
             "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==",
             "dev": true
         },
-        "node_modules/optional": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/optional/-/optional-0.1.4.tgz",
-            "integrity": "sha512-gtvrrCfkE08wKcgXaVwQVgwEQ8vel2dc5DDBn9RLQZ3YtmtkBss6A2HY6BnJH4N/4Ku97Ri/SF8sNWE2225WJw=="
-        },
         "node_modules/optionator": {
             "version": "0.8.3",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -10358,6 +9726,11 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
             "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+        },
+        "node_modules/picocolors": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -10757,23 +10130,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/prometheus-gc-stats": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/prometheus-gc-stats/-/prometheus-gc-stats-0.6.3.tgz",
-            "integrity": "sha512-vCX+HZ1jZHkha25r5dAcRSNjue+K3Hn0B33EcZl7y3hgp3o1YsQ4Y3x7oJWKvDdbelFIL0McsXGmRg3zBrmq+g==",
-            "dependencies": {
-                "optional": "^0.1.3"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "optionalDependencies": {
-                "gc-stats": "^1.4.0"
-            },
-            "peerDependencies": {
-                "prom-client": ">= 10 <= 12"
-            }
-        },
         "node_modules/promptly": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/promptly/-/promptly-2.2.0.tgz",
@@ -10989,22 +10345,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/read-pkg/node_modules/resolve": {
-            "version": "1.22.1",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-            "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
-            "dependencies": {
-                "is-core-module": "^2.9.0",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/read-pkg/node_modules/type-fest": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
@@ -11050,22 +10390,6 @@
             },
             "engines": {
                 "node": ">= 0.10"
-            }
-        },
-        "node_modules/rechoir/node_modules/resolve": {
-            "version": "1.22.1",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-            "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
-            "dependencies": {
-                "is-core-module": "^2.9.0",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/regex-not": {
@@ -11271,6 +10595,22 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/resolve": {
+            "version": "1.22.8",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+            "dependencies": {
+                "is-core-module": "^2.13.0",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/resolve-from": {
@@ -14969,6 +14309,25 @@
             "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
             "dev": true
         },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
+        "node_modules/whatwg-url/node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "node_modules/whatwg-url/node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
         "node_modules/which": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -16029,28 +15388,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/yeoman-generator/node_modules/make-dir": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-            "dependencies": {
-                "semver": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/yeoman-generator/node_modules/make-dir/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
         "node_modules/yeoman-generator/node_modules/p-locate": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
@@ -16792,7 +16129,6 @@
                 "nconf-yaml": "^1.0.2",
                 "pidusage": "^1.1.6",
                 "prom-client": "12.0.0",
-                "prometheus-gc-stats": "0.6.3",
                 "ps-node": "^0.1.6",
                 "table": "^4.0.1",
                 "triple-beam": "^1.3.0",
@@ -17179,26 +16515,6 @@
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "packages/caliper-tests-integration/node_modules/yeoman-generator/node_modules/make-dir": {
-            "version": "3.1.0",
-            "license": "MIT",
-            "dependencies": {
-                "semver": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "packages/caliper-tests-integration/node_modules/yeoman-generator/node_modules/make-dir/node_modules/semver": {
-            "version": "6.3.0",
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
             }
         },
         "packages/caliper-tests-integration/node_modules/yeoman-generator/node_modules/mem-fs-editor": {
@@ -17626,22 +16942,6 @@
                 "node": ">=6"
             }
         },
-        "packages/generator-caliper/node_modules/resolve": {
-            "version": "1.22.8",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-            "dependencies": {
-                "is-core-module": "^2.13.0",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "packages/generator-caliper/node_modules/rimraf": {
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -17715,12 +17015,12 @@
     },
     "dependencies": {
         "@babel/code-frame": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
-            "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+            "version": "7.24.2",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+            "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
             "requires": {
-                "@babel/highlight": "^7.23.4",
-                "chalk": "^2.4.2"
+                "@babel/highlight": "^7.24.2",
+                "picocolors": "^1.0.0"
             }
         },
         "@babel/helper-validator-identifier": {
@@ -17729,13 +17029,14 @@
             "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A=="
         },
         "@babel/highlight": {
-            "version": "7.23.4",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-            "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
+            "version": "7.24.2",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
+            "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
             "requires": {
                 "@babel/helper-validator-identifier": "^7.22.20",
                 "chalk": "^2.4.2",
-                "js-tokens": "^4.0.0"
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.0.0"
             }
         },
         "@colors/colors": {
@@ -17945,7 +17246,6 @@
                 "nyc": "11.1.0",
                 "pidusage": "^1.1.6",
                 "prom-client": "12.0.0",
-                "prometheus-gc-stats": "0.6.3",
                 "ps-node": "^0.1.6",
                 "rewire": "^4.0.0",
                 "sinon": "^7.3.2",
@@ -18230,16 +17530,6 @@
                     "requires": {
                         "find-up": "^3.0.0",
                         "read-pkg": "^3.0.0"
-                    }
-                },
-                "resolve": {
-                    "version": "1.22.8",
-                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-                    "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-                    "requires": {
-                        "is-core-module": "^2.13.0",
-                        "path-parse": "^1.0.7",
-                        "supports-preserve-symlinks-flag": "^1.0.0"
                     }
                 },
                 "rimraf": {
@@ -19696,17 +18986,6 @@
                             "requires": {
                                 "p-locate": "^3.0.0",
                                 "path-exists": "^3.0.0"
-                            }
-                        },
-                        "make-dir": {
-                            "version": "3.1.0",
-                            "requires": {
-                                "semver": "^6.0.0"
-                            },
-                            "dependencies": {
-                                "semver": {
-                                    "version": "6.3.0"
-                                }
                             }
                         },
                         "mem-fs-editor": {
@@ -22201,487 +21480,6 @@
             "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
             "dev": true
         },
-        "gc-stats": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/gc-stats/-/gc-stats-1.4.0.tgz",
-            "integrity": "sha512-4FcCj9e8j8rCjvLkqRpGZBLgTC/xr9XEf5By3x77cDucWWB3pJK6FEwXZCTCbb4z8xdaOoi4owBNrvn3ciDdxA==",
-            "optional": true,
-            "requires": {
-                "nan": "^2.13.2",
-                "node-pre-gyp": "^0.13.0"
-            },
-            "dependencies": {
-                "abbrev": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "aproba": {
-                    "version": "1.2.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "are-we-there-yet": {
-                    "version": "1.1.5",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "delegates": "^1.0.0",
-                        "readable-stream": "^2.0.6"
-                    }
-                },
-                "balanced-match": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "brace-expansion": {
-                    "version": "1.1.11",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                    }
-                },
-                "chownr": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "code-point-at": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "concat-map": {
-                    "version": "0.0.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "console-control-strings": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "core-util-is": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "debug": {
-                    "version": "4.1.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "deep-extend": {
-                    "version": "0.6.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "delegates": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "detect-libc": {
-                    "version": "1.0.3",
-                    "bundled": true,
-                    "optional": true
-                },
-                "fs-minipass": {
-                    "version": "1.2.5",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "minipass": "^2.2.1"
-                    }
-                },
-                "fs.realpath": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "gauge": {
-                    "version": "2.7.4",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "aproba": "^1.0.3",
-                        "console-control-strings": "^1.0.0",
-                        "has-unicode": "^2.0.0",
-                        "object-assign": "^4.1.0",
-                        "signal-exit": "^3.0.0",
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1",
-                        "wide-align": "^1.1.0"
-                    }
-                },
-                "glob": {
-                    "version": "7.1.3",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "has-unicode": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "iconv-lite": {
-                    "version": "0.4.24",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3"
-                    }
-                },
-                "ignore-walk": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "minimatch": "^3.0.4"
-                    }
-                },
-                "inflight": {
-                    "version": "1.0.6",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
-                    }
-                },
-                "inherits": {
-                    "version": "2.0.3",
-                    "bundled": true,
-                    "optional": true
-                },
-                "ini": {
-                    "version": "1.3.5",
-                    "bundled": true,
-                    "optional": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "number-is-nan": "^1.0.0"
-                    }
-                },
-                "isarray": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "minimatch": {
-                    "version": "3.0.4",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                },
-                "minimist": {
-                    "version": "0.0.8",
-                    "bundled": true,
-                    "optional": true
-                },
-                "minipass": {
-                    "version": "2.3.5",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "safe-buffer": "^5.1.2",
-                        "yallist": "^3.0.0"
-                    }
-                },
-                "minizlib": {
-                    "version": "1.2.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "minipass": "^2.2.1"
-                    }
-                },
-                "mkdirp": {
-                    "version": "0.5.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "minimist": "0.0.8"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "needle": {
-                    "version": "2.3.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "debug": "^4.1.0",
-                        "iconv-lite": "^0.4.4",
-                        "sax": "^1.2.4"
-                    }
-                },
-                "node-pre-gyp": {
-                    "version": "0.13.0",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "detect-libc": "^1.0.2",
-                        "mkdirp": "^0.5.1",
-                        "needle": "^2.2.1",
-                        "nopt": "^4.0.1",
-                        "npm-packlist": "^1.1.6",
-                        "npmlog": "^4.0.2",
-                        "rc": "^1.2.7",
-                        "rimraf": "^2.6.1",
-                        "semver": "^5.3.0",
-                        "tar": "^4"
-                    }
-                },
-                "nopt": {
-                    "version": "4.0.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "abbrev": "1",
-                        "osenv": "^0.1.4"
-                    }
-                },
-                "npm-bundled": {
-                    "version": "1.0.6",
-                    "bundled": true,
-                    "optional": true
-                },
-                "npm-packlist": {
-                    "version": "1.4.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "ignore-walk": "^3.0.1",
-                        "npm-bundled": "^1.0.1"
-                    }
-                },
-                "npmlog": {
-                    "version": "4.1.2",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "are-we-there-yet": "~1.1.2",
-                        "console-control-strings": "~1.1.0",
-                        "gauge": "~2.7.3",
-                        "set-blocking": "~2.0.0"
-                    }
-                },
-                "number-is-nan": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "object-assign": {
-                    "version": "4.1.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "once": {
-                    "version": "1.4.0",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "wrappy": "1"
-                    }
-                },
-                "os-homedir": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "os-tmpdir": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "osenv": {
-                    "version": "0.1.5",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "os-homedir": "^1.0.0",
-                        "os-tmpdir": "^1.0.0"
-                    }
-                },
-                "path-is-absolute": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "process-nextick-args": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "rc": {
-                    "version": "1.2.8",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "deep-extend": "^0.6.0",
-                        "ini": "~1.3.0",
-                        "minimist": "^1.2.0",
-                        "strip-json-comments": "~2.0.1"
-                    },
-                    "dependencies": {
-                        "minimist": {
-                            "version": "1.2.0",
-                            "bundled": true,
-                            "optional": true
-                        }
-                    }
-                },
-                "readable-stream": {
-                    "version": "2.3.6",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "rimraf": {
-                    "version": "2.6.3",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "glob": "^7.1.3"
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.1.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "safer-buffer": {
-                    "version": "2.1.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "sax": {
-                    "version": "1.2.4",
-                    "bundled": true,
-                    "optional": true
-                },
-                "semver": {
-                    "version": "5.7.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "set-blocking": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "optional": true
-                },
-                "signal-exit": {
-                    "version": "3.0.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
-                },
-                "string-width": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
-                },
-                "strip-json-comments": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "optional": true
-                },
-                "tar": {
-                    "version": "4.4.8",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "chownr": "^1.1.1",
-                        "fs-minipass": "^1.2.5",
-                        "minipass": "^2.3.4",
-                        "minizlib": "^1.1.1",
-                        "mkdirp": "^0.5.0",
-                        "safe-buffer": "^5.1.2",
-                        "yallist": "^3.0.2"
-                    }
-                },
-                "util-deprecate": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "wide-align": {
-                    "version": "1.1.3",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "string-width": "^1.0.2 || 2"
-                    }
-                },
-                "wrappy": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "optional": true
-                },
-                "yallist": {
-                    "version": "3.0.3",
-                    "bundled": true,
-                    "optional": true
-                }
-            }
-        },
         "get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -23953,6 +22751,21 @@
             "integrity": "sha512-BJ+ffciw5dRj+B7gsjlP5B8kmuveANbP6OTqb3YItv6vlRjtAGCkaDbguAHI4lUqv/gNBTwQzUEUEUTetcyGEg==",
             "dev": true
         },
+        "make-dir": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+            "requires": {
+                "semver": "^6.0.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+                    "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
+                }
+            }
+        },
         "map-cache": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -24604,6 +23417,14 @@
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
             "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
         },
+        "node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "requires": {
+                "whatwg-url": "^5.0.0"
+            }
+        },
         "node-gyp-build": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
@@ -24638,39 +23459,12 @@
                         "shallow-clone": "^3.0.0"
                     }
                 },
-                "node-fetch": {
-                    "version": "2.6.7",
-                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-                    "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-                    "requires": {
-                        "whatwg-url": "^5.0.0"
-                    }
-                },
                 "shallow-clone": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
                     "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
                     "requires": {
                         "kind-of": "^6.0.2"
-                    }
-                },
-                "tr46": {
-                    "version": "0.0.3",
-                    "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-                    "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-                },
-                "webidl-conversions": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-                    "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-                },
-                "whatwg-url": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-                    "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-                    "requires": {
-                        "tr46": "~0.0.3",
-                        "webidl-conversions": "^3.0.0"
                     }
                 }
             }
@@ -26500,11 +25294,6 @@
                 }
             }
         },
-        "optional": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/optional/-/optional-0.1.4.tgz",
-            "integrity": "sha512-gtvrrCfkE08wKcgXaVwQVgwEQ8vel2dc5DDBn9RLQZ3YtmtkBss6A2HY6BnJH4N/4Ku97Ri/SF8sNWE2225WJw=="
-        },
         "optionator": {
             "version": "0.8.3",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -26711,6 +25500,11 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
             "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+        },
+        "picocolors": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
         },
         "picomatch": {
             "version": "2.3.1",
@@ -27039,15 +25833,6 @@
                 "tdigest": "^0.1.1"
             }
         },
-        "prometheus-gc-stats": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/prometheus-gc-stats/-/prometheus-gc-stats-0.6.3.tgz",
-            "integrity": "sha512-vCX+HZ1jZHkha25r5dAcRSNjue+K3Hn0B33EcZl7y3hgp3o1YsQ4Y3x7oJWKvDdbelFIL0McsXGmRg3zBrmq+g==",
-            "requires": {
-                "gc-stats": "^1.4.0",
-                "optional": "^0.1.3"
-            }
-        },
         "promptly": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/promptly/-/promptly-2.2.0.tgz",
@@ -27234,16 +26019,6 @@
                         "lines-and-columns": "^1.1.6"
                     }
                 },
-                "resolve": {
-                    "version": "1.22.1",
-                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-                    "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
-                    "requires": {
-                        "is-core-module": "^2.9.0",
-                        "path-parse": "^1.0.7",
-                        "supports-preserve-symlinks-flag": "^1.0.0"
-                    }
-                },
                 "type-fest": {
                     "version": "0.6.0",
                     "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
@@ -27282,18 +26057,6 @@
             "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
             "requires": {
                 "resolve": "^1.1.6"
-            },
-            "dependencies": {
-                "resolve": {
-                    "version": "1.22.1",
-                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-                    "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
-                    "requires": {
-                        "is-core-module": "^2.9.0",
-                        "path-parse": "^1.0.7",
-                        "supports-preserve-symlinks-flag": "^1.0.0"
-                    }
-                }
             }
         },
         "regex-not": {
@@ -27449,6 +26212,16 @@
                     "integrity": "sha512-kT10v4dhrlLNcnO084hEjvXCI1wUG9qZLoz2RogxqDQQYy7IxjI/iMUkOtQTNEh6rzHxvdQWHsJyel1pKOVCxg==",
                     "dev": true
                 }
+            }
+        },
+        "resolve": {
+            "version": "1.22.8",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+            "requires": {
+                "is-core-module": "^2.13.0",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
             }
         },
         "resolve-from": {
@@ -30540,6 +29313,27 @@
             "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
             "dev": true
         },
+        "whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "requires": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            },
+            "dependencies": {
+                "tr46": {
+                    "version": "0.0.3",
+                    "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+                    "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+                },
+                "webidl-conversions": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+                    "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+                }
+            }
+        },
         "which": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -31350,21 +30144,6 @@
                     "requires": {
                         "p-locate": "^3.0.0",
                         "path-exists": "^3.0.0"
-                    }
-                },
-                "make-dir": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-                    "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-                    "requires": {
-                        "semver": "^6.0.0"
-                    },
-                    "dependencies": {
-                        "semver": {
-                            "version": "6.3.0",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                        }
                     }
                 },
                 "p-locate": {

--- a/packages/caliper-core/lib/worker/tx-observers/prometheus-push-tx-observer.js
+++ b/packages/caliper-core/lib/worker/tx-observers/prometheus-push-tx-observer.js
@@ -20,7 +20,6 @@ const ConfigUtil = require('../../common/config/config-util');
 const Constants = require('../../common/utils/constants');
 
 const prometheusClient = require('prom-client');
-const prometheusGcStats = require('prometheus-gc-stats');
 
 const Logger = CaliperUtils.getLogger('prometheus-push-tx-observer');
 
@@ -91,8 +90,6 @@ class PrometheusPushTxObserver extends TxObserverInterface {
                 timestamps: false,
                 timeout: this.processMetricCollectInterval
             });
-            const startGcStats = prometheusGcStats(this.registry);
-            startGcStats();
         }
 
         if (!(options && options.pushUrl)) {

--- a/packages/caliper-core/lib/worker/tx-observers/prometheus-tx-observer.js
+++ b/packages/caliper-core/lib/worker/tx-observers/prometheus-tx-observer.js
@@ -21,7 +21,6 @@ const TxObserverInterface = require('./tx-observer-interface');
 const express = require('express');
 const appServer = express();
 const prometheusClient = require('prom-client');
-const prometheusGcStats = require('prometheus-gc-stats');
 
 const Logger = CaliperUtils.getLogger('prometheus-tx-observer');
 
@@ -99,8 +98,6 @@ class PrometheusTxObserver extends TxObserverInterface {
                 timestamps: false,
                 timeout: this.processMetricCollectInterval
             });
-            const startGcStats = prometheusGcStats(this.registry);
-            startGcStats();
         }
 
         // configure server for Prometheus scrapes:

--- a/packages/caliper-core/package.json
+++ b/packages/caliper-core/package.json
@@ -33,7 +33,6 @@
         "nconf-yaml": "^1.0.2",
         "pidusage": "^1.1.6",
         "prom-client": "12.0.0",
-        "prometheus-gc-stats": "0.6.3",
         "ps-node": "^0.1.6",
         "table": "^4.0.1",
         "winston": "^3.2.1",


### PR DESCRIPTION
reasons for this

1. we have never documented the metrics
2. not sure how much use it is anyway
3. was using an old version of gc-stats which is now unmaintained and has security issues
4. replacement version of gc-stats is maintained by a single person who controls the binary builds available so is a dangerous thing to rely on
5. it has no pure javascript fallback therefore requires caliper to pull down or build a binary module (meaning you need python and compilers installed) which will also be dependent on the version of node being used.

