### PR TITLE
add test for the message handling behavior

### DIFF
--- a/packages/caliper-core/test/worker/worker-message-handler.js
+++ b/packages/caliper-core/test/worker/worker-message-handler.js
@@ -1,0 +1,176 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+const sinon = require('sinon');
+const chai = require('chai');
+chai.should();
+const EventEmitter = require('events');
+const mockery = require('mockery');
+
+const MessageTypes = require('../../lib/common/utils/constants').Messages.Types;
+const ConnectedMessage = require('../../lib/common/messages/connectedMessage');
+const AssignedMessage = require('../../lib/common/messages/assignedMessage');
+const ReadyMessage = require('../../lib/common/messages/readyMessage');
+const PreparedMessage = require('../../lib/common/messages/preparedMessage');
+const TestResultMessage = require('../../lib/common/messages/testResultMessage');
+const WorkerMessageHandler = require('../../lib/worker/worker-message-handler');
+const CaliperWorker = require('../../lib/worker/caliper-worker');
+
+describe('When receiving messages', () => {
+    let messengerMock, connectorFactoryMock, workerMock, sandbox;
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        messengerMock = new EventEmitter();
+        messengerMock.on = sandbox.spy(messengerMock.on.bind(messengerMock));
+        messengerMock.send = sandbox.stub();
+        messengerMock.getUUID = sandbox.stub().returns('worker-uuid');
+
+        connectorFactoryMock = sandbox.stub();
+
+        workerMock = sinon.createStubInstance(CaliperWorker);
+
+        mockery.enable({
+            warnOnReplace: false,
+            warnOnUnregistered: false,
+            useCleanCache: true
+        });
+
+        mockery.registerMock('./caliper-worker', {
+            CaliperWorker: () => workerMock
+        });
+    });
+
+    afterEach(() => {
+        mockery.deregisterAll();
+        mockery.disable();
+        sandbox.restore();
+    });
+
+    it('should register the worker when receiving a "register" message', async () => {
+        const handler = new WorkerMessageHandler(messengerMock, connectorFactoryMock);
+        const message = {
+            getType: () => MessageTypes.Register,
+            getSender: () => 'manager-uuid',
+            stringify: () => 'register message'
+        };
+
+        messengerMock.emit(MessageTypes.Register, message);
+        await new Promise(setImmediate);
+
+        sinon.assert.calledOnce(messengerMock.send);
+        sinon.assert.calledWith(messengerMock.send, sinon.match.instanceOf(ConnectedMessage));
+    });
+
+    it('should assign the worker ID when receiving an "assignId" message', async () => {
+        const handler = new WorkerMessageHandler(messengerMock, connectorFactoryMock);
+        const message = {
+            getType: () => MessageTypes.AssignId,
+            getWorkerIndex: () => 1,
+            stringify: () => 'assignId message'
+        };
+        messengerMock.emit(MessageTypes.AssignId, message);
+        await new Promise(setImmediate);
+        sinon.assert.calledOnce(messengerMock.send);
+        sinon.assert.calledWith(messengerMock.send, sinon.match.instanceOf(AssignedMessage));
+    });
+
+    it('should initialize the worker when receiving an "initialize" message', async () => {
+        connectorFactoryMock.resolves('connector-instance');
+        const handler = new WorkerMessageHandler(messengerMock, connectorFactoryMock);
+        const message = {
+            getType: () => MessageTypes.Initialize,
+            stringify: () => 'initialize message'
+        };
+        messengerMock.emit(MessageTypes.Initialize, message);
+        await new Promise(setImmediate);
+        sinon.assert.calledOnce(connectorFactoryMock);
+        sinon.assert.calledOnce(messengerMock.send);
+        sinon.assert.calledWith(messengerMock.send, sinon.match.instanceOf(ReadyMessage));
+    });
+
+    it('should prepare the test when receiving a "prepare" message', async () => {
+        const handler = new WorkerMessageHandler(messengerMock, connectorFactoryMock);
+        handler.worker = workerMock;
+        const message = {
+            getType: () => MessageTypes.Prepare,
+            getRoundIndex: () => 0,
+            stringify: () => 'prepare message'
+        };
+
+        workerMock.prepareTest.resolves();
+        messengerMock.emit(MessageTypes.Prepare, message);
+        await new Promise(setImmediate);
+        sinon.assert.calledOnce(workerMock.prepareTest);
+        sinon.assert.calledOnce(messengerMock.send);
+        sinon.assert.calledWith(messengerMock.send, sinon.match.instanceOf(PreparedMessage));
+    });
+
+    it('should execute the test round when receiving a "test" message', async () => {
+        const handler = new WorkerMessageHandler(messengerMock, connectorFactoryMock);
+        handler.worker = workerMock;
+        const message = {
+            getType: () => MessageTypes.Test,
+            getRoundIndex: () => 0,
+            stringify: () => 'test message'
+        };
+
+        workerMock.executeRound.resolves();
+        messengerMock.emit(MessageTypes.Test, message);
+        await new Promise(setImmediate);
+        sinon.assert.calledOnce(workerMock.executeRound);
+        sinon.assert.calledOnce(messengerMock.send);
+        sinon.assert.calledWith(messengerMock.send, sinon.match.instanceOf(TestResultMessage));
+    });
+
+    it('should resolve the exit promise when receiving an "exit" message', async () => {
+        const handler = new WorkerMessageHandler(messengerMock, connectorFactoryMock);
+        const message = {
+            getType: () => MessageTypes.Exit,
+            stringify: () => 'exit message'
+        };
+
+        const exitPromise = handler.waitForExit();
+        messengerMock.emit(MessageTypes.Exit, message);
+        await exitPromise;
+    });
+});
+
+describe('When instantiating the worker message handler', () => {
+    let messengerMock, connectorFactoryMock;
+
+    beforeEach(() => {
+        messengerMock = {
+            on: sinon.stub(),
+            send: sinon.stub(),
+            getUUID: sinon.stub().returns('worker-uuid')
+        };
+        connectorFactoryMock = sinon.stub();
+    });
+
+    it('should throw an error if messenger is undefined', () => {
+        (() => new WorkerMessageHandler(undefined, connectorFactoryMock))
+            .should.throw('Messenger instance is undefined');
+    });
+
+    it('should throw an error if connectorFactory is undefined', () => {
+        (() => new WorkerMessageHandler(messengerMock, undefined))
+            .should.throw('Connector factory is undefined or not a function');
+    });
+
+    it('should throw an error if connectorFactory is not a function', () => {
+        (() => new WorkerMessageHandler(messengerMock, {}))
+            .should.throw('Connector factory is undefined or not a function');
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
<!--- What issue / user story is this for -->
Partially addresses #1606

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-caliper)
- [x] [GitHub Issues](https://github.com/hyperledger/caliper/issues)
- [ ] [Discord history](https://discord.com/channels/905194001349627914/941417677778473031)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->

## Validation of the fix
<!--- Tell us what should happen -->
After this PR: Running the tests in caliper-core the listed %stmts in the code coverage report should tally with the below listed
- caliper-core/lib/worker/worker-message-handler.js: 89.13

<!--- Tell us what happens instead -->
Before the PR: Running the tests in caliper-core the listed %stmts in the code coverage report the below listed was what was there before

- caliper-core/lib/worker/worker-message-handler.js: 9.78
## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->
