### PR TITLE
Add tests for `rate-control/compositeRate.js`

### DIFF
--- a/packages/caliper-core/test/worker/rate-control/compositeRate.js
+++ b/packages/caliper-core/test/worker/rate-control/compositeRate.js
@@ -1,0 +1,116 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+const CompositeRateController = require('../../../lib/worker/rate-control/compositeRate.js');
+// const RateControl = require('../../../lib/worker/rate-control/rateControl.js');
+// const TransactionStatisticsCollector = require('../../../lib/common/core/transaction-statistics-collector');
+const TestMessage = require('../../../lib/common/messages/testMessage.js');
+
+/**
+ * Encapsulates a controller and its scheduling information.
+ *
+ * @property {boolean} isLast Indicates whether the controller is the last in the round.
+ * @property {RateControl} controller The controller instance.
+ * @property {number} lastTxIndex The last TX index associated with the controller based on its weight. Only used in Tx number-based rounds.
+ * @property {number} relFinishTime The finish time of the controller based on its weight, relative to the start time of the round. Only used in duration-based rounds.
+ * @property {TransactionStatisticsCollector} txStatSubCollector The TX stat (sub-)collector associated with the sub-controller.
+ */
+
+describe('CompositeRateController', () => {
+    let testMessage;
+    beforeEach(() => {
+        let msgContent = {
+            label: 'query2',
+            rateControl: {
+                type: 'fixed-rate',
+                opts: {},
+            },
+            workload: {
+                module: './../queryByChannel.js',
+            },
+            testRound: 0,
+            txDuration: 250,
+            totalWorkers: 2,
+            weights: [1],
+            rateControllers: ['composite-rate'],
+        };
+        testMessage = new TestMessage('test', [], msgContent);
+    });
+
+    describe('Initialization', () => {
+        it('should correctly initialize with default settings', () => {
+            const testMessage = new TestMessage('test', [], {
+                weights: [1],
+                rateControllers: ['fixed-rate']
+            });
+            const controller = new CompositeRateController(testMessage, {}, 0);
+            expect(controller.activeControllerIndex).to.equal(0);
+            expect(controller.controllers.length).to.equal(1);
+        });
+    });
+
+    describe('applyRateControl', () => {
+        it('should apply rate control correctly', async () => {
+            expect(() => CompositeRateController.applyRateControl()).be.a('function');
+        });
+    });
+
+    describe('#_prepareControllers', () => {
+        it('should throw error when weights and rateControllers are not arrays', async () => {
+            testMessage.content.weights = 'not an array';
+            testMessage.content.rateControllers = 'not an array';
+            expect(() =>
+                CompositeRateController.createRateController(testMessage, {}, 0)
+            ).to.throw('Weight and controller definitions must be arrays.');
+        });
+
+        it('should throw error when weights and rateControllers lengths are not the same', async () => {
+            testMessage.content.weights = [1, 2];
+            testMessage.content.rateControllers = ['composite-rate'];
+            expect(() =>
+                CompositeRateController.createRateController(testMessage, {}, 0)
+            ).to.throw(
+                'The number of weights and controllers must be the same.'
+            );
+        });
+
+        it('should throw error when weights contains non-numeric value', async () => {
+            testMessage.content.weights = [1, 'not a number'];
+            testMessage.content.rateControllers = ['composite-rate', 'composite-rate'];
+            expect(() =>
+                CompositeRateController.createRateController(testMessage, {}, 0)
+            ).to.throw('Not-a-number element among weights: not a number');
+        });
+
+        it('should throw error when weights contains negative number', async () => {
+            testMessage.content.weights = [1, -2];
+            testMessage.content.rateControllers = ['composite-rate', 'composite-rate'];
+            expect(() =>
+                CompositeRateController.createRateController(testMessage, {}, 0)
+            ).to.throw('Negative element among weights: -2');
+        });
+
+        it('should throw error when all weights are zero', async () => {
+            testMessage.content.weights = [0, 0];
+            testMessage.content.rateControllers = ['composite-rate', 'composite-rate'];
+            expect(() =>
+                CompositeRateController.createRateController(testMessage, {}, 0)
+            ).to.throw('Every weight is zero.');
+        });
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->
This PR aims to create unit-tests for `compositeRate.js` class within our `caliper-core` package.

However, the current tests are failing due to following reasons.

Within our `packages/caliper-core/lib/worker/rate-control/compositeRate.js`, we find the following line : 

https://github.com/hyperledger/caliper/blob/21a98f496c850840c211a670c32fcfa9240612bb/packages/caliper-core/lib/worker/rate-control/compositeRate.js#L76


However, I tried logging out `this.options` and was returned with an empty Object as output. 

```javascript
console.log('Options: ', this.options);
let weights = this.options.weights;
let rateControllers = this.options.rateControllers;
```

I was returned with following logs : 

```markdown
Options:  {}
2024.05.12-00:43:27.856 error [caliper] [composite-rate-controller]     Weight and controller definitions must be arrays.
      2) should throw error when weights and rateControllers lengths are not the same
(Similar errors for other tests too)
```

Due to this our initial check at line 86, that is : 

https://github.com/hyperledger/caliper/blob/21a98f496c850840c211a670c32fcfa9240612bb/packages/caliper-core/lib/worker/rate-control/compositeRate.js#L79

Always throws an error. However, if we replace the line 76 above with 
```javascript
let weights = this.testMessage.content.weights;
```

Then, our tests pass.

What would be the most optimum fix for such cases?

## Checklist
 - [x]  A link to the issue/user story that the pull request relates to 
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
<!--- What issue / user story is this for -->

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-caliper)
- [ ] [GitHub Issues](https://github.com/hyperledger/caliper/issues)
- [ ] [Discord history](https://discord.com/channels/905194001349627914/941417677778473031)

<!-- please include any links to issues here -->
This issue is a small part of #1557 which aims to increase overall code-coverage for the `caliper-core` package.