### PR TITLE
Make workflow secret passing and usage explicit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,4 +13,6 @@ jobs:
   publish-caliper:
     uses: ./.github/workflows/publish.yml
     needs: unit-tests
-    secrets: inherit
+    secrets:
+      DOCKER_USER: ${{ secrets.DOCKER_USER }}
+      DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,11 @@ name: Publish
 
 on:
   workflow_call:
+    secrets:
+      DOCKER_TOKEN:
+        required: true
+      DOCKER_USER:
+        required: true
 
 permissions:
   id-token: write  # Required for OIDC
@@ -22,3 +27,6 @@ jobs:
       run: npm install -g npm@11.5.1
     - name: Publish Caliper
       run: .build/publish-caliper.sh
+      env:
+        DOCKER_USER: ${{ secrets.DOCKER_USER }}
+        DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}


### PR DESCRIPTION
Resolves #1716 and hopefully also fixes the Docker publish issue (we now set secrets explicitly as envs for a job, which should have been the implicit behavior anyway, but now somehow the scripts can't see the passed secret as env var)