### PR TITLE
`caliper-core`: add tests for `Message` classes

### DIFF
--- a/packages/caliper-core/test/common/core/messages/assignedMessage.js
+++ b/packages/caliper-core/test/common/core/messages/assignedMessage.js
@@ -1,0 +1,71 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const AssignedMessage = require('../../../../lib/common/messages/assignedMessage');
+const MessageTypes = require('../../../../lib/common/utils/constants').Messages.Types;
+
+const chai = require('chai');
+chai.should();
+
+describe('AssignedMessage', () => {
+    describe('Constructor', () => {
+        it('should create an AssignedMessage instance with sender, recipients, and type', () => {
+            const sender = 'John';
+            const recipients = ['Alice', 'Bob'];
+            const message = new AssignedMessage(sender, recipients);
+
+            message.should.be.an.instanceOf(AssignedMessage);
+            message.sender.should.equal(sender);
+            message.recipients.should.deep.equal(recipients);
+            message.type.should.equal(MessageTypes.Assigned);
+        });
+
+        it('should set the content of the message as an empty object', () => {
+            const message = new AssignedMessage('John', ['Alice', 'Bob']);
+
+            message.content.should.deep.equal({});
+        });
+
+        it('should parse the date argument as a Date object for the AssignedMessage', () => {
+            const date = '2024-04-25';
+            const message = new AssignedMessage('John', ['Alice', 'Bob'], date);
+
+            message.date.should.be.an.instanceOf(Date);
+            message.date
+                .toISOString()
+                .should.equal(new Date(date).toISOString());
+        });
+
+        it('should set the error correctly if passed', () => {
+            const error = 'Some error';
+            const message = new AssignedMessage(
+                'John',
+                ['Alice', 'Bob'],
+                undefined,
+                error
+            );
+
+            message.error.should.equal(error);
+        });
+
+        it('should create an AssignedMessage with undefined date and error if not provided', () => {
+            const message = new AssignedMessage('John', ['Alice', 'Bob']);
+            
+            chai.expect(message.date).to.be.undefined;
+            chai.expect(message.error).to.be.undefined;
+        });
+    });
+});

--- a/packages/caliper-core/test/common/core/messages/message.js
+++ b/packages/caliper-core/test/common/core/messages/message.js
@@ -20,7 +20,7 @@ const AllMessageTarget = require('../../../../lib/common/utils/constants').Messa
 const chai = require('chai');
 chai.should();
 
-describe('Message', () => { 
+describe('Message', () => {
     const mockSender = 'Test User';
     const mockRecipients = ["recepient-id-1", "recepient-id-2", "recepient-id-3"];
     const mockType = 'Assigned';
@@ -32,7 +32,7 @@ describe('Message', () => {
         it("should create a Message instance with sender, recipients, type, content, date, and error", () => {
             const message = new Message(mockSender, mockRecipients, mockType, mockContent, mockDate, mockError);
 
-            message.should.be.an.instanceOf(Message);   
+            message.should.be.an.instanceOf(Message);
             message.sender.should.equal(mockSender);
             message.recipients.should.deep.equal(mockRecipients);
             message.type.should.equal(mockType);
@@ -48,7 +48,7 @@ describe('Message', () => {
             chai.expect(message.date).to.be.undefined;
         });
 
-        it("should set the date of the message as an invalid Date object if the date is invalid", () => { 
+        it("should set the date of the message as an invalid Date object if the date is invalid", () => {
             const message = new Message(mockSender, mockRecipients, mockType, mockContent, 'Invalid Date');
 
             message.date.should.be.an.instanceOf(Date);
@@ -56,7 +56,7 @@ describe('Message', () => {
         })
     })
 
-    describe("Getters", () => { 
+    describe("Getters", () => {
         beforeEach(() => {
             this.message = new Message(mockSender, mockRecipients, mockType, mockContent, mockDate, mockError);
         })
@@ -78,8 +78,8 @@ describe('Message', () => {
         });
     })
 
-    describe("hasError", () => { 
-        it("should return true if the message has an error", () => { 
+    describe("hasError", () => {
+        it("should return true if the message has an error", () => {
             const message = new Message(mockSender, mockRecipients, mockType, mockContent, mockDate, mockError);
             message.hasError().should.be.true;
         })
@@ -90,25 +90,31 @@ describe('Message', () => {
         })
     })
 
-    describe("forRecipient", () => { 
+    describe("forRecipient", () => {
         it("should return true if the message is for the recipient", () => {
             const message = new Message(mockSender, mockRecipients, mockType, mockContent, mockDate);
-            
+
             mockRecipients.forEach(recipient => {
                 message.forRecipient(recipient).should.be.true;
             })
         })
 
-        it("should return true for all people if the message if for all", () => { 
+        it("should return true for all people if the message if for all", () => {
             const message = new Message(mockSender, [AllMessageTarget], mockType, mockContent, mockDate);
 
             message.forRecipient(AllMessageTarget).should.be.true;
             message.forRecipient('random-id').should.be.true;
         })
+
+        it("should return false if the message is not for the recipient", () => {
+            const message = new Message(mockSender, mockRecipients, mockType, mockContent, mockDate);
+
+            message.forRecipient('random-id').should.be.false;
+        })
     })
 
-    describe("stringify", () => { 
-        it("should contain the date and the error if present", () => { 
+    describe("stringify", () => {
+        it("should contain the date and the error if present", () => {
             const message = new Message(mockSender, mockRecipients, mockType, mockContent, mockDate, mockError);
             const stringifiedMessage = message.stringify();
             const decodedMessage = JSON.parse(stringifiedMessage);
@@ -129,7 +135,7 @@ describe('Message', () => {
             chai.expect(decodedMessage.error).to.be.undefined;
         })
 
-        it("should set the current date if the date is not provided", () => { 
+        it("should set the current date if the date is not provided", () => {
             const message = new Message(mockSender, mockRecipients, mockType, mockContent);
             const stringifiedMessage = message.stringify();
             const decodedMessage = JSON.parse(stringifiedMessage);

--- a/packages/caliper-core/test/common/core/messages/message.js
+++ b/packages/caliper-core/test/common/core/messages/message.js
@@ -1,0 +1,140 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const Message = require('../../../../lib/common/messages/message');
+const AllMessageTarget = require('../../../../lib/common/utils/constants').Messages.Targets.All
+
+const chai = require('chai');
+chai.should();
+
+describe('Message', () => { 
+    const mockSender = 'Test User';
+    const mockRecipients = ["recepient-id-1", "recepient-id-2", "recepient-id-3"];
+    const mockType = 'Assigned';
+    const mockContent = { message: 'Hello' };
+    const mockDate = '2024-04-25';
+    const mockError = "Test Error";
+
+    describe("Constructor", () => {
+        it("should create a Message instance with sender, recipients, type, content, date, and error", () => {
+            const message = new Message(mockSender, mockRecipients, mockType, mockContent, mockDate, mockError);
+
+            message.should.be.an.instanceOf(Message);   
+            message.sender.should.equal(mockSender);
+            message.recipients.should.deep.equal(mockRecipients);
+            message.type.should.equal(mockType);
+            message.content.should.deep.equal(mockContent);
+            message.date.should.be.an.instanceOf(Date);
+            message.date.toISOString().should.equal(new Date(mockDate).toISOString());
+            message.error.should.equal(mockError);
+        });
+
+        it("should set the date of the message as undefined not passed", () => {
+            const message = new Message(mockSender, mockRecipients, mockType);
+
+            chai.expect(message.date).to.be.undefined;
+        });
+
+        it("should set the date of the message as an invalid Date object if the date is invalid", () => { 
+            const message = new Message(mockSender, mockRecipients, mockType, mockContent, 'Invalid Date');
+
+            message.date.should.be.an.instanceOf(Date);
+            chai.expect(message.date.toString()).to.equal('Invalid Date');
+        })
+    })
+
+    describe("Getters", () => { 
+        beforeEach(() => {
+            this.message = new Message(mockSender, mockRecipients, mockType, mockContent, mockDate, mockError);
+        })
+
+        it("should get the sender of the message", () => {
+            this.message.getSender().should.equal(mockSender);
+        });
+
+        it("should get the recipients of the message", () => {
+            this.message.getRecipients().should.deep.equal(mockRecipients);
+        });
+
+        it("should get the type of the message", () => {
+            this.message.getType().should.equal(mockType);
+        });
+
+        it("should get the content of the message", () => {
+            this.message.getContent().should.deep.equal(mockContent);
+        });
+    })
+
+    describe("hasError", () => { 
+        it("should return true if the message has an error", () => { 
+            const message = new Message(mockSender, mockRecipients, mockType, mockContent, mockDate, mockError);
+            message.hasError().should.be.true;
+        })
+
+        it("should return false if the message has no error", () => {
+            const message = new Message(mockSender, mockRecipients, mockType, mockContent, mockDate);
+            message.hasError().should.be.false;
+        })
+    })
+
+    describe("forRecipient", () => { 
+        it("should return true if the message is for the recipient", () => {
+            const message = new Message(mockSender, mockRecipients, mockType, mockContent, mockDate);
+            
+            mockRecipients.forEach(recipient => {
+                message.forRecipient(recipient).should.be.true;
+            })
+        })
+
+        it("should return true for all people if the message if for all", () => { 
+            const message = new Message(mockSender, [AllMessageTarget], mockType, mockContent, mockDate);
+
+            message.forRecipient(AllMessageTarget).should.be.true;
+            message.forRecipient('random-id').should.be.true;
+        })
+    })
+
+    describe("stringify", () => { 
+        it("should contain the date and the error if present", () => { 
+            const message = new Message(mockSender, mockRecipients, mockType, mockContent, mockDate, mockError);
+            const stringifiedMessage = message.stringify();
+            const decodedMessage = JSON.parse(stringifiedMessage);
+
+            decodedMessage.sender.should.equal(mockSender);
+            decodedMessage.recipients.should.deep.equal(mockRecipients);
+            decodedMessage.type.should.equal(mockType);
+            decodedMessage.content.should.deep.equal(mockContent);
+            decodedMessage.date.should.equal(new Date(mockDate).toISOString());
+            decodedMessage.error.should.equal(mockError);
+        })
+
+        it("should not include the error attribute if the message had no error", () => {
+            const message = new Message(mockSender, mockRecipients, mockType, mockContent, mockDate);
+            const stringifiedMessage = message.stringify();
+            const decodedMessage = JSON.parse(stringifiedMessage);
+
+            chai.expect(decodedMessage.error).to.be.undefined;
+        })
+
+        it("should set the current date if the date is not provided", () => { 
+            const message = new Message(mockSender, mockRecipients, mockType, mockContent);
+            const stringifiedMessage = message.stringify();
+            const decodedMessage = JSON.parse(stringifiedMessage);
+
+            decodedMessage.date.should.equal(new Date().toISOString());
+        })
+    })
+})

--- a/packages/caliper-core/test/common/core/messages/preparedMessage.js
+++ b/packages/caliper-core/test/common/core/messages/preparedMessage.js
@@ -1,0 +1,71 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const PreparedMessage = require('../../../../lib/common/messages/preparedMessage');
+const MessageTypes = require('../../../../lib/common/utils/constants').Messages.Types;
+
+const chai = require('chai');
+chai.should();
+
+describe('PreparedMessage', () => {
+    describe('Constructor', () => {
+        it('should create an PreparedMessage instance with sender, recipients, and type', () => {
+            const sender = 'John';
+            const recipients = ['Alice', 'Bob'];
+            const message = new PreparedMessage(sender, recipients);
+
+            message.should.be.an.instanceOf(PreparedMessage);
+            message.sender.should.equal(sender);
+            message.recipients.should.deep.equal(recipients);
+            message.type.should.equal(MessageTypes.Prepared);
+        });
+
+        it('should set the content of the message as an empty object', () => {
+            const message = new PreparedMessage('John', ['Alice', 'Bob']);
+
+            message.content.should.deep.equal({});
+        });
+
+        it('should parse the date argument as a Date object for the PreparedMessage', () => {
+            const date = '2024-04-25';
+            const message = new PreparedMessage('John', ['Alice', 'Bob'], date);
+
+            message.date.should.be.an.instanceOf(Date);
+            message.date
+                .toISOString()
+                .should.equal(new Date(date).toISOString());
+        });
+
+        it('should set the error correctly if passed', () => {
+            const error = 'Some error';
+            const message = new PreparedMessage(
+                'John',
+                ['Alice', 'Bob'],
+                undefined,
+                error
+            );
+
+            message.error.should.equal(error);
+        });
+
+        it('should create an PreparedMessage with undefined date and error if not provided', () => {
+            const message = new PreparedMessage('John', ['Alice', 'Bob']);
+
+            chai.expect(message.date).to.be.undefined;
+            chai.expect(message.error).to.be.undefined;
+        });
+    });
+});

--- a/packages/caliper-core/test/common/core/messages/readyMessage.js
+++ b/packages/caliper-core/test/common/core/messages/readyMessage.js
@@ -1,0 +1,71 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const ReadyMessage = require('../../../../lib/common/messages/readyMessage');
+const MessageTypes = require('../../../../lib/common/utils/constants').Messages.Types;
+
+const chai = require('chai');
+chai.should();
+
+describe('ReadyMessage', () => {
+    describe('Constructor', () => {
+        it('should create an ReadyMessage instance with sender, recipients, and type', () => {
+            const sender = 'John';
+            const recipients = ['Alice', 'Bob'];
+            const message = new ReadyMessage(sender, recipients);
+
+            message.should.be.an.instanceOf(ReadyMessage);
+            message.sender.should.equal(sender);
+            message.recipients.should.deep.equal(recipients);
+            message.type.should.equal(MessageTypes.Ready);
+        });
+
+        it('should set the content of the message as an empty object', () => {
+            const message = new ReadyMessage('John', ['Alice', 'Bob']);
+
+            message.content.should.deep.equal({});
+        });
+
+        it('should parse the date argument as a Date object for the ReadyMessage', () => {
+            const date = '2024-04-25';
+            const message = new ReadyMessage('John', ['Alice', 'Bob'], date);
+
+            message.date.should.be.an.instanceOf(Date);
+            message.date
+                .toISOString()
+                .should.equal(new Date(date).toISOString());
+        });
+
+        it('should set the error correctly if passed', () => {
+            const error = 'Some error';
+            const message = new ReadyMessage(
+                'John',
+                ['Alice', 'Bob'],
+                undefined,
+                error
+            );
+
+            message.error.should.equal(error);
+        });
+
+        it('should create an ReadyMessage with undefined date and error if not provided', () => {
+            const message = new ReadyMessage('John', ['Alice', 'Bob']);
+            
+            chai.expect(message.date).to.be.undefined;
+            chai.expect(message.error).to.be.undefined;
+        });
+    });
+});


### PR DESCRIPTION
This PR introduces the tests for the base `Message` class in `caliper-core`, and then introduces three similar test suites for the constructors of three types of messages. When approved, I can work on adding similar tests for all the message classes. 

## Checklist
 - [X]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [X]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
Fixes part of #1557 

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-caliper)
- [ ] [GitHub Issues](https://github.com/hyperledger/caliper/issues)
- [ ] [Discord history](https://discord.com/channels/905194001349627914/941417677778473031)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->
