### PR TITLE
Address test flake due to timing

### DIFF
--- a/packages/caliper-core/test/common/core/messages/message.js
+++ b/packages/caliper-core/test/common/core/messages/message.js
@@ -137,10 +137,13 @@ describe('Message', () => {
 
         it("should set the current date if the date is not provided", () => {
             const message = new Message(mockSender, mockRecipients, mockType, mockContent);
+            const firstDate = new Date();
             const stringifiedMessage = message.stringify();
             const decodedMessage = JSON.parse(stringifiedMessage);
-
-            decodedMessage.date.should.equal(new Date().toISOString());
+            const secondDate = new Date(decodedMessage.date);
+            const millisecondDifference = secondDate - firstDate;
+            // allow for upto 5 second discrepancy
+            chai.assert(millisecondDifference < 5 * 1000);
         })
     })
 })


### PR DESCRIPTION
The original test assumes that the 2 generated dates will occur on the exact same millisecond which is going to be unlikely. This fix allows for upto a 5 second discrepancy

