### PR TITLE
Add more test for tx observers

### DIFF
--- a/packages/caliper-core/lib/worker/tx-observers/logging-tx-observer.js
+++ b/packages/caliper-core/lib/worker/tx-observers/logging-tx-observer.js
@@ -49,18 +49,10 @@ class LoggingTxObserver extends TxObserverInterface{
         // TODO: appending metadata should be done by the dispatch
         if (Array.isArray(results)) {
             for (let result of results) {
-                // add extra metadata
-                result.workerIndex = this.workerIndex;
-                result.roundIndex = this.roundIndex;
-
                 // TODO: use fast-json-stringify
                 this.logFunction(JSON.stringify(result));
             }
         } else {
-            // add extra metadata
-            results.workerIndex = this.workerIndex;
-            results.roundIndex = this.roundIndex;
-
             // TODO: use fast-json-stringify
             this.logFunction(JSON.stringify(results));
         }

--- a/packages/caliper-core/lib/worker/tx-observers/tx-observer-dispatch.js
+++ b/packages/caliper-core/lib/worker/tx-observers/tx-observer-dispatch.js
@@ -102,33 +102,24 @@ class TxObserverDispatch extends TxObserverInterface {
             return;
         }
 
+        const metadata = {
+            workerIndex: this.workerIndex,
+            roundIndex: this.currentRound,
+        };
+        const resultWithMetadata = Array.isArray(results)
+            ? results.map(result => ({
+                ...result,
+                ...metadata,
+            }))
+            : {
+                ...results,
+                ...metadata
+            };
+
         for (let observer of this.txObservers) {
-            observer.txFinished(results);
+            observer.txFinished(resultWithMetadata);
         }
     }
 }
 
 module.exports = TxObserverDispatch;
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/packages/caliper-core/test/worker/tx-observers/internal-tx-observer.js
+++ b/packages/caliper-core/test/worker/tx-observers/internal-tx-observer.js
@@ -1,0 +1,218 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+chai.use(require('sinon-chai'));
+const sinon = require('sinon');
+const expect = chai.expect;
+const mockery = require('mockery');
+
+const warnLogger = sinon.stub();
+const errorLogger = sinon.stub();
+
+/**
+ * Mock implementation of CaliperUtils for testing purposes.
+ */
+class CaliperUtils {
+    /**
+     * Mocked version of the resolvePath method.
+     * Resolves the provided relative or absolute path and returns a fake path for testing.
+     *
+     * @param {string} path - The relative or absolute path to resolve.
+     * @returns {string} - Returns a hardcoded fake path, 'fake/path'.
+     */
+    static resolvePath(path) {
+        return 'fake/path';
+    }
+
+    /**
+     * Mocked version of the sleep method.
+     * Simulates a sleep by immediately resolving the promise.
+     *
+     * @param {number} ms - The number of milliseconds to sleep (ignored in the mock).
+     * @returns {Promise<void>} - A resolved promise, simulating the sleep.
+     */
+    static sleep(ms) {
+        return Promise.resolve();
+    }
+
+    /**
+     *
+     * @param {*} yaml res
+     * @return {string} the fake yaml
+     */
+    static parseYaml(yaml) {
+        return 'yaml';
+    }
+
+    /**
+     * Mocked version of the getLogger method.
+     * Returns a logger object with warn and error stubs for logging testing.
+     *
+     * @returns {{warn: function, error: function}} - A mocked logger with stubs for `warn` and `error` methods.
+     */
+    static getLogger() {
+        return {
+            warn: warnLogger,
+            error: errorLogger
+        };
+    }
+}
+
+
+mockery.enable({
+    warnOnReplace: false,
+    warnOnUnregistered: false
+});
+mockery.registerMock('../../common/utils/caliper-utils', CaliperUtils);
+
+describe('When using Internal Transaction Observer', () => {
+    const TxUpdateMessage = require('../../../lib/common/messages/txUpdateMessage');
+    const InternalTxObserver = require('../../../lib/worker/tx-observers/internal-tx-observer');
+    const TxResetMessage = require('../../../lib/common/messages/txResetMessage');
+    const ConfigUtil = require('../../../lib/common/config/config-util');
+
+
+    let messengerMock, managerUuid, workerIndex;
+    let clock;
+
+    beforeEach(() => {
+        // Mocking dependencies
+        messengerMock = {
+            getUUID: sinon.stub().returns('mocked-messenger-uuid'),
+            send: sinon.stub().resolves()
+        };
+        managerUuid = 'mocked-manager-uuid';
+        workerIndex = 0;
+        clock = sinon.useFakeTimers();
+        warnLogger.reset();
+        errorLogger.reset();
+    });
+
+    afterEach(() => {
+        sinon.restore();
+        mockery.deregisterAll();
+        mockery.disable();
+        clock.restore();
+    });
+
+    it('should initialize with correct properties', () => {
+        sinon.stub(ConfigUtil, 'get').returns(1000);
+        const observer = new InternalTxObserver(messengerMock, managerUuid, workerIndex);
+
+        expect(observer.messengerUUID).to.equal('mocked-messenger-uuid');
+        expect(observer.managerUuid).to.equal(managerUuid);
+        expect(observer.updateInterval).to.equal(1000);
+        expect(observer.intervalObject).to.be.undefined;
+    });
+
+    describe('Activating and scheduling updates', () => {
+        it('should activate the observer and start sending periodic updates', async () => {
+            sinon.stub(ConfigUtil, 'get').returns(1000);
+            const observer = new InternalTxObserver(messengerMock, managerUuid, workerIndex);
+
+            await observer.activate(1, 'round1');
+
+            // Fast forward the clock to simulate intervals
+            clock.tick(1000);
+            expect(messengerMock.send).to.have.been.calledOnce;
+
+            clock.tick(1000);
+            expect(messengerMock.send).to.have.been.calledTwice;
+
+            sinon.assert.notCalled(warnLogger);
+            sinon.assert.notCalled(errorLogger);
+        });
+
+        it('should log warning if interval is invalid and use default value', async () => {
+            sinon.stub(ConfigUtil, 'get').returns(-1); // Invalid interval
+            const observer = new InternalTxObserver(messengerMock, managerUuid, workerIndex);
+
+            await observer.activate(1, 'round1');
+
+            // Check if default interval was used
+            expect(observer.updateInterval).to.equal(1000);
+            sinon.assert.calledOnce(warnLogger);
+        });
+    });
+
+    describe('Deactivating and stopping updates', () => {
+        it('should deactivate the observer, stop updates and send final messages', async () => {
+            sinon.stub(ConfigUtil, 'get').returns(1000);
+            const observer = new InternalTxObserver(messengerMock, managerUuid, workerIndex);
+
+            await observer.activate(1, 'round1');
+            clock.tick(1000);
+
+            await observer.deactivate();
+            expect(observer.intervalObject).to.be.null;
+
+            expect(messengerMock.send).to.have.been.calledThrice; // Once during activate, twice during deactivate
+
+            // Ensure the first two messages were TxUpdateMessages
+            const firstCallArg = messengerMock.send.getCall(0).args[0];
+            const secondCallArg = messengerMock.send.getCall(1).args[0];
+            expect(firstCallArg).to.be.instanceOf(TxUpdateMessage);
+            expect(secondCallArg).to.be.instanceOf(TxUpdateMessage);
+
+            // Ensure the third message is a TxResetMessage
+            const txResetMessage = new TxResetMessage('mocked-messenger-uuid', [managerUuid]);
+            sinon.assert.calledWith(messengerMock.send, txResetMessage);
+
+            // Ensure the error logger was not called
+            sinon.assert.notCalled(errorLogger);
+        });
+
+
+        it('should log error if deactivation fails due to message sending', async () => {
+            sinon.stub(ConfigUtil, 'get').returns(1000);
+            messengerMock.send.rejects(new Error('Send error'));
+            const observer = new InternalTxObserver(messengerMock, managerUuid, workerIndex);
+
+            await observer.activate(1, 'round1');
+            clock.tick(1000);
+
+            await expect(observer.deactivate()).to.be.rejectedWith('Send error');
+            sinon.assert.calledOnce(errorLogger);
+        });
+    });
+
+    it('should send the correct update message with the correct transaction count when activated', async () => {
+        const observer = new InternalTxObserver(messengerMock, managerUuid, workerIndex);
+
+        await observer.activate(1, 'round1');
+
+        // Simulate 12 transactions being submitted
+        observer.txSubmitted(12);
+        clock.tick(1000);
+
+        // Check if messenger.send was called
+        sinon.assert.calledOnce(messengerMock.send);
+
+        const messageSent = messengerMock.send.getCall(0).args[0];
+        expect(messageSent).to.be.instanceOf(TxUpdateMessage);
+
+        // Check the properties of the message
+        expect(messageSent.sender).to.equal('mocked-messenger-uuid');
+        expect(messageSent.recipients).to.deep.equal([managerUuid]);
+
+        // Check the actual transaction counters after submission
+        expect(messageSent.content.stats.txCounters.totalSubmitted).to.equal(12);
+        expect(messageSent.content.type).to.equal('txUpdate');
+    });
+});

--- a/packages/caliper-core/test/worker/tx-observers/logging-tx-observer.js
+++ b/packages/caliper-core/test/worker/tx-observers/logging-tx-observer.js
@@ -1,0 +1,125 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const chai = require('chai');
+const sinon = require('sinon');
+const expect = chai.expect;
+const mockery = require('mockery');
+
+chai.use(require('sinon-chai'));
+
+describe('When monitoring transaction activity', () => {
+    let createLoggingTxObserver, CaliperUtils, observer, logStub;
+
+    before(() => {
+        mockery.enable({
+            warnOnReplace: false,
+            warnOnUnregistered: false
+        });
+
+        CaliperUtils = {
+            getLogger: sinon.stub().returns({
+                info: sinon.stub(),
+                error: sinon.stub(),
+                warn: sinon.stub()
+            })
+        };
+
+        mockery.registerMock('../../common/utils/caliper-utils', CaliperUtils);
+        createLoggingTxObserver = require('../../../lib/worker/tx-observers/logging-tx-observer').createTxObserver;
+    });
+
+    beforeEach(() => {
+        logStub = CaliperUtils.getLogger().info;
+        observer = createLoggingTxObserver({ messageLevel: 'info' }, null, 0);
+    });
+
+    afterEach(() => {
+        sinon.restore();
+        logStub.resetHistory();
+    });
+
+    after(() => {
+        mockery.deregisterAll();
+        mockery.disable();
+    });
+
+    describe('On initialization', () => {
+        it('should set up the logger with default settings if no options are provided', () => {
+            observer = createLoggingTxObserver({}, null, 0);
+            expect(logStub).to.exist;
+        });
+
+        it('should use a specific log level if provided in options', () => {
+            observer = createLoggingTxObserver({ messageLevel: 'warn' }, null, 0);
+            const warnLogger = CaliperUtils.getLogger().warn;
+            expect(warnLogger).to.exist;
+        });
+    });
+
+    describe('When processing submitted transactions', () => {
+        it('should ignore submissions and not log any data', () => {
+            observer.txSubmitted(5);
+            expect(logStub).to.not.have.been.called;
+        });
+    });
+
+    describe('When processing finished transactions', () => {
+        it('should log a single transaction result with metadata', () => {
+            const result = { status: 'success' };
+            observer.txFinished(result);
+            expect(logStub).to.have.been.calledOnce;
+            expect(logStub).to.have.been.calledWithMatch(JSON.stringify({
+                status: 'success',
+            }));
+        });
+
+        it('should log multiple transaction results with metadata for each', () => {
+            const results = [{ status: 'success' }, { status: 'failed' }];
+            observer.txFinished(results);
+            expect(logStub).to.have.been.calledTwice;
+            expect(logStub.firstCall).to.have.been.calledWithMatch(JSON.stringify({
+                status: 'success',
+            }));
+            expect(logStub.secondCall).to.have.been.calledWithMatch(JSON.stringify({
+                status: 'failed',
+            }));
+        });
+
+        it('should handle empty results without logging', () => {
+            observer.txFinished([]);
+            expect(logStub).to.not.have.been.called;
+        });
+
+        it('should log with custom round index if set', () => {
+            observer.roundIndex = 1;
+            const result = { status: 'success' };
+            observer.txFinished(result);
+            expect(logStub).to.have.been.calledOnce;
+            expect(logStub).to.have.been.calledWithMatch(JSON.stringify({
+                status: 'success',
+            }));
+        });
+
+        it('should not modify the original result object properties', () => {
+            const result = { status: 'success' };
+            observer.txFinished(result);
+
+            expect(result).to.not.have.property('workerIndex');
+            expect(result).to.not.have.property('roundIndex');
+        });
+    });
+});

--- a/packages/caliper-core/test/worker/tx-observers/prometheus-tx-observer.js
+++ b/packages/caliper-core/test/worker/tx-observers/prometheus-tx-observer.js
@@ -15,6 +15,7 @@
 'use strict';
 
 const chai = require('chai');
+const prometheusClient = require('prom-client');
 const chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
 const should = chai.should();
@@ -61,8 +62,14 @@ class Utils {
         };
     }
 
+    /**
+     * Stubs the 'listen' method of the appServer and returns an object with a stubbed 'close' method.
+     *
+     * @param {sinon.SinonSandbox} sandbox - The Sinon sandbox used to stub methods.
+     * @param {Object} appServer - The app server instance whose 'listen' method will be stubbed.
+    */
     static stubAppServer(sandbox, appServer) {
-        sandbox.stub(appServer, 'listen').returns({close: sinon.stub()})
+        sandbox.stub(appServer, 'listen').returns({close: sinon.stub()});
     }
 }
 
@@ -81,7 +88,7 @@ describe('When using a PrometheusTxObserver', () => {
 
     before(() => {
         sandbox = sinon.createSandbox();
-    })
+    });
 
     after(()=> {
         mockery.deregisterAll();
@@ -204,5 +211,71 @@ describe('When using a PrometheusTxObserver', () => {
         const txFinished = await prometheusTxObserver.counterTxFinished.get();
         txFinished.values.should.deep.equal([]);
     });
+
+    it('should adjust scrapePort if process is forked', () => {
+        sinon.stub(Utils, 'isForkedProcess').returns(true);
+        const prometheusTxObserver = PrometheusTxObserver.createTxObserver({ scrapePort: 3000 }, undefined, 1);
+
+        // The scrapePort should be adjusted by the workerIndex (1)
+        prometheusTxObserver.scrapePort.should.equal(3001);
+
+        Utils.isForkedProcess.restore();
+    });
+
+    it('should configure explicit histogram buckets', () => {
+        const options = {
+            histogramBuckets: {
+                explicit: [0.1, 0.5, 1, 2, 5]
+            }
+        };
+        const prometheusTxObserver = PrometheusTxObserver.createTxObserver(options, undefined, 0);
+        prometheusTxObserver.histogramLatency.upperBounds.should.deep.equal([0.1, 0.5, 1, 2, 5]);
+    });
+
+    it('should configure linear histogram buckets', () => {
+        const options = {
+            histogramBuckets: {
+                linear: {
+                    start: 0.5,
+                    width: 0.5,
+                    count: 5
+                }
+            }
+        };
+        const prometheusTxObserver = PrometheusTxObserver.createTxObserver(options, undefined, 0);
+        prometheusTxObserver.histogramLatency.upperBounds.should.deep.equal([0.5, 1, 1.5, 2, 2.5]);
+    });
+
+    it('should configure exponential histogram buckets', () => {
+        const options = {
+            histogramBuckets: {
+                exponential: {
+                    start: 0.5,
+                    factor: 2,
+                    count: 5
+                }
+            }
+        };
+        const prometheusTxObserver = PrometheusTxObserver.createTxObserver(options, undefined, 0);
+        prometheusTxObserver.histogramLatency.upperBounds.should.deep.equal([0.5, 1, 2, 4, 8]);
+    });
+
+    it('should enable process metric collection if processMetricCollectInterval is set', () => {
+        sinon.spy(prometheusClient, 'collectDefaultMetrics');
+        const options = {
+            processMetricCollectInterval: 1000
+        };
+        const prometheusTxObserver = PrometheusTxObserver.createTxObserver(options, undefined, 0);
+
+        // Ensure process metric collection is enabled
+        prometheusClient.collectDefaultMetrics.calledOnceWith({
+            register: prometheusTxObserver.registry,
+            timestamps: false,
+            timeout: 1000
+        }).should.be.true;
+
+        prometheusClient.collectDefaultMetrics.restore();
+    });
+
 
 });

--- a/packages/caliper-core/test/worker/tx-observers/tx-observer-dispatch.js
+++ b/packages/caliper-core/test/worker/tx-observers/tx-observer-dispatch.js
@@ -1,0 +1,137 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+const sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+
+const TxObserverDispatch = require('../../../lib/worker/tx-observers/tx-observer-dispatch');
+const TxObserverInterface = require('../../../lib/worker/tx-observers/tx-observer-interface');
+const CaliperUtils = require('../../../lib/common/utils/caliper-utils');
+
+describe('Transaction Observer Dispatch behavior', function() {
+    let mockMessenger;
+    let internalObserver;
+    let dispatcher;
+    let mockFactory;
+
+    beforeEach(function() {
+        // Mocks and stubs
+        mockMessenger = sinon.stub();
+        internalObserver = sinon.createStubInstance(TxObserverInterface);
+
+        // Mock a factory function for creating TX observers
+        mockFactory = sinon.stub().returns({
+            activate: sinon.stub(),
+            deactivate: sinon.stub(),
+            txSubmitted: sinon.stub(),
+            txFinished: sinon.stub(),
+        });
+
+        // Stub the utils to return the mock factory function
+        sinon.stub(CaliperUtils, 'loadModuleFunction').returns(mockFactory);
+
+        // Instantiate the dispatcher
+        dispatcher = new TxObserverDispatch(mockMessenger, internalObserver, 'managerUuid', 1);
+    });
+
+    afterEach(function() {
+        // Restore any stubs or mocks
+        sinon.restore();
+    });
+
+    describe('When Activated', function() {
+        it('should activate all registered observers', async function() {
+            await dispatcher.activate(0, 'test-round');
+
+            expect(internalObserver.activate.calledOnce).to.be.true;
+            dispatcher.txObservers.forEach(observer => {
+                expect(observer.activate.calledOnce).to.be.true;
+            });
+        });
+    });
+
+    describe('When Deactivation', function() {
+        it('should deactivate all registered observers', async function() {
+            await dispatcher.activate(0, 'test-round');
+            // Deactivate the dispatcher
+            await dispatcher.deactivate();
+            expect(internalObserver.deactivate.calledOnce).to.be.true;
+            dispatcher.txObservers.forEach(observer => {
+                expect(observer).to.have.property('deactivate');
+                expect(observer.deactivate.calledOnce).to.be.true;
+            });
+        });
+
+    });
+
+    describe('When Transaction is Submitted', function() {
+        it('should forward the transaction submission event to all observers after the dispatcher is activated', async function() {
+            // Activate the dispatcher first
+            await dispatcher.activate(0, 'test-round');
+
+            // Call txSubmitted
+            dispatcher.txSubmitted(5);
+
+            // Ensure each observer's txSubmitted method was called with the correct count
+            dispatcher.txObservers.forEach(observer => {
+                expect(observer.txSubmitted.calledWith(5)).to.be.true;
+            });
+        });
+
+
+        it('should not forward the transaction submission event to observers if the dispatcher is not active', function() {
+            dispatcher.active = false;
+            dispatcher.txSubmitted(5);
+
+            dispatcher.txObservers.forEach(observer => {
+                expect(observer.txSubmitted.called).to.be.false;
+            });
+        });
+    });
+
+    describe('When Transaction is Completed', function() {
+        it('should forward the transaction completion event to all observers after the dispatcher is activated', async function() {
+            const mockResult = { status: 'success' };
+
+            // Activate the dispatcher first
+            await dispatcher.activate(0, 'test-round');
+
+            // Call txFinished
+            dispatcher.txFinished(mockResult);
+
+            // Ensure each observer's txFinished method was called with the correct result
+            dispatcher.txObservers.forEach(observer => {
+                expect(observer.txFinished.calledWith(sinon.match({
+                    status: 'success',
+                    workerIndex: dispatcher.workerIndex,
+                    roundIndex: dispatcher.currentRound,
+                }))).to.be.true;
+            });
+        });
+
+
+        it('should not forward the transaction completion event to observers if the dispatcher is not active', function() {
+            dispatcher.active = false;
+            const mockResult = { status: 'success' };
+            dispatcher.txFinished(mockResult);
+
+            dispatcher.txObservers.forEach(observer => {
+                expect(observer.txFinished.called).to.be.false;
+            });
+        });
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
<!--- What issue / user story is this for -->
Partially addresses #1606

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-caliper)
- [x] [GitHub Issues](https://github.com/hyperledger/caliper/issues)
- [ ] [Discord history](https://discord.com/channels/905194001349627914/941417677778473031)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->

## Validation of the fix
<!--- Tell us what should happen -->
After this PR: Running the tests in caliper-core the below listed %stmts in the code coverage report should tally with the below listed
- caliper-core/lib/worker/tx-observers: 93.06
- caliper-core/lib/worker/tx-observers/internal-tx-observer.js: 100
- caliper-core/lib/worker/tx-observers/logging-tx-observer.js: 100
- caliper-core/lib/worker/tx-observers/prometheus-tx-observer.js : 92.06
- caliper-core/lib/worker/tx-observers/tx-observer-dispatch.js : 92.59

![Screenshot from 2024-09-09 13-36-44](https://github.com/user-attachments/assets/e52d6840-1577-48d4-b958-0568dfa50d8f)

<!--- Tell us what happens instead -->
Before the PR: Running the tests in caliper-core the below listed %stmts in the code coverage report the below listed was what was there before

- caliper-core/lib/worker/tx-observers: 68.82
- caliper-core/lib/worker/tx-observers/internal-tx-observer.js: 26.08
- caliper-core/lib/worker/tx-observers/logging-tx-observer.js: 0
- caliper-core/lib/worker/tx-observers/prometheus-tx-observer.js : 77.77
- caliper-core/lib/worker/tx-observers/tx-observer-dispatch.js : 19.23

![Screenshot from 2024-09-09 13-40-12](https://github.com/user-attachments/assets/f2f0b8aa-4574-4daa-928f-58a278e95afd)

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->
