### PR TITLE
Implementation of Issue #1497 - Allow the Ethereum connector to use an already deployed contract

### DIFF
--- a/packages/caliper-ethereum/lib/ethereum-connector.js
+++ b/packages/caliper-ethereum/lib/ethereum-connector.js
@@ -114,24 +114,31 @@ class EthereumConnector extends ConnectorBase {
             }
 
             this.ethereumConfig.contracts[key].abi = contractData.abi;
-            promises.push(new Promise(async function(resolve, reject) {
-                let contractInstance;
-                try {
-                    if (privacy) {
-                        contractInstance = await self.deployPrivateContract(contractData, privacy);
-                        logger.info(`Deployed private contract ${contractData.name} at ${contractInstance.options.address}`);
-                    } else {
-                        contractInstance = await self.deployContract(contractData);
-                        logger.info(`Deployed contract ${contractData.name} at ${contractInstance.options.address}`);
-                    }
-                } catch (err) {
-                    reject(err);
-                }
-                self.ethereumConfig.contracts[key].address = contractInstance.options.address;
+            if (contractData.address) {
+                logger.info(`Using pre-deployed contract ${contractData.name} at ${contractData.address}`);
+                self.ethereumConfig.contracts[key].address = contractData.address;
                 self.ethereumConfig.contracts[key].gas = contractGas;
                 self.ethereumConfig.contracts[key].estimateGas = estimateGas;
-                resolve(contractInstance);
-            }));
+            } else {
+                promises.push(new Promise(async function(resolve, reject) {
+                    let contractInstance;
+                    try {
+                        if (privacy) {
+                            contractInstance = await self.deployPrivateContract(contractData, privacy);
+                            logger.info(`Deployed private contract ${contractData.name} at ${contractInstance.options.address}`);
+                        } else {
+                            contractInstance = await self.deployContract(contractData);
+                            logger.info(`Deployed contract ${contractData.name} at ${contractInstance.options.address}`);
+                        }
+                    } catch (err) {
+                        reject(err);
+                    }
+                    self.ethereumConfig.contracts[key].address = contractInstance.options.address;
+                    self.ethereumConfig.contracts[key].gas = contractGas;
+                    self.ethereumConfig.contracts[key].estimateGas = estimateGas;
+                    resolve(contractInstance);
+                }));
+            }
         }
         return Promise.all(promises);
     }


### PR DESCRIPTION
## Checklist
 - [x]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
Issue #1497 - Allow the Ethereum connector to use an already deployed contract

## Existing issues
- [x] [GitHub Issues](https://github.com/hyperledger/caliper/issues/1497)

## Design of the fix
To use a contract that is already deployed, an optional 'address' key may be specified on the [Contract Definition file](https://hyperledger.github.io/caliper/vNext/ethereum-config/#contract-definition-file). The new connector reads the 'address' key from the Contract Definition File, and if it exists, it does not deploy a new contract.

## Validation of the fix
Working on my local Besu network
